### PR TITLE
Hide --no-cache flag from rwx run help output

### DIFF
--- a/.agents/skills/worktree-build/SKILL.md
+++ b/.agents/skills/worktree-build/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: worktree-build
+description: >-
+  Build the RWX CLI inside a git worktree. The LSP bundle is gitignored and
+  won't be present in new worktrees, so it must be copied from the main repo
+  before `go build` will succeed. TRIGGER when: a `go build`, `go vet`, or
+  similar command fails with "pattern bundle/server.js: no matching files found"
+  inside a worktree.
+---
+
+# Building in a Git Worktree
+
+The `internal/lsp/embed.go` file uses `//go:embed` to bundle `bundle/server.js`.
+That file is produced by `make build` (which clones and compiles the language-server
+repo) and is gitignored, so it is **not** present in fresh worktrees.
+
+## Fix
+
+Copy `server.js` from the main repo into the worktree:
+
+```bash
+# Identify the main repo root (parent of .claude/worktrees/)
+MAIN_REPO="$(git worktree list --porcelain | head -1 | sed 's/worktree //')"
+WORKTREE_ROOT="$(git rev-parse --show-toplevel)"
+
+mkdir -p "$WORKTREE_ROOT/internal/lsp/bundle"
+cp "$MAIN_REPO/internal/lsp/bundle/server.js" \
+   "$WORKTREE_ROOT/internal/lsp/bundle/server.js"
+```
+
+After this, `go build ./cmd/rwx` will succeed.
+
+## Notes
+
+- Only `server.js` is required for the embed directive; the rest of the bundle
+  directory (node_modules, out, support) is not needed.
+- Do **not** commit the copied file -- it is gitignored for a reason.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/cmd/rwx/run.go
+++ b/cmd/rwx/run.go
@@ -190,6 +190,7 @@ var (
 
 func init() {
 	runCmd.Flags().BoolVar(&NoCache, "no-cache", false, "do not read or write to the cache")
+	_ = runCmd.Flags().MarkHidden("no-cache")
 	runCmd.Flags().StringArrayVar(&InitParameters, flagInit, []string{}, "initialization parameters for the run, available in the `init` context. Can be specified multiple times")
 	runCmd.Flags().StringArrayVar(&TargetedTasks, "target", []string{}, "task to target for execution. Can be specified multiple times")
 	runCmd.Flags().StringVarP(&MintFilePath, "file", "f", "", "an RWX config file to use for sourcing task definitions (required)")


### PR DESCRIPTION
### Background

[RWX-323](https://linear.app/rwx-cloud/issue/RWX-323/hide-no-cache-flag-from-rwx-run-help-output)

### Problem

Telemetry shows the `--no-cache` flag on `rwx run` is being used more than expected. The decision was made to hide it from help output to discourage casual usage.

### Solution

- Added `MarkHidden("no-cache")` to the `rwx run` command's flag registration, following the same pattern already used for the `--file` flag.
- The flag remains fully functional — it's just no longer listed in `rwx run --help`.
- Also added a `worktree-build` skill under `.agents/skills/` and symlinked `.claude/skills` to it, documenting how to build the CLI in git worktrees (the LSP embed requires copying `server.js` from the main repo).

#### Further confirmation needed

- [ ] Verify `--no-cache` still works end-to-end in a dispatched run (local verification confirmed the flag is accepted and hidden)