### PR TITLE
Add --task flag to rwx results command

### DIFF
--- a/.rwx/integration/results-test.yml
+++ b/.rwx/integration/results-test.yml
@@ -138,23 +138,12 @@ tasks:
       run_url=$(echo "$kickoff" | jq -r '.RunURL // empty')
       echo "$run_url" > "$RWX_LINKS/Run URL"
 
-      # NOTE: This is not great, but is currently the best way to get an unknown, successful task ID from the server to the CLI.
-      artifacts_result=$(rwx artifacts download --all --json "$run_id" --task will-pass)
-      task_id=$(echo "$artifacts_result" | jq -r '.OutputFiles[0]' | grep -o '[a-f0-9]\{32\}')
-      echo "Identified task ID to use for results: $task_id"
-
-      task_result=$(rwx results --wait --json "$task_id")
+      task_result=$(rwx results $run_id --task will-pass --wait --json)
       task_status=$(echo "$task_result" | jq -r '.ResultStatus')
       task_result_task_id=$(echo "$task_result" | jq -r '.TaskID')
 
       if [ "$task_status" != "succeeded" ]; then
         echo "Expected task status 'succeeded', got '$task_status'"
-        echo "$task_result"
-        exit 1
-      fi
-
-      if [ "$task_result_task_id" != "$task_id" ]; then
-        echo "Expected .TaskID to be '$task_id', got '$task_result_task_id'"
         echo "$task_result"
         exit 1
       fi

--- a/cmd/rwx/results.go
+++ b/cmd/rwx/results.go
@@ -22,10 +22,11 @@ var (
 	ResultsRepo       string
 	ResultsDefinition string
 	ResultsCommit     string
+	ResultsTaskKey    string
 
 	resultsCmd = &cobra.Command{
 		GroupID: "outputs",
-		Use:     "results [run-id]",
+		Use:     "results [run-id | run-id --task <key>]",
 		Short:   "Get results for a run",
 		Args:    cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -33,6 +34,7 @@ var (
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			useJson := useJsonOutput()
+			taskKeySet := cmd.Flags().Changed("task")
 
 			var runID string
 			runIDFromGit := false
@@ -54,19 +56,32 @@ var (
 
 			result, err := service.GetRunStatus(cli.GetRunStatusConfig{
 				RunID:    runID,
+				TaskKey:  ResultsTaskKey,
 				Wait:     ResultsWait,
 				FailFast: ResultsFailFast,
 				Json:     useJson,
 			})
 			if err != nil {
+				if taskKeySet {
+					return handleResultsTaskKeyError(err)
+				}
 				return err
 			}
 
-			promptID := result.RunID
-			if result.TaskID != "" {
-				promptID = result.TaskID
+			var promptResult *cli.GetRunPromptResult
+			var promptErr error
+			if taskKeySet {
+				promptResult, promptErr = service.GetRunPromptByTaskKey(runID, ResultsTaskKey)
+				if promptErr != nil {
+					promptErr = handleResultsTaskKeyError(promptErr)
+				}
+			} else {
+				promptID := result.RunID
+				if result.TaskID != "" {
+					promptID = result.TaskID
+				}
+				promptResult, promptErr = service.GetRunPrompt(promptID)
 			}
-			promptResult, promptErr := service.GetRunPrompt(promptID)
 
 			if useJson {
 				jsonOutput := struct {
@@ -146,6 +161,16 @@ func init() {
 	resultsCmd.Flags().StringVar(&ResultsRepo, "repo", "", "get results for a specific repository instead of the current git repository")
 	resultsCmd.Flags().StringVar(&ResultsDefinition, "definition", "", "get results for a specific definition path")
 	resultsCmd.Flags().StringVar(&ResultsCommit, "commit", "", "get results for a specific commit SHA")
+	resultsCmd.Flags().StringVar(&ResultsTaskKey, "task", "", "task key (e.g., ci.checks.lint); resolves the task by key instead of ID")
+}
+
+func handleResultsTaskKeyError(err error) error {
+	var ambiguousErr *api.AmbiguousTaskKeyError
+	if errors.As(err, &ambiguousErr) {
+		return errors.WrapSentinel(errors.New(ambiguousErr.Error()), errors.ErrAmbiguousTaskKey)
+	}
+
+	return err
 }
 
 func HandleAmbiguousDefinitionPathError(err error, branch, repo string) error {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1008,7 +1008,13 @@ func (c Client) TaskIDStatus(cfg TaskIDStatusConfig) (TaskStatusResult, error) {
 func (c Client) RunStatus(cfg RunStatusConfig) (RunStatusResult, error) {
 	var endpoint string
 	failFast := fmt.Sprintf("%t", cfg.FailFast)
-	if cfg.RunID != "" {
+	if cfg.RunID != "" && cfg.TaskKey != "" {
+		params := url.Values{}
+		params.Set("run_id", cfg.RunID)
+		params.Set("task_key", cfg.TaskKey)
+		params.Set("fail_fast", failFast)
+		endpoint = "/mint/api/results/status?" + params.Encode()
+	} else if cfg.RunID != "" {
 		params := url.Values{}
 		params.Set("id", cfg.RunID)
 		params.Set("fail_fast", failFast)
@@ -1043,13 +1049,19 @@ func (c Client) RunStatus(cfg RunStatusConfig) (RunStatusResult, error) {
 	}
 	defer resp.Body.Close()
 
-	if cfg.RunID == "" && resp.StatusCode == http.StatusUnprocessableEntity {
+	if resp.StatusCode == http.StatusUnprocessableEntity {
 		bodyBytes, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
 			return result, errors.New("Unable to call RWX API - 422 Unprocessable Entity")
 		}
-		if ambiguousErr := parseAmbiguousDefinitionPathError(bytes.NewReader(bodyBytes)); ambiguousErr != nil {
-			return result, ambiguousErr
+		if cfg.TaskKey != "" {
+			if ambiguousErr := parseAmbiguousTaskKeyError(bytes.NewReader(bodyBytes), cfg.TaskKey); ambiguousErr != nil {
+				return result, ambiguousErr
+			}
+		} else if cfg.RunID == "" {
+			if ambiguousErr := parseAmbiguousDefinitionPathError(bytes.NewReader(bodyBytes)); ambiguousErr != nil {
+				return result, ambiguousErr
+			}
 		}
 		resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 	}
@@ -1075,6 +1087,54 @@ func (c Client) GetRunPrompt(runID string) (string, error) {
 		return "", errors.Wrap(err, "HTTP request failed")
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errMsg := extractErrorMessage(resp.Body)
+		if errMsg == "" {
+			errMsg = fmt.Sprintf("Unable to call RWX API - %s", resp.Status)
+		}
+		if resp.StatusCode == http.StatusNotFound {
+			return "", errors.Wrap(ErrNotFound, errMsg)
+		}
+		return "", errors.New(errMsg)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to read response body")
+	}
+
+	return string(body), nil
+}
+
+func (c Client) GetRunPromptByTaskKey(runID, taskKey string) (string, error) {
+	params := url.Values{}
+	params.Set("run_id", runID)
+	params.Set("task_key", taskKey)
+	endpoint := "/mint/api/results/prompt?" + params.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to create new HTTP request")
+	}
+	req.Header.Set("Accept", "text/plain")
+
+	resp, err := c.RoundTrip(req)
+	if err != nil {
+		return "", errors.Wrap(err, "HTTP request failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		bodyBytes, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return "", errors.New("Unable to call RWX API - 422 Unprocessable Entity")
+		}
+		if ambiguousErr := parseAmbiguousTaskKeyError(bytes.NewReader(bodyBytes), taskKey); ambiguousErr != nil {
+			return "", ambiguousErr
+		}
+		return "", errors.New(string(bodyBytes))
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		errMsg := extractErrorMessage(resp.Body)

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -329,6 +329,7 @@ type ArtifactDownloadRequestResult struct {
 
 type RunStatusConfig struct {
 	RunID          string
+	TaskKey        string
 	BranchName     string
 	RepositoryName string
 	DefinitionPath string

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -47,6 +47,7 @@ type APIClient interface {
 	GetArtifactDownloadRequestByTaskKey(runID, taskKey, artifactKey string) (api.ArtifactDownloadRequestResult, error)
 	DownloadArtifact(api.ArtifactDownloadRequestResult) ([]byte, error)
 	GetRunPrompt(runID string) (string, error)
+	GetRunPromptByTaskKey(runID, taskKey string) (string, error)
 	GetSandboxInitTemplate() (api.SandboxInitTemplateResult, error)
 	ListSandboxRuns() (*api.ListSandboxRunsResult, error)
 	CancelRun(runID, scopedToken string) error

--- a/internal/cli/service_prompt.go
+++ b/internal/cli/service_prompt.go
@@ -11,3 +11,11 @@ func (s Service) GetRunPrompt(runID string) (*GetRunPromptResult, error) {
 	}
 	return &GetRunPromptResult{Prompt: prompt}, nil
 }
+
+func (s Service) GetRunPromptByTaskKey(runID, taskKey string) (*GetRunPromptResult, error) {
+	prompt, err := s.APIClient.GetRunPromptByTaskKey(runID, taskKey)
+	if err != nil {
+		return nil, err
+	}
+	return &GetRunPromptResult{Prompt: prompt}, nil
+}

--- a/internal/cli/service_wait.go
+++ b/internal/cli/service_wait.go
@@ -9,6 +9,7 @@ import (
 
 type GetRunStatusConfig struct {
 	RunID          string
+	TaskKey        string
 	BranchName     string
 	RepositoryName string
 	Wait           bool
@@ -36,6 +37,7 @@ func (s Service) GetRunStatus(cfg GetRunStatusConfig) (*GetRunStatusResult, erro
 	for {
 		statusResult, err := s.APIClient.RunStatus(api.RunStatusConfig{
 			RunID:          cfg.RunID,
+			TaskKey:        cfg.TaskKey,
 			BranchName:     cfg.BranchName,
 			RepositoryName: cfg.RepositoryName,
 			FailFast:       cfg.FailFast,

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -42,6 +42,7 @@ type API struct {
 	MockGetArtifactDownloadRequestByTaskKey     func(string, string, string) (api.ArtifactDownloadRequestResult, error)
 	MockDownloadArtifact                        func(api.ArtifactDownloadRequestResult) ([]byte, error)
 	MockGetRunPrompt                            func(string) (string, error)
+	MockGetRunPromptByTaskKey                   func(string, string) (string, error)
 	MockGetSandboxInitTemplate                  func() (api.SandboxInitTemplateResult, error)
 	MockListSandboxRuns                         func() (*api.ListSandboxRunsResult, error)
 	MockCancelRun                               func(runID, scopedToken string) error
@@ -330,6 +331,14 @@ func (c *API) GetRunPrompt(runID string) (string, error) {
 	}
 
 	return "", errors.New("MockGetRunPrompt was not configured")
+}
+
+func (c *API) GetRunPromptByTaskKey(runID, taskKey string) (string, error) {
+	if c.MockGetRunPromptByTaskKey != nil {
+		return c.MockGetRunPromptByTaskKey(runID, taskKey)
+	}
+
+	return "", errors.New("MockGetRunPromptByTaskKey was not configured")
 }
 
 func (c *API) ListSandboxRuns() (*api.ListSandboxRunsResult, error) {


### PR DESCRIPTION
### Background

https://linear.app/rwx-cloud/issue/RWX-299/add-task-flag-to-rwx-results-command
https://github.com/rwx-cloud/cloud/pull/7268

### Problem

`rwx results` only accepts a run/task ID (positional or from git context). Users can't get task-level results without first finding the task's external ID. `rwx logs` and `rwx artifacts` both support `--task <key>` for this purpose, but `rwx results` does not.

### Solution

- Added `--task` flag to `rwx results` following the same pattern as `rwx logs` and `rwx artifacts`
- When `--task` is set, the positional arg (or git context) is treated as a run ID and the flag value is the task key
- **API layer**: Added `TaskKey` field to `RunStatusConfig`; `RunStatus()` now has a third branch that hits `/mint/api/results/status?run_id=<id>&task_key=<key>` when both are set. Added `GetRunPromptByTaskKey()` for the prompt endpoint. Both handle 422 ambiguous task key errors via the existing `parseAmbiguousTaskKeyError` helper.
- **Service layer**: Added `TaskKey` to `GetRunStatusConfig` (forwarded to API). Added `GetRunPromptByTaskKey` service method.
- **Command layer**: Added `--task` flag, branching logic in `RunE`, and `handleResultsTaskKeyError` (same pattern as logs/artifacts). Works with `--wait`, `--open`, and `--output json`.
- **Interface/mock**: Added `GetRunPromptByTaskKey` to `APIClient` interface and mock.

#### Further confirmation needed

- [x] Verify ambiguous key error message renders correctly in CLI output
- [x] Verify `--task` with `--wait` polls until task completes
- [x] Verify `--task` with `--open` opens the task URL
- [x] Verify JSON output includes task-level fields
- [ ] Depends on server-side PR (rwx-cloud/cloud#7268) being deployed