### PR TITLE
Fall back to CancelRun API when SSH fails during sandbox stop and reset

### DIFF
--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -990,6 +990,12 @@ func (s Service) StopSandbox(cfg StopSandboxConfig) (*StopSandboxResult, error) 
 				_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_end__")
 				s.SSHClient.Close()
 				wasRunning = true
+			} else {
+				// SSH connection failed — cancel via API to avoid orphaned runs
+				if cancelErr := s.APIClient.CancelRun(session.RunID, session.ScopedToken); cancelErr != nil {
+					fmt.Fprintf(s.Stderr, "Warning: failed to cancel run %s: %v\n", session.RunID, cancelErr)
+				}
+				wasRunning = true
 			}
 		} else if err == nil && !connInfo.Polling.Completed {
 			// Run is still active but not yet sandboxable — cancel it server-side
@@ -1066,6 +1072,16 @@ func (s Service) ResetSandbox(cfg ResetSandboxConfig) (*ResetSandboxResult, erro
 				if err := s.connectSSH(&connInfo); err == nil {
 					_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_end__")
 					s.SSHClient.Close()
+				} else {
+					// SSH connection failed — cancel via API to avoid orphaned runs
+					if cancelErr := s.APIClient.CancelRun(session.RunID, session.ScopedToken); cancelErr != nil {
+						fmt.Fprintf(s.Stderr, "Warning: failed to cancel run %s: %v\n", session.RunID, cancelErr)
+					}
+				}
+			} else if err == nil && !connInfo.Polling.Completed {
+				// Run is still active but not yet sandboxable — cancel it server-side
+				if cancelErr := s.APIClient.CancelRun(session.RunID, session.ScopedToken); cancelErr != nil {
+					fmt.Fprintf(s.Stderr, "Warning: failed to cancel run %s: %v\n", session.RunID, cancelErr)
 				}
 			}
 

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -982,6 +982,7 @@ func (s Service) StopSandbox(cfg StopSandboxConfig) (*StopSandboxResult, error) 
 	now := time.Now().UTC()
 	for i, session := range toStop {
 		wasRunning := false
+		cancelMethod := ""
 
 		// Check if sandbox is still active and send stop command (use scoped token if available)
 		connInfo, err := s.APIClient.GetSandboxConnectionInfo(session.RunID, session.ScopedToken)
@@ -990,12 +991,14 @@ func (s Service) StopSandbox(cfg StopSandboxConfig) (*StopSandboxResult, error) 
 				_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_end__")
 				s.SSHClient.Close()
 				wasRunning = true
+				cancelMethod = "ssh"
 			} else {
 				// SSH connection failed — cancel via API to avoid orphaned runs
 				if cancelErr := s.APIClient.CancelRun(session.RunID, session.ScopedToken); cancelErr != nil {
 					fmt.Fprintf(s.Stderr, "Warning: failed to cancel run %s: %v\n", session.RunID, cancelErr)
 				}
 				wasRunning = true
+				cancelMethod = "api"
 			}
 		} else if err == nil && !connInfo.Polling.Completed {
 			// Run is still active but not yet sandboxable — cancel it server-side
@@ -1003,6 +1006,7 @@ func (s Service) StopSandbox(cfg StopSandboxConfig) (*StopSandboxResult, error) 
 				fmt.Fprintf(s.Stderr, "Warning: failed to cancel run %s: %v\n", session.RunID, cancelErr)
 			}
 			wasRunning = true
+			cancelMethod = "api"
 		}
 
 		// Remove from storage
@@ -1021,8 +1025,9 @@ func (s Service) StopSandbox(cfg StopSandboxConfig) (*StopSandboxResult, error) 
 			lifetimeS = int64(now.Sub(*session.CreatedAt).Seconds())
 		}
 		s.recordTelemetry("sandbox.stop", map[string]any{
-			"lifetime_s": lifetimeS,
-			"exec_count": session.ExecCount,
+			"lifetime_s":    lifetimeS,
+			"exec_count":    session.ExecCount,
+			"cancel_method": cancelMethod,
 		})
 
 		stopped = append(stopped, StoppedSandbox{
@@ -1046,6 +1051,7 @@ func (s Service) ResetSandbox(cfg ResetSandboxConfig) (*ResetSandboxResult, erro
 	branch := GetCurrentGitBranch(cwd)
 
 	var oldRunID string
+	cancelMethod := ""
 
 	// Check for existing sandbox with same config file.
 	// Lock around the load+delete+save to cooperate with concurrent writers.
@@ -1072,17 +1078,20 @@ func (s Service) ResetSandbox(cfg ResetSandboxConfig) (*ResetSandboxResult, erro
 				if err := s.connectSSH(&connInfo); err == nil {
 					_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_end__")
 					s.SSHClient.Close()
+					cancelMethod = "ssh"
 				} else {
 					// SSH connection failed — cancel via API to avoid orphaned runs
 					if cancelErr := s.APIClient.CancelRun(session.RunID, session.ScopedToken); cancelErr != nil {
 						fmt.Fprintf(s.Stderr, "Warning: failed to cancel run %s: %v\n", session.RunID, cancelErr)
 					}
+					cancelMethod = "api"
 				}
 			} else if err == nil && !connInfo.Polling.Completed {
 				// Run is still active but not yet sandboxable — cancel it server-side
 				if cancelErr := s.APIClient.CancelRun(session.RunID, session.ScopedToken); cancelErr != nil {
 					fmt.Fprintf(s.Stderr, "Warning: failed to cancel run %s: %v\n", session.RunID, cancelErr)
 				}
+				cancelMethod = "api"
 			}
 
 			// Remove old session
@@ -1111,7 +1120,9 @@ func (s Service) ResetSandbox(cfg ResetSandboxConfig) (*ResetSandboxResult, erro
 		return nil, err
 	}
 
-	s.recordTelemetry("sandbox.reset", map[string]any{})
+	s.recordTelemetry("sandbox.reset", map[string]any{
+		"cancel_method": cancelMethod,
+	})
 
 	return &ResetSandboxResult{
 		OldRunID: oldRunID,

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -2382,6 +2382,10 @@ func TestService_StopSandbox(t *testing.T) {
 		require.True(t, cancelCalled, "CancelRun should have been called")
 		require.Len(t, result.Stopped, 1)
 		require.True(t, result.Stopped[0].WasRunning)
+
+		stopEvent := findEvent(setup.drainEvents(), "sandbox.stop")
+		require.NotNil(t, stopEvent)
+		require.Equal(t, "api", stopEvent.Props["cancel_method"])
 	})
 
 	t.Run("logs warning when CancelRun fails but still succeeds", func(t *testing.T) {
@@ -2474,6 +2478,10 @@ func TestService_StopSandbox(t *testing.T) {
 		require.True(t, cancelCalled, "CancelRun should have been called when SSH fails")
 		require.Len(t, result.Stopped, 1)
 		require.True(t, result.Stopped[0].WasRunning)
+
+		stopEvent := findEvent(setup.drainEvents(), "sandbox.stop")
+		require.NotNil(t, stopEvent)
+		require.Equal(t, "api", stopEvent.Props["cancel_method"])
 	})
 
 	t.Run("does not call CancelRun for completed run", func(t *testing.T) {
@@ -2591,6 +2599,10 @@ func TestService_ResetSandbox(t *testing.T) {
 		require.True(t, cancelCalled, "CancelRun should have been called")
 		require.Equal(t, "run-initializing", result.OldRunID)
 		require.Equal(t, "run-new", result.NewRunID)
+
+		resetEvent := findEvent(setup.drainEvents(), "sandbox.reset")
+		require.NotNil(t, resetEvent)
+		require.Equal(t, "api", resetEvent.Props["cancel_method"])
 	})
 
 	t.Run("calls CancelRun when SSH connection fails for sandboxable run", func(t *testing.T) {
@@ -2626,6 +2638,10 @@ func TestService_ResetSandbox(t *testing.T) {
 		require.True(t, cancelCalled, "CancelRun should have been called when SSH fails")
 		require.Equal(t, "run-ssh-fail", result.OldRunID)
 		require.Equal(t, "run-new", result.NewRunID)
+
+		resetEvent := findEvent(setup.drainEvents(), "sandbox.reset")
+		require.NotNil(t, resetEvent)
+		require.Equal(t, "api", resetEvent.Props["cancel_method"])
 	})
 
 	t.Run("does not call CancelRun for completed run", func(t *testing.T) {
@@ -2652,6 +2668,10 @@ func TestService_ResetSandbox(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "run-completed", result.OldRunID)
 		require.Equal(t, "run-new", result.NewRunID)
+
+		resetEvent := findEvent(setup.drainEvents(), "sandbox.reset")
+		require.NotNil(t, resetEvent)
+		require.Equal(t, "", resetEvent.Props["cancel_method"])
 	})
 }
 

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -2442,6 +2442,40 @@ func TestService_StopSandbox(t *testing.T) {
 		require.True(t, result.Stopped[0].WasRunning)
 	})
 
+	t.Run("calls CancelRun when SSH connection fails for sandboxable run", func(t *testing.T) {
+		setup := setupTest(t)
+		seedSandboxStorage(t, setup.tmp, "run-ssh-fail", "token-ssh")
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
+			return errors.New("connection timed out")
+		}
+		cancelCalled := false
+		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
+			require.Equal(t, "run-ssh-fail", runID)
+			require.Equal(t, "token-ssh", scopedToken)
+			cancelCalled = true
+			return nil
+		}
+
+		result, err := setup.service.StopSandbox(cli.StopSandboxConfig{
+			RunID: "run-ssh-fail",
+			Json:  true,
+		})
+
+		require.NoError(t, err)
+		require.True(t, cancelCalled, "CancelRun should have been called when SSH fails")
+		require.Len(t, result.Stopped, 1)
+		require.True(t, result.Stopped[0].WasRunning)
+	})
+
 	t.Run("does not call CancelRun for completed run", func(t *testing.T) {
 		setup := setupTest(t)
 		seedSandboxStorage(t, setup.tmp, "run-completed", "token-done")
@@ -2465,6 +2499,159 @@ func TestService_StopSandbox(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result.Stopped, 1)
 		require.False(t, result.Stopped[0].WasRunning)
+	})
+}
+
+func TestService_ResetSandbox(t *testing.T) {
+	// setupResetMocks configures the mocks needed for StartSandbox to succeed after the old sandbox is stopped.
+	setupResetMocks := func(setup *testSetup) {
+		configPath := filepath.Join(setup.tmp, ".rwx", "sandbox.yml")
+		_ = os.WriteFile(configPath, []byte("tasks:\n  - key: test\n"), 0o644)
+
+		setup.mockGit.MockGetBranch = "main"
+		setup.mockGit.MockGetCommit = "abc123"
+		setup.mockGit.MockGetOriginUrl = "https://github.com/test/repo"
+		setup.mockGit.MockGeneratePatchFile = git.PatchFile{}
+
+		setup.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+			return &api.InitiateRunResult{
+				RunID:  "run-new",
+				RunURL: "https://cloud.rwx.com/runs/run-new",
+			}, nil
+		}
+		setup.mockAPI.MockCreateSandboxToken = func(cfg api.CreateSandboxTokenConfig) (*api.CreateSandboxTokenResult, error) {
+			return &api.CreateSandboxTokenResult{Token: "token"}, nil
+		}
+		setup.mockAPI.MockGetDefaultBase = func() (api.DefaultBaseResult, error) {
+			return api.DefaultBaseResult{}, nil
+		}
+		setup.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+			return &api.PackageVersionsResult{}, nil
+		}
+	}
+
+	// seedResetStorage initializes a git repo on "main" and writes a sandbox session
+	// keyed by branch+configFile so ResetSandbox can find it via GetCurrentGitBranch.
+	seedResetStorage := func(t *testing.T, setup *testSetup, runID, scopedToken string) {
+		t.Helper()
+
+		// GetCurrentGitBranch uses a real git client, so the temp dir must be a repo.
+		cmd := exec.Command("git", "init", "-b", "main")
+		cmd.Dir = setup.tmp
+		require.NoError(t, cmd.Run())
+		cmd = exec.Command("git", "commit", "--allow-empty", "-m", "init")
+		cmd.Dir = setup.tmp
+		require.NoError(t, cmd.Run())
+
+		storageDir := filepath.Join(setup.tmp, ".rwx", "sandboxes")
+		require.NoError(t, os.MkdirAll(storageDir, 0o755))
+
+		configFile := filepath.Join(setup.tmp, ".rwx", "sandbox.yml")
+		key := cli.SessionKey("main", configFile)
+		storage := cli.SandboxStorage{
+			Version: 1,
+			Sandboxes: map[string]cli.SandboxSession{
+				key: {
+					RunID:       runID,
+					ConfigFile:  configFile,
+					ScopedToken: scopedToken,
+				},
+			},
+		}
+		data, err := json.Marshal(storage)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(storageDir, "sandboxes.json"), data, 0o644))
+	}
+
+	t.Run("calls CancelRun for active but not yet sandboxable run", func(t *testing.T) {
+		setup := setupTest(t)
+		setupResetMocks(setup)
+		seedResetStorage(t, setup, "run-initializing", "scoped-token-123")
+
+		cancelCalled := false
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable: false,
+				Polling:     api.PollingResult{Completed: false},
+			}, nil
+		}
+		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
+			require.Equal(t, "run-initializing", runID)
+			require.Equal(t, "scoped-token-123", scopedToken)
+			cancelCalled = true
+			return nil
+		}
+
+		result, err := setup.service.ResetSandbox(cli.ResetSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.True(t, cancelCalled, "CancelRun should have been called")
+		require.Equal(t, "run-initializing", result.OldRunID)
+		require.Equal(t, "run-new", result.NewRunID)
+	})
+
+	t.Run("calls CancelRun when SSH connection fails for sandboxable run", func(t *testing.T) {
+		setup := setupTest(t)
+		setupResetMocks(setup)
+		seedResetStorage(t, setup, "run-ssh-fail", "token-ssh")
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
+			return errors.New("connection timed out")
+		}
+		cancelCalled := false
+		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
+			require.Equal(t, "run-ssh-fail", runID)
+			require.Equal(t, "token-ssh", scopedToken)
+			cancelCalled = true
+			return nil
+		}
+
+		result, err := setup.service.ResetSandbox(cli.ResetSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.True(t, cancelCalled, "CancelRun should have been called when SSH fails")
+		require.Equal(t, "run-ssh-fail", result.OldRunID)
+		require.Equal(t, "run-new", result.NewRunID)
+	})
+
+	t.Run("does not call CancelRun for completed run", func(t *testing.T) {
+		setup := setupTest(t)
+		setupResetMocks(setup)
+		seedResetStorage(t, setup, "run-completed", "token-done")
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable: false,
+				Polling:     api.PollingResult{Completed: true},
+			}, nil
+		}
+		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
+			t.Fatal("CancelRun should not be called for completed runs")
+			return nil
+		}
+
+		result, err := setup.service.ResetSandbox(cli.ResetSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "run-completed", result.OldRunID)
+		require.Equal(t, "run-new", result.NewRunID)
 	})
 }
 


### PR DESCRIPTION
### Background

- [RWX-366: Investigate duplicate sandboxes after sandbox reset](https://linear.app/rwx-cloud/issue/RWX-366/investigate-duplicate-sandboxes-after-sandbox-reset)

### Problem

When a customer's network drops outbound TCP packets on port 22, `sandbox reset` silently fails to stop the old run — it only attempts the SSH `__rwx_sandbox_end__` command, and if SSH is unreachable (or the sandbox isn't sandboxable yet), it moves on without canceling the old run server-side. This results in duplicate sandboxes and excess compute charges.

`sandbox stop` had a partial fallback (calling `CancelRun` when the sandbox wasn't yet sandboxable) but also lacked a fallback for when the sandbox *was* sandboxable but the SSH connection itself failed.

### Solution

- **`sandbox reset`**: Added fallback to call the `CancelRun` API endpoint in two cases:
  - When the sandbox is not yet sandboxable (still initializing) but the run is active
  - When the sandbox is sandboxable but the SSH connection fails or times out
- **`sandbox stop`**: Added the same SSH-failure fallback (it already handled the not-yet-sandboxable case)
- Added tests for both flows covering: SSH failure fallback, not-yet-sandboxable fallback, and the negative case (completed runs should not trigger CancelRun)

#### Further confirmation needed

- [ ] Verify the fix with a real sandbox where SSH is blocked (e.g. firewall rule on port 22) to confirm the API cancel path fires and the old run is properly terminated