### PR TITLE
Show firewall hint when sandbox SSH connection times out

### DIFF
--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -653,6 +654,14 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 	// Connect via SSH
 	err = s.connectSSH(connInfo)
 	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			port := "43215"
+			if _, p, splitErr := net.SplitHostPort(connInfo.Address); splitErr == nil {
+				port = p
+			}
+			return nil, fmt.Errorf("Failed to connect to sandbox '%s': %v\nThis is likely caused by a firewall or network configuration blocking outbound connections on port %s.", runID, err, port)
+		}
 		return nil, fmt.Errorf("Failed to connect to sandbox '%s': %v\nThe sandbox may have timed out. Run 'rwx sandbox reset %s' to restart.", runID, err, configFile)
 	}
 	defer s.SSHClient.Close()

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -34,6 +34,16 @@ AAAEC6442PQKevgYgeT0SIu9zwlnEMl6MF59ZgM+i0ByMv4eLJPqG3xnZcEQmktHj/GY2i
 	sandboxPublicTestKey = `ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLJPqG3xnZcEQmktHj/GY2i6rkoN2fkb75xRxMfgSHP rwx CLI testing`
 )
 
+// netTimeoutError implements net.Error with Timeout() returning true,
+// simulating a dial timeout caused by a firewall blocking the port.
+type netTimeoutError struct {
+	msg string
+}
+
+func (e *netTimeoutError) Error() string   { return e.msg }
+func (e *netTimeoutError) Timeout() bool   { return true }
+func (e *netTimeoutError) Temporary() bool { return false }
+
 func TestService_ListSandboxes(t *testing.T) {
 	t.Run("returns list without error", func(t *testing.T) {
 		setup := setupTest(t)
@@ -632,6 +642,67 @@ func TestService_ExecSandbox(t *testing.T) {
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "completed before becoming ready")
+	})
+
+	t.Run("shows firewall hint when SSH connection times out", func(t *testing.T) {
+		setup := setupTest(t)
+
+		runID := "run-timeout"
+		address := "192.168.1.1:43215"
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        address,
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
+			return &netTimeoutError{msg: "dial tcp 192.168.1.1:43215: connect: operation timed out"}
+		}
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      runID,
+			Json:       true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "firewall or network configuration blocking outbound connections on port 43215")
+	})
+
+	t.Run("shows generic sandbox timeout hint for non-timeout SSH errors", func(t *testing.T) {
+		setup := setupTest(t)
+
+		runID := "run-ssh-fail"
+		address := "192.168.1.1:43215"
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        address,
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
+			return fmt.Errorf("connection refused")
+		}
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      runID,
+			Json:       true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "The sandbox may have timed out")
+		require.NotContains(t, err.Error(), "firewall")
 	})
 }
 


### PR DESCRIPTION
### Problem

When a user's firewall blocks outbound connections on port 43215, `rwx sandbox exec` fails with a misleading message suggesting the sandbox may have timed out. This sends users down the wrong path — the sandbox is fine, it's their network that's blocking the connection.

### Solution

- Detect when the SSH connection error is a network timeout (via `net.Error` interface) and show a message pointing to firewall/network configuration as the likely cause
- Preserve the existing generic message for non-timeout SSH failures

#### Before

```
Error: Failed to connect to sandbox '331e12b3d38b4a3bbdd2999a6545b7f9': unable to establish SSH connection to remote host: dial tcp 3.128.188.188:43215: connect: operation timed out
The sandbox may have timed out. Run 'rwx sandbox reset /path/to/sandbox.yml' to restart.
```

#### After

```
Error: Failed to connect to sandbox '331e12b3d38b4a3bbdd2999a6545b7f9': unable to establish SSH connection to remote host: dial tcp 3.128.188.188:43215: connect: operation timed out
This is likely caused by a firewall or network configuration blocking outbound connections on port 43215.
```

Non-timeout SSH errors (e.g. connection refused) still show the original message unchanged.

#### Further confirmation needed

- [x] Verify the error message reads well on a real firewall-blocked connection