### PR TITLE
Wait for server confirmation before returning from sandbox stop and reset

### DIFF
--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1009,6 +1009,12 @@ func (s Service) StopSandbox(cfg StopSandboxConfig) (*StopSandboxResult, error) 
 			cancelMethod = "api"
 		}
 
+		// Wait for the server to confirm the run has completed so that
+		// immediately-following commands (exec, list, etc.) see consistent state.
+		if wasRunning {
+			s.waitForSandboxCompletion(session.RunID, session.ScopedToken)
+		}
+
 		// Remove from storage
 		delete(storage.Sandboxes, keys[i])
 
@@ -1041,6 +1047,37 @@ func (s Service) StopSandbox(cfg StopSandboxConfig) (*StopSandboxResult, error) 
 	}
 
 	return &StopSandboxResult{Stopped: stopped}, nil
+}
+
+// waitForSandboxCompletion polls the server until the run is confirmed
+// completed. This prevents immediately-following commands from finding
+// a stale in-progress run during the window between stop signal and
+// server-side teardown.
+func (s Service) waitForSandboxCompletion(runID, scopedToken string) {
+	const (
+		timeout         = 30 * time.Second
+		defaultInterval = 500 * time.Millisecond
+	)
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		connInfo, err := s.APIClient.GetSandboxConnectionInfo(runID, scopedToken)
+		if err != nil {
+			// Error (404, 410, etc.) means the run is no longer active
+			return
+		}
+		if connInfo.Polling.Completed {
+			return
+		}
+
+		interval := defaultInterval
+		if connInfo.Polling.BackoffMs != nil && *connInfo.Polling.BackoffMs > 0 {
+			interval = time.Duration(*connInfo.Polling.BackoffMs) * time.Millisecond
+		}
+		time.Sleep(interval)
+	}
+
+	fmt.Fprintf(s.Stderr, "Warning: timed out waiting for sandbox %s to fully stop\n", runID)
 }
 
 func (s Service) ResetSandbox(cfg ResetSandboxConfig) (*ResetSandboxResult, error) {
@@ -1092,6 +1129,13 @@ func (s Service) ResetSandbox(cfg ResetSandboxConfig) (*ResetSandboxResult, erro
 					fmt.Fprintf(s.Stderr, "Warning: failed to cancel run %s: %v\n", session.RunID, cancelErr)
 				}
 				cancelMethod = "api"
+			}
+
+			// Wait for the server to confirm the old run has completed before
+			// starting a new sandbox, avoiding a window where the old run is
+			// still in-progress and could conflict with the new one.
+			if cancelMethod != "" {
+				s.waitForSandboxCompletion(session.RunID, session.ScopedToken)
 			}
 
 			// Remove old session

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -2360,11 +2360,15 @@ func TestService_StopSandbox(t *testing.T) {
 		seedSandboxStorage(t, setup.tmp, "run-initializing", "scoped-token-123")
 
 		cancelCalled := false
+		connInfoCalls := atomic.Int32{}
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
-			return api.SandboxConnectionInfo{
-				Sandboxable: false,
-				Polling:     api.PollingResult{Completed: false},
-			}, nil
+			if connInfoCalls.Add(1) == 1 {
+				return api.SandboxConnectionInfo{
+					Sandboxable: false,
+					Polling:     api.PollingResult{Completed: false},
+				}, nil
+			}
+			return api.SandboxConnectionInfo{Polling: api.PollingResult{Completed: true}}, nil
 		}
 		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
 			require.Equal(t, "run-initializing", runID)
@@ -2392,11 +2396,15 @@ func TestService_StopSandbox(t *testing.T) {
 		setup := setupTest(t)
 		seedSandboxStorage(t, setup.tmp, "run-cancel-fail", "token-456")
 
+		connInfoCalls := atomic.Int32{}
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
-			return api.SandboxConnectionInfo{
-				Sandboxable: false,
-				Polling:     api.PollingResult{Completed: false},
-			}, nil
+			if connInfoCalls.Add(1) == 1 {
+				return api.SandboxConnectionInfo{
+					Sandboxable: false,
+					Polling:     api.PollingResult{Completed: false},
+				}, nil
+			}
+			return api.SandboxConnectionInfo{Polling: api.PollingResult{Completed: true}}, nil
 		}
 		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
 			return errors.New("server error")
@@ -2417,13 +2425,17 @@ func TestService_StopSandbox(t *testing.T) {
 		setup := setupTest(t)
 		seedSandboxStorage(t, setup.tmp, "run-sandboxable", "token-789")
 
+		connInfoCalls := atomic.Int32{}
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
-			return api.SandboxConnectionInfo{
-				Sandboxable:    true,
-				Address:        "192.168.1.1:22",
-				PrivateUserKey: sandboxPrivateTestKey,
-				PublicHostKey:  sandboxPublicTestKey,
-			}, nil
+			if connInfoCalls.Add(1) == 1 {
+				return api.SandboxConnectionInfo{
+					Sandboxable:    true,
+					Address:        "192.168.1.1:22",
+					PrivateUserKey: sandboxPrivateTestKey,
+					PublicHostKey:  sandboxPublicTestKey,
+				}, nil
+			}
+			return api.SandboxConnectionInfo{Polling: api.PollingResult{Completed: true}}, nil
 		}
 		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
 			return nil
@@ -2450,13 +2462,17 @@ func TestService_StopSandbox(t *testing.T) {
 		setup := setupTest(t)
 		seedSandboxStorage(t, setup.tmp, "run-ssh-fail", "token-ssh")
 
+		connInfoCalls := atomic.Int32{}
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
-			return api.SandboxConnectionInfo{
-				Sandboxable:    true,
-				Address:        "192.168.1.1:22",
-				PrivateUserKey: sandboxPrivateTestKey,
-				PublicHostKey:  sandboxPublicTestKey,
-			}, nil
+			if connInfoCalls.Add(1) == 1 {
+				return api.SandboxConnectionInfo{
+					Sandboxable:    true,
+					Address:        "192.168.1.1:22",
+					PrivateUserKey: sandboxPrivateTestKey,
+					PublicHostKey:  sandboxPublicTestKey,
+				}, nil
+			}
+			return api.SandboxConnectionInfo{Polling: api.PollingResult{Completed: true}}, nil
 		}
 		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
 			return errors.New("connection timed out")
@@ -2507,6 +2523,146 @@ func TestService_StopSandbox(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result.Stopped, 1)
 		require.False(t, result.Stopped[0].WasRunning)
+	})
+}
+
+func TestService_StopSandbox_WaitsForCompletion(t *testing.T) {
+	t.Run("polls until server confirms completion", func(t *testing.T) {
+		setup := setupTest(t)
+		seedSandboxStorage(t, setup.tmp, "run-poll", "token-poll")
+
+		callCount := atomic.Int32{}
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				// First call: stop check — sandbox is still active
+				return api.SandboxConnectionInfo{
+					Sandboxable: false,
+					Polling:     api.PollingResult{Completed: false},
+				}, nil
+			}
+			if n == 2 {
+				// Second call: first poll — still in progress
+				return api.SandboxConnectionInfo{
+					Polling: api.PollingResult{Completed: false},
+				}, nil
+			}
+			// Third call: completed
+			return api.SandboxConnectionInfo{
+				Polling: api.PollingResult{Completed: true},
+			}, nil
+		}
+		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
+			return nil
+		}
+
+		result, err := setup.service.StopSandbox(cli.StopSandboxConfig{
+			RunID: "run-poll",
+			Json:  true,
+		})
+
+		require.NoError(t, err)
+		require.Len(t, result.Stopped, 1)
+		require.True(t, result.Stopped[0].WasRunning)
+		require.Equal(t, int32(3), callCount.Load(), "should have polled until completion")
+	})
+
+	t.Run("stops polling when server returns an error", func(t *testing.T) {
+		setup := setupTest(t)
+		seedSandboxStorage(t, setup.tmp, "run-err", "token-err")
+
+		callCount := atomic.Int32{}
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				// First call: stop check
+				return api.SandboxConnectionInfo{
+					Sandboxable: false,
+					Polling:     api.PollingResult{Completed: false},
+				}, nil
+			}
+			// Second call: run is gone
+			return api.SandboxConnectionInfo{}, errors.New("not found")
+		}
+		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
+			return nil
+		}
+
+		result, err := setup.service.StopSandbox(cli.StopSandboxConfig{
+			RunID: "run-err",
+			Json:  true,
+		})
+
+		require.NoError(t, err)
+		require.Len(t, result.Stopped, 1)
+		require.Equal(t, int32(2), callCount.Load(), "should stop polling on error")
+	})
+
+	t.Run("respects server-provided backoff", func(t *testing.T) {
+		setup := setupTest(t)
+		seedSandboxStorage(t, setup.tmp, "run-backoff", "token-backoff")
+
+		var pollTimes []time.Time
+		callCount := atomic.Int32{}
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			n := callCount.Add(1)
+			if n == 1 {
+				// First call: stop check
+				return api.SandboxConnectionInfo{
+					Sandboxable: false,
+					Polling:     api.PollingResult{Completed: false},
+				}, nil
+			}
+			pollTimes = append(pollTimes, time.Now())
+			if n == 2 {
+				backoff := 100
+				return api.SandboxConnectionInfo{
+					Polling: api.PollingResult{Completed: false, BackoffMs: &backoff},
+				}, nil
+			}
+			return api.SandboxConnectionInfo{
+				Polling: api.PollingResult{Completed: true},
+			}, nil
+		}
+		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
+			return nil
+		}
+
+		_, err := setup.service.StopSandbox(cli.StopSandboxConfig{
+			RunID: "run-backoff",
+			Json:  true,
+		})
+
+		require.NoError(t, err)
+		require.Len(t, pollTimes, 2)
+		// The interval between polls should be at least the backoff (100ms)
+		gap := pollTimes[1].Sub(pollTimes[0])
+		require.GreaterOrEqual(t, gap.Milliseconds(), int64(90), "should respect server backoff")
+	})
+
+	t.Run("does not poll for already-completed sandbox", func(t *testing.T) {
+		setup := setupTest(t)
+		seedSandboxStorage(t, setup.tmp, "run-done", "token-done")
+
+		callCount := atomic.Int32{}
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			callCount.Add(1)
+			return api.SandboxConnectionInfo{
+				Sandboxable: false,
+				Polling:     api.PollingResult{Completed: true},
+			}, nil
+		}
+
+		result, err := setup.service.StopSandbox(cli.StopSandboxConfig{
+			RunID: "run-done",
+			Json:  true,
+		})
+
+		require.NoError(t, err)
+		require.Len(t, result.Stopped, 1)
+		require.False(t, result.Stopped[0].WasRunning)
+		// Only the initial check call, no polling
+		require.Equal(t, int32(1), callCount.Load())
 	})
 }
 
@@ -2577,11 +2733,15 @@ func TestService_ResetSandbox(t *testing.T) {
 		seedResetStorage(t, setup, "run-initializing", "scoped-token-123")
 
 		cancelCalled := false
+		connInfoCalls := atomic.Int32{}
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
-			return api.SandboxConnectionInfo{
-				Sandboxable: false,
-				Polling:     api.PollingResult{Completed: false},
-			}, nil
+			if connInfoCalls.Add(1) == 1 {
+				return api.SandboxConnectionInfo{
+					Sandboxable: false,
+					Polling:     api.PollingResult{Completed: false},
+				}, nil
+			}
+			return api.SandboxConnectionInfo{Polling: api.PollingResult{Completed: true}}, nil
 		}
 		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
 			require.Equal(t, "run-initializing", runID)
@@ -2610,13 +2770,17 @@ func TestService_ResetSandbox(t *testing.T) {
 		setupResetMocks(setup)
 		seedResetStorage(t, setup, "run-ssh-fail", "token-ssh")
 
+		connInfoCalls := atomic.Int32{}
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
-			return api.SandboxConnectionInfo{
-				Sandboxable:    true,
-				Address:        "192.168.1.1:22",
-				PrivateUserKey: sandboxPrivateTestKey,
-				PublicHostKey:  sandboxPublicTestKey,
-			}, nil
+			if connInfoCalls.Add(1) == 1 {
+				return api.SandboxConnectionInfo{
+					Sandboxable:    true,
+					Address:        "192.168.1.1:22",
+					PrivateUserKey: sandboxPrivateTestKey,
+					PublicHostKey:  sandboxPublicTestKey,
+				}, nil
+			}
+			return api.SandboxConnectionInfo{Polling: api.PollingResult{Completed: true}}, nil
 		}
 		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
 			return errors.New("connection timed out")


### PR DESCRIPTION
### Problem

When running `rwx sandbox stop && rwx sandbox exec -- ...` in quick succession, `exec` can reattach to the old (dying) sandbox via remote recovery. This happens because `stop` sends the shutdown signal and returns immediately, but the server hasn't transitioned the run out of `in_progress` yet. The `exec` command's `ListSandboxRuns` API call (which filters for `execution_status=in_progress`) still returns the old run, and `GetSandboxConnectionInfo` shows `Polling.Completed: false` — so exec reattaches and tries to sync changes to a sandbox in an inconsistent state, resulting in `git apply` failures.

The same race window affects `rwx sandbox list` and any other command that queries the API immediately after stop.

### Solution

- After sending the stop signal (SSH `__rwx_sandbox_end__` or `CancelRun` API), `StopSandbox` now polls `GetSandboxConnectionInfo` until `Polling.Completed` is true or the server returns an error (404/410). This ensures the run has fully transitioned before `stop` returns.
- The same polling is applied in `ResetSandbox` after stopping the old sandbox, before starting the new one.
- Polling uses a 500ms default interval, respects the server's `BackoffMs` hint when provided, and times out after 30 seconds.
- Updated 6 existing tests whose mocks now need to transition to `Completed: true` on subsequent `GetSandboxConnectionInfo` calls.
- Added 4 new tests covering: multi-poll until completion, early exit on error, server backoff respect, and skip-polling for already-completed sandboxes.

#### Further confirmation needed

- [x] Verify the polling doesn't noticeably slow down `rwx sandbox stop` in normal usage (server should confirm completion quickly)
- [x] Verify `rwx sandbox stop && rwx sandbox exec` no longer produces `git apply` errors