### PR TITLE
Add --reset flag to sandbox exec and reconnection hint on 2nd exec

### DIFF
--- a/cmd/rwx/sandbox.go
+++ b/cmd/rwx/sandbox.go
@@ -207,6 +207,7 @@ CONFIG FILE
 			Json:           useJson,
 			Sync:           !sandboxNoSync,
 			InitParameters: initParams,
+			Reset:          sandboxReset,
 		})
 		if err != nil {
 			return err
@@ -388,6 +389,7 @@ var (
 	sandboxOpen       bool
 	sandboxWait       bool
 	sandboxNoSync     bool
+	sandboxReset      bool
 	sandboxInitParams []string
 )
 
@@ -411,6 +413,7 @@ func init() {
 	sandboxExecCmd.Flags().StringVar(&sandboxRunID, "id", "", "Use specific run ID")
 	sandboxExecCmd.Flags().BoolVar(&sandboxOpen, "open", false, "Open the run in a browser")
 	sandboxExecCmd.Flags().BoolVar(&sandboxNoSync, "no-sync", false, "Skip syncing local changes before execution")
+	sandboxExecCmd.Flags().BoolVar(&sandboxReset, "reset", false, "Reset the sandbox before executing")
 	sandboxExecCmd.Flags().StringArrayVar(&sandboxInitParams, "init", []string{}, "initialization parameters for the sandbox run, available in the `init` context. Can be specified multiple times")
 
 	// stop flags

--- a/internal/cli/sandbox_storage.go
+++ b/internal/cli/sandbox_storage.go
@@ -40,14 +40,15 @@ func DecodeCliState(encoded string) (*CliState, error) {
 }
 
 type SandboxSession struct {
-	RunID       string     `json:"runId"`
-	ConfigFile  string     `json:"configFile"`
-	ScopedToken string     `json:"scopedToken,omitempty"`
-	RunURL      string     `json:"runUrl,omitempty"`
-	ConfigHash  string     `json:"configHash,omitempty"`
-	CreatedAt   *time.Time `json:"createdAt,omitempty"`
-	LastExecAt  *time.Time `json:"lastExecAt,omitempty"`
-	ExecCount   int        `json:"execCount,omitempty"`
+	RunID         string     `json:"runId"`
+	ConfigFile    string     `json:"configFile"`
+	ScopedToken   string     `json:"scopedToken,omitempty"`
+	RunURL        string     `json:"runUrl,omitempty"`
+	ConfigHash    string     `json:"configHash,omitempty"`
+	CreatedAt     *time.Time `json:"createdAt,omitempty"`
+	LastExecAt    *time.Time `json:"lastExecAt,omitempty"`
+	ExecCount     int        `json:"execCount,omitempty"`
+	ResetNagShown bool       `json:"resetNagShown,omitempty"`
 }
 
 // HashConfigFile returns a hex-encoded SHA-256 hash of the file at the given path.

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -52,6 +52,7 @@ type ExecSandboxConfig struct {
 	Json           bool
 	Sync           bool
 	InitParameters map[string]string
+	Reset          bool
 }
 
 type ListSandboxesConfig struct {
@@ -434,6 +435,9 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 	var scopedToken string
 	var sessionRunURL string
 	var storedConfigHash string
+	var execCount int
+	var resetNagShown bool
+	isNewSandbox := false
 
 	// Sandbox selection priority:
 	// 1. --id flag
@@ -501,6 +505,8 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 					scopedToken = session.ScopedToken
 					sessionRunURL = session.RunURL
 					storedConfigHash = session.ConfigHash
+					execCount = session.ExecCount
+					resetNagShown = session.ResetNagShown
 				}
 			}
 		} else {
@@ -533,6 +539,8 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 				scopedToken = activeSessions[0].ScopedToken
 				sessionRunURL = activeSessions[0].RunURL
 				storedConfigHash = activeSessions[0].ConfigHash
+				execCount = activeSessions[0].ExecCount
+				resetNagShown = activeSessions[0].ResetNagShown
 				found = true
 			} else if len(activeSessions) > 1 {
 				UnlockSandboxStorage(lockFile)
@@ -606,10 +614,40 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 			}
 		}
 
+		if found && cfg.Reset {
+			connInfo, connErr := s.APIClient.GetSandboxConnectionInfo(runID, scopedToken)
+			if connErr == nil && connInfo.Sandboxable {
+				if sshErr := s.connectSSH(&connInfo); sshErr == nil {
+					_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_end__")
+					s.SSHClient.Close()
+				} else {
+					if cancelErr := s.APIClient.CancelRun(runID, scopedToken); cancelErr != nil {
+						fmt.Fprintf(s.Stderr, "Warning: failed to cancel run %s: %v\n", runID, cancelErr)
+					}
+				}
+			} else if connErr == nil && !connInfo.Polling.Completed {
+				if cancelErr := s.APIClient.CancelRun(runID, scopedToken); cancelErr != nil {
+					fmt.Fprintf(s.Stderr, "Warning: failed to cancel run %s: %v\n", runID, cancelErr)
+				}
+			}
+			s.waitForSandboxCompletion(runID, scopedToken)
+			storage.DeleteSession(branch, configFile)
+			if saveErr := storage.Save(); saveErr != nil {
+				fmt.Fprintf(s.Stderr, "Warning: unable to save sandbox sessions: %v\n", saveErr)
+			}
+			found = false
+			runID = ""
+			configFile = ""
+			scopedToken = ""
+			sessionRunURL = ""
+			storedConfigHash = ""
+		}
+
 		if !found {
 			// Pass the lock to StartSandbox so the "no session found → create
 			// new sandbox → persist session" sequence is atomic. StartSandbox
 			// will release it after the initial session is saved.
+			isNewSandbox = true
 			startResult, err := s.StartSandbox(StartSandboxConfig{
 				ConfigFile:     cfgFile,
 				RwxDirectory:   cfg.RwxDirectory,
@@ -634,6 +672,20 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 			// Resolution complete — release the file lock so concurrent execs
 			// can proceed. The agent-side lock serializes from here.
 			UnlockSandboxStorage(lockFile)
+		}
+	}
+
+	if !isNewSandbox && execCount >= 1 && !resetNagShown {
+		fmt.Fprintf(s.Stderr, "Reconnecting to existing sandbox. To re-run setup tasks, use: rwx sandbox exec --reset -- <command>\n")
+		if nagLock, nagLockErr := s.lockSandboxStorageWithInfo(cfg.Json); nagLockErr == nil {
+			if nagStorage, nagLoadErr := LoadSandboxStorage(); nagLoadErr == nil {
+				if nagSession, ok := nagStorage.GetSession(branch, configFile); ok {
+					nagSession.ResetNagShown = true
+					nagStorage.SetSession(branch, configFile, *nagSession)
+					_ = nagStorage.Save()
+				}
+			}
+			UnlockSandboxStorage(nagLock)
 		}
 	}
 

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -3476,3 +3476,401 @@ func TestService_ExecSandbox_DefinitionDrift(t *testing.T) {
 		require.NotContains(t, setup.mockStderr.String(), "has changed since this sandbox was started")
 	})
 }
+
+func TestService_ExecSandbox_Reset(t *testing.T) {
+	// seedExecResetStorage creates the config file and seeds a session under the
+	// "detached" branch key (what GetCurrentGitBranch returns in a non-git temp dir).
+	seedExecResetStorage := func(t *testing.T, setup *testSetup, runID, scopedToken string, execCount int) string {
+		t.Helper()
+		configFile := setup.absConfig(".rwx/sandbox.yml")
+		require.NoError(t, os.WriteFile(configFile, []byte("tasks:\n  - key: sandbox\n    run: rwx-sandbox\n"), 0o644))
+		key := cli.SessionKey("detached", configFile)
+		seedSandboxStorageMulti(t, setup.tmp, map[string]cli.SandboxSession{
+			key: {
+				RunID:       runID,
+				ConfigFile:  configFile,
+				ScopedToken: scopedToken,
+				ExecCount:   execCount,
+			},
+		})
+		return configFile
+	}
+
+	// setupNewSandboxMocks configures the mocks needed for StartSandbox to succeed
+	// and create "run-new".
+	setupNewSandboxMocks := func(setup *testSetup) {
+		setup.mockGit.MockGetBranch = "main"
+		setup.mockGit.MockGetCommit = "abc123"
+		setup.mockGit.MockGetOriginUrl = "git@github.com:example/repo.git"
+		setup.mockGit.MockGeneratePatchFile = git.PatchFile{}
+		setup.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+			return &api.InitiateRunResult{
+				RunID:  "run-new",
+				RunURL: "https://cloud.rwx.com/runs/run-new",
+			}, nil
+		}
+		setup.mockAPI.MockCreateSandboxToken = func(cfg api.CreateSandboxTokenConfig) (*api.CreateSandboxTokenResult, error) {
+			return &api.CreateSandboxTokenResult{Token: "new-token"}, nil
+		}
+		setup.mockAPI.MockGetDefaultBase = func() (api.DefaultBaseResult, error) {
+			return api.DefaultBaseResult{}, nil
+		}
+		setup.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+			return &api.PackageVersionsResult{}, nil
+		}
+	}
+
+	t.Run("stops existing sandbox via SSH and creates fresh sandbox", func(t *testing.T) {
+		setup := setupTest(t)
+		configFile := seedExecResetStorage(t, setup, "run-existing", "scoped-token", 2)
+		setupNewSandboxMocks(setup)
+
+		oldConnCalls := atomic.Int32{}
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			if runID == "run-existing" {
+				n := oldConnCalls.Add(1)
+				if n >= 3 {
+					return api.SandboxConnectionInfo{Polling: api.PollingResult{Completed: true}}, nil
+				}
+				return api.SandboxConnectionInfo{
+					Sandboxable:    true,
+					Address:        "192.168.1.1:22",
+					PrivateUserKey: sandboxPrivateTestKey,
+					PublicHostKey:  sandboxPublicTestKey,
+				}, nil
+			}
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+
+		sshEndSent := false
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error { return nil }
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
+			if cmd == "__rwx_sandbox_end__" {
+				sshEndSent = true
+			}
+			return 0, nil
+		}
+		setup.mockGit.MockGeneratePatch = func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error) {
+			return nil, nil, nil
+		}
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"echo", "hello"},
+			Json:       true,
+			Reset:      true,
+		})
+
+		require.NoError(t, err)
+		require.True(t, sshEndSent, "expected __rwx_sandbox_end__ to be sent to old sandbox")
+		require.Equal(t, "run-new", result.RunID)
+
+		storage, loadErr := cli.LoadSandboxStorage()
+		require.NoError(t, loadErr)
+		_, _, foundOld := storage.FindByRunID("run-existing")
+		require.False(t, foundOld, "old session should have been removed from storage")
+	})
+
+	t.Run("cancels via API when existing sandbox is not yet sandboxable", func(t *testing.T) {
+		setup := setupTest(t)
+		configFile := seedExecResetStorage(t, setup, "run-initializing", "scoped-token", 0)
+		setupNewSandboxMocks(setup)
+
+		oldConnCalls := atomic.Int32{}
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			if runID == "run-initializing" {
+				n := oldConnCalls.Add(1)
+				if n >= 3 {
+					return api.SandboxConnectionInfo{Polling: api.PollingResult{Completed: true}}, nil
+				}
+				return api.SandboxConnectionInfo{
+					Sandboxable: false,
+					Polling:     api.PollingResult{Completed: false},
+				}, nil
+			}
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+
+		cancelCalled := false
+		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
+			require.Equal(t, "run-initializing", runID)
+			require.Equal(t, "scoped-token", scopedToken)
+			cancelCalled = true
+			return nil
+		}
+
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error { return nil }
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) { return 0, nil }
+		setup.mockGit.MockGeneratePatch = func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error) {
+			return nil, nil, nil
+		}
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"echo", "hello"},
+			Json:       true,
+			Reset:      true,
+		})
+
+		require.NoError(t, err)
+		require.True(t, cancelCalled, "CancelRun should have been called for pre-sandboxable run")
+		require.Equal(t, "run-new", result.RunID)
+	})
+
+	t.Run("cancels via API when SSH fails for sandboxable existing sandbox", func(t *testing.T) {
+		setup := setupTest(t)
+		configFile := seedExecResetStorage(t, setup, "run-ssh-fail", "token-ssh", 0)
+		setupNewSandboxMocks(setup)
+
+		oldConnCalls := atomic.Int32{}
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			if runID == "run-ssh-fail" {
+				n := oldConnCalls.Add(1)
+				if n >= 3 {
+					return api.SandboxConnectionInfo{Polling: api.PollingResult{Completed: true}}, nil
+				}
+				return api.SandboxConnectionInfo{
+					Sandboxable:    true,
+					Address:        "192.168.1.1:22",
+					PrivateUserKey: sandboxPrivateTestKey,
+					PublicHostKey:  sandboxPublicTestKey,
+				}, nil
+			}
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+
+		cancelCalled := false
+		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
+			require.Equal(t, "run-ssh-fail", runID)
+			require.Equal(t, "token-ssh", scopedToken)
+			cancelCalled = true
+			return nil
+		}
+
+		connectCalls := atomic.Int32{}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
+			if connectCalls.Add(1) == 1 {
+				return errors.New("connection refused")
+			}
+			return nil
+		}
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) { return 0, nil }
+		setup.mockGit.MockGeneratePatch = func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error) {
+			return nil, nil, nil
+		}
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"echo", "hello"},
+			Json:       true,
+			Reset:      true,
+		})
+
+		require.NoError(t, err)
+		require.True(t, cancelCalled, "CancelRun should have been called when SSH fails")
+		require.Equal(t, "run-new", result.RunID)
+	})
+
+	t.Run("creates new sandbox when no existing session", func(t *testing.T) {
+		setup := setupTest(t)
+		configFile := setup.absConfig(".rwx/sandbox.yml")
+		require.NoError(t, os.WriteFile(configFile, []byte("tasks:\n  - key: sandbox\n    run: rwx-sandbox\n"), 0o644))
+		setupNewSandboxMocks(setup)
+
+		// No session in storage — ListSandboxRuns is called during remote recovery
+		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
+			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+		}
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error { return nil }
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) { return 0, nil }
+		setup.mockGit.MockGeneratePatch = func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error) {
+			return nil, nil, nil
+		}
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"echo", "hello"},
+			Json:       true,
+			Reset:      true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "run-new", result.RunID)
+	})
+}
+
+func TestService_ExecSandbox_ReconnectionHint(t *testing.T) {
+	// seedHintStorage creates the config file and seeds a session with the given
+	// ExecCount and ResetNagShown under the "detached" branch key.
+	seedHintStorage := func(t *testing.T, setup *testSetup, runID string, execCount int, resetNagShown bool) string {
+		t.Helper()
+		configFile := setup.absConfig(".rwx/sandbox.yml")
+		require.NoError(t, os.WriteFile(configFile, []byte("tasks:\n  - key: sandbox\n"), 0o644))
+		key := cli.SessionKey("detached", configFile)
+		seedSandboxStorageMulti(t, setup.tmp, map[string]cli.SandboxSession{
+			key: {
+				RunID:         runID,
+				ConfigFile:    configFile,
+				ScopedToken:   "scoped-token",
+				ExecCount:     execCount,
+				ResetNagShown: resetNagShown,
+			},
+		})
+		return configFile
+	}
+
+	// setupExecMocks configures standard SSH and connection info mocks for a
+	// successful exec against an existing sandbox.
+	setupExecMocks := func(setup *testSetup) {
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error { return nil }
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) { return 0, nil }
+		setup.mockGit.MockGeneratePatch = func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error) {
+			return nil, nil, nil
+		}
+	}
+
+	t.Run("shows reconnection hint on second exec", func(t *testing.T) {
+		setup := setupTest(t)
+		configFile := seedHintStorage(t, setup, "run-hint", 1, false)
+		setupExecMocks(setup)
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"echo", "hello"},
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.Contains(t, setup.mockStderr.String(), "Reconnecting to existing sandbox")
+		require.Contains(t, setup.mockStderr.String(), "--reset")
+	})
+
+	t.Run("persists ResetNagShown to storage after showing hint", func(t *testing.T) {
+		setup := setupTest(t)
+		configFile := seedHintStorage(t, setup, "run-nag-persist", 1, false)
+		setupExecMocks(setup)
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"echo", "hello"},
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+
+		storage, loadErr := cli.LoadSandboxStorage()
+		require.NoError(t, loadErr)
+		session, found := storage.GetSession("detached", configFile)
+		require.True(t, found)
+		require.True(t, session.ResetNagShown, "ResetNagShown should be persisted as true after hint is shown")
+	})
+
+	t.Run("does not show reconnection hint on first exec", func(t *testing.T) {
+		setup := setupTest(t)
+		configFile := seedHintStorage(t, setup, "run-first-exec", 0, false)
+		setupExecMocks(setup)
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"echo", "hello"},
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.NotContains(t, setup.mockStderr.String(), "Reconnecting to existing sandbox")
+	})
+
+	t.Run("does not show reconnection hint after it has been shown before", func(t *testing.T) {
+		setup := setupTest(t)
+		configFile := seedHintStorage(t, setup, "run-nag-done", 5, true)
+		setupExecMocks(setup)
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"echo", "hello"},
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.NotContains(t, setup.mockStderr.String(), "Reconnecting to existing sandbox")
+	})
+
+	t.Run("does not show reconnection hint for new sandboxes", func(t *testing.T) {
+		setup := setupTest(t)
+		configFile := setup.absConfig(".rwx/sandbox.yml")
+		require.NoError(t, os.WriteFile(configFile, []byte("tasks:\n  - key: sandbox\n    run: rwx-sandbox\n"), 0o644))
+
+		setup.mockGit.MockGetBranch = "main"
+		setup.mockGit.MockGetCommit = "abc123"
+		setup.mockGit.MockGetOriginUrl = "git@github.com:example/repo.git"
+		setup.mockGit.MockGeneratePatchFile = git.PatchFile{}
+		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
+			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+		}
+		setup.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+			return &api.InitiateRunResult{RunID: "run-brand-new", RunURL: "https://cloud.rwx.com/runs/run-brand-new"}, nil
+		}
+		setup.mockAPI.MockCreateSandboxToken = func(cfg api.CreateSandboxTokenConfig) (*api.CreateSandboxTokenResult, error) {
+			return &api.CreateSandboxTokenResult{Token: "token"}, nil
+		}
+		setup.mockAPI.MockGetDefaultBase = func() (api.DefaultBaseResult, error) {
+			return api.DefaultBaseResult{}, nil
+		}
+		setup.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+			return &api.PackageVersionsResult{}, nil
+		}
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error { return nil }
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) { return 0, nil }
+		setup.mockGit.MockGeneratePatch = func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error) {
+			return nil, nil, nil
+		}
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"echo", "hello"},
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.NotContains(t, setup.mockStderr.String(), "Reconnecting to existing sandbox")
+	})
+}

--- a/test/integration/sandbox-exec-reset.sh
+++ b/test/integration/sandbox-exec-reset.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/sandbox-helpers.sh"
+
+start_sandbox
+trap stop_sandbox EXIT
+
+# Create a sentinel file in the existing sandbox
+"${RWX_CLI}" sandbox exec -- sh -c 'echo "sentinel" > /tmp/exec-reset-marker.txt'
+
+# Verify the sentinel exists before reset
+marker=$("${RWX_CLI}" sandbox exec --no-sync -- cat /tmp/exec-reset-marker.txt)
+if [ "$marker" != "sentinel" ]; then
+  echo "ERROR: Sentinel file not found in sandbox before exec --reset"
+  exit 1
+fi
+
+# exec --reset should stop the existing sandbox, start a fresh one, and run the command
+"${RWX_CLI}" sandbox exec --reset --init ref=main --init "cli=${COMMIT_SHA}" "${SCRIPT_DIR}/definitions/sandbox.yml" -- sh -c 'echo "exec-reset-complete"'
+
+# In the fresh sandbox, the sentinel file should not exist
+exit_code=0
+"${RWX_CLI}" sandbox exec --no-sync -- cat /tmp/exec-reset-marker.txt 2>/dev/null || exit_code=$?
+
+if [ "$exit_code" -eq 0 ]; then
+  echo "ERROR: Sentinel file still exists after exec --reset - sandbox was not re-provisioned"
+  exit 1
+fi

--- a/test/integration/sandbox-reconnect-hint.sh
+++ b/test/integration/sandbox-reconnect-hint.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/sandbox-helpers.sh"
+
+start_sandbox
+trap stop_sandbox EXIT
+
+# First exec: reconnection hint should NOT appear
+first_stderr=$("${RWX_CLI}" sandbox exec -- sh -c 'echo first' 2>&1 >/dev/null) || true
+if echo "$first_stderr" | grep -q "Reconnecting to existing sandbox"; then
+  echo "ERROR: Unexpected reconnection hint on first exec"
+  echo "stderr was: $first_stderr"
+  exit 1
+fi
+
+# Second exec: reconnection hint SHOULD appear
+second_stderr=$("${RWX_CLI}" sandbox exec -- sh -c 'echo second' 2>&1 >/dev/null) || true
+if ! echo "$second_stderr" | grep -q "Reconnecting to existing sandbox"; then
+  echo "ERROR: Expected reconnection hint on second exec but did not find it"
+  echo "stderr was: $second_stderr"
+  exit 1
+fi
+
+# Third exec: hint should NOT appear again (only shown once)
+third_stderr=$("${RWX_CLI}" sandbox exec -- sh -c 'echo third' 2>&1 >/dev/null) || true
+if echo "$third_stderr" | grep -q "Reconnecting to existing sandbox"; then
+  echo "ERROR: Unexpected reconnection hint on third exec (should only appear once)"
+  exit 1
+fi

--- a/test/integration/sandbox-reset.sh
+++ b/test/integration/sandbox-reset.sh
@@ -11,7 +11,7 @@ trap stop_sandbox EXIT
 "${RWX_CLI}" sandbox exec -- sh -c 'echo "before-reset" > /tmp/reset-marker.txt'
 
 # Verify the file exists
-marker_check=$("${RWX_CLI}" sandbox exec --no-sync -- cat /tmp/reset-marker.txt 2>&1 | head -1)
+marker_check=$("${RWX_CLI}" sandbox exec --no-sync -- cat /tmp/reset-marker.txt)
 if [ "$marker_check" != "before-reset" ]; then
   echo "Marker file not found in sandbox before reset"
   exit 1


### PR DESCRIPTION
### Background

[RWX-678](https://linear.app/rwx-cloud/issue/RWX-678/reset-flag-on-sandbox-exec-reconnection-hint-on-2nd-exec) · [RFC 168: Sandbox setup syncing](https://www.notion.so/rwx/RFC-168-Sandbox-setup-syncing-337c3a490d98803ea3d2c45a50bba14b)

### Problem

1. There's no single-step way to reset a sandbox and immediately exec a command. Agents must run `rwx sandbox reset` followed by `rwx sandbox exec`, which is awkward.
2. When an agent reconnects to an existing sandbox, there's no indication that it's reusing prior state or how to force a fresh one.

### Solution

- **`--reset` flag on `sandbox exec`**: `rwx sandbox exec --reset -- <command>` stops the existing sandbox inline (via SSH `__rwx_sandbox_end__` or API cancel fallback, same pattern as `StopSandbox`) and waits for server confirmation before starting a fresh sandbox and exec-ing. The stop logic is inlined rather than delegating to `ResetSandbox` to avoid a double-lock deadlock.
- **Reconnection hint on 2nd exec only**: When auto-resolution finds an existing sandbox and `ExecCount >= 1` (i.e. this is the second exec), prints to stderr: `Reconnecting to existing sandbox. To re-run setup tasks, use: rwx sandbox exec --reset -- <command>`. A new `ResetNagShown bool` field on `SandboxSession` ensures this prints exactly once per sandbox.

**Files changed:**
- `internal/cli/sandbox_storage.go` — added `ResetNagShown bool` to `SandboxSession`
- `internal/cli/service_sandbox.go` — added `Reset bool` to `ExecSandboxConfig`; capture `ExecCount`/`ResetNagShown` from found sessions; insert inline reset logic and nag display after session resolution
- `cmd/rwx/sandbox.go` — added `sandboxReset` var, `--reset` flag registration, and pass-through to `ExecSandboxConfig`

#### Further confirmation needed

- [ ] Verify `rwx sandbox exec --reset -- <command>` correctly stops an active sandbox, waits for it to fully stop, then starts a fresh one and executes
- [ ] Verify the reconnection hint appears on the second exec (not the first, not the third+)
- [ ] Verify `--reset` against a sandbox that is not yet sandboxable (pre-setup) triggers the API cancel path