### PR TITLE
Surface setup failures in CLI when sandbox connection polling completes

### DIFF
--- a/cmd/rwx/main.go
+++ b/cmd/rwx/main.go
@@ -104,6 +104,8 @@ func classifyError(err error) string {
 		return "ambiguous_task_key"
 	case errors.Is(err, internalerrors.ErrNetworkTransient):
 		return "network_transient_error"
+	case errors.Is(err, internalerrors.ErrSandboxSetupFailure):
+		return "sandbox_setup_failure"
 	default:
 		return "unknown"
 	}

--- a/internal/api/sandbox_connection_info.go
+++ b/internal/api/sandbox_connection_info.go
@@ -6,6 +6,7 @@ type SandboxConnectionInfo struct {
 	PublicHostKey  string        `json:"public_host_key"`
 	PrivateUserKey string        `json:"private_user_key"`
 	Polling        PollingResult `json:"polling"`
+	FailureReason  string        `json:"failure_reason,omitempty"`
 }
 
 type SandboxConnectionInfoError struct {

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1510,6 +1510,7 @@ func (s Service) waitForSandboxReadyWithToken(runID, scopedToken string, jsonMod
 	// Check once before showing spinner - sandbox may already be ready
 	connInfo, err := s.APIClient.GetSandboxConnectionInfo(runID, scopedToken)
 	if err != nil {
+		s.printSandboxRunPrompt(runID)
 		return nil, errors.Wrap(err, "unable to get sandbox connection info")
 	}
 
@@ -1518,7 +1519,7 @@ func (s Service) waitForSandboxReadyWithToken(runID, scopedToken string, jsonMod
 	}
 
 	if connInfo.Polling.Completed {
-		return nil, fmt.Errorf("Sandbox run '%s' completed before becoming ready", runID)
+		return nil, s.sandboxCompletedError(runID, connInfo)
 	}
 
 	// Sandbox not ready yet - start spinner and poll
@@ -1538,6 +1539,7 @@ func (s Service) waitForSandboxReadyWithToken(runID, scopedToken string, jsonMod
 
 		connInfo, err = s.APIClient.GetSandboxConnectionInfo(runID, scopedToken)
 		if err != nil {
+			s.printSandboxRunPrompt(runID)
 			return nil, errors.Wrap(err, "unable to get sandbox connection info")
 		}
 
@@ -1546,8 +1548,33 @@ func (s Service) waitForSandboxReadyWithToken(runID, scopedToken string, jsonMod
 		}
 
 		if connInfo.Polling.Completed {
-			return nil, fmt.Errorf("Sandbox run '%s' completed before becoming ready", runID)
+			return nil, s.sandboxCompletedError(runID, connInfo)
 		}
+	}
+}
+
+// sandboxCompletedError prints run failure output to stderr and returns an appropriate error.
+// The prompt fetch is best-effort and silently skipped if unavailable.
+func (s Service) sandboxCompletedError(runID string, connInfo api.SandboxConnectionInfo) error {
+	s.printSandboxRunPrompt(runID)
+
+	switch connInfo.FailureReason {
+	case "timed_out":
+		return errors.WrapSentinel(fmt.Errorf("Sandbox run '%s' timed out before becoming ready", runID), errors.ErrSandboxSetupFailure)
+	case "cancelled":
+		return errors.WrapSentinel(fmt.Errorf("Sandbox run '%s' was cancelled before becoming ready", runID), errors.ErrSandboxSetupFailure)
+	case "failed":
+		return errors.WrapSentinel(fmt.Errorf("Sandbox run '%s' failed before becoming ready", runID), errors.ErrSandboxSetupFailure)
+	default:
+		return errors.WrapSentinel(fmt.Errorf("Sandbox run '%s' completed before becoming ready", runID), errors.ErrSandboxSetupFailure)
+	}
+}
+
+// printSandboxRunPrompt fetches and prints the run prompt to stderr.
+// Best-effort: silently skipped if the prompt is unavailable or the run is still in progress.
+func (s Service) printSandboxRunPrompt(runID string) {
+	if prompt, err := s.APIClient.GetRunPrompt(runID); err == nil && prompt != "" {
+		fmt.Fprintf(s.Stderr, "\n%s", prompt)
 	}
 }
 

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -644,6 +644,202 @@ func TestService_ExecSandbox(t *testing.T) {
 		require.Contains(t, err.Error(), "completed before becoming ready")
 	})
 
+	t.Run("prints run failure output to stderr on polling completion", func(t *testing.T) {
+		setup := setupTest(t)
+
+		runID := "run-setup-failed"
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable: false,
+				Polling:     api.PollingResult{Completed: true},
+			}, nil
+		}
+
+		setup.mockAPI.MockGetRunPrompt = func(id string) (string, error) {
+			require.Equal(t, runID, id)
+			return "# Failed task:\n\n- setup\n", nil
+		}
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      runID,
+			Json:       true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "completed before becoming ready")
+		require.Contains(t, setup.mockStderr.String(), "Failed task")
+	})
+
+	t.Run("prints run failure output to stderr when polling loop completes", func(t *testing.T) {
+		setup := setupTest(t)
+
+		runID := "run-polling-failed"
+		calls := atomic.Int32{}
+		backoff := 0
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			if calls.Add(1) == 1 {
+				return api.SandboxConnectionInfo{
+					Sandboxable: false,
+					Polling:     api.PollingResult{Completed: false, BackoffMs: &backoff},
+				}, nil
+			}
+			return api.SandboxConnectionInfo{
+				Sandboxable: false,
+				Polling:     api.PollingResult{Completed: true},
+			}, nil
+		}
+
+		setup.mockAPI.MockGetRunPrompt = func(id string) (string, error) {
+			require.Equal(t, runID, id)
+			return "# Failed task:\n\n- setup\n", nil
+		}
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      runID,
+			Json:       true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "completed before becoming ready")
+		require.Contains(t, setup.mockStderr.String(), "Failed task")
+	})
+
+	t.Run("gracefully degrades when GetRunPrompt fails on polling completion", func(t *testing.T) {
+		setup := setupTest(t)
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable: false,
+				Polling:     api.PollingResult{Completed: true},
+			}, nil
+		}
+
+		setup.mockAPI.MockGetRunPrompt = func(id string) (string, error) {
+			return "", errors.New("server unavailable")
+		}
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      "run-no-prompt",
+			Json:       true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "completed before becoming ready")
+		require.Empty(t, setup.mockStderr.String())
+	})
+
+	t.Run("prints run failure output to stderr when GetSandboxConnectionInfo returns an error", func(t *testing.T) {
+		setup := setupTest(t)
+
+		runID := "run-conn-error"
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{}, errors.New("This run or task is no longer available for sandbox")
+		}
+
+		setup.mockAPI.MockGetRunPrompt = func(id string) (string, error) {
+			require.Equal(t, runID, id)
+			return "# Failed task:\n\n- preflight\n", nil
+		}
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      runID,
+			Json:       true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unable to get sandbox connection info")
+		require.Contains(t, setup.mockStderr.String(), "Failed task")
+	})
+
+	t.Run("uses timed_out FailureReason for natural error message", func(t *testing.T) {
+		setup := setupTest(t)
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:   false,
+				Polling:       api.PollingResult{Completed: true},
+				FailureReason: "timed_out",
+			}, nil
+		}
+
+		setup.mockAPI.MockGetRunPrompt = func(id string) (string, error) {
+			return "", nil
+		}
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      "run-timed-out",
+			Json:       true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "timed out before becoming ready")
+	})
+
+	t.Run("uses cancelled FailureReason for natural error message", func(t *testing.T) {
+		setup := setupTest(t)
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:   false,
+				Polling:       api.PollingResult{Completed: true},
+				FailureReason: "cancelled",
+			}, nil
+		}
+
+		setup.mockAPI.MockGetRunPrompt = func(id string) (string, error) {
+			return "", nil
+		}
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      "run-cancelled",
+			Json:       true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "was cancelled before becoming ready")
+	})
+
+	t.Run("uses failed FailureReason for natural error message", func(t *testing.T) {
+		setup := setupTest(t)
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:   false,
+				Polling:       api.PollingResult{Completed: true},
+				FailureReason: "failed",
+			}, nil
+		}
+
+		setup.mockAPI.MockGetRunPrompt = func(id string) (string, error) {
+			return "", nil
+		}
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      "run-failed",
+			Json:       true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed before becoming ready")
+	})
+
 	t.Run("shows firewall hint when SSH connection times out", func(t *testing.T) {
 		setup := setupTest(t)
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -64,6 +64,7 @@ var (
 	ErrGone                    = errors.New("gone")
 	ErrRetry                   = errors.New("retry")
 	ErrSandboxNoGitDir         = errors.New("no .git directory found in sandbox. Set 'preserve-git-dir: true' on your git/clone task")
+	ErrSandboxSetupFailure     = errors.New("sandbox setup failure")
 	ErrSSH                     = errors.New("ssh error")
 	ErrPatch                   = errors.New("patch error")
 	ErrTimeout                 = errors.New("timeout")

--- a/test/integration/definitions/sandbox-setup-failure.yml
+++ b/test/integration/definitions/sandbox-setup-failure.yml
@@ -1,0 +1,9 @@
+tasks:
+  - key: preflight
+    run: |
+      echo "intentional-setup-failure"
+      exit 1
+
+  - key: sandbox
+    use: preflight
+    run: rwx-sandbox

--- a/test/integration/sandbox-setup-failure.sh
+++ b/test/integration/sandbox-setup-failure.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Verifies that setup failure output is surfaced in stderr when a sandbox run
+# fails before reaching the sandbox task.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RWX_CLI="${REPO_ROOT}/rwx"
+
+stderr_output=$("${RWX_CLI}" sandbox exec \
+  "${SCRIPT_DIR}/definitions/sandbox-setup-failure.yml" \
+  -- echo hello 2>&1 >/dev/null) || true
+
+if ! echo "$stderr_output" | grep -q "Failed task"; then
+  echo "ERROR: Expected setup failure prompt in stderr but did not find it"
+  echo "stderr was: $stderr_output"
+  exit 1
+fi
+
+if ! echo "$stderr_output" | grep -q "preflight"; then
+  echo "ERROR: Expected failing task name in stderr but did not find it"
+  echo "stderr was: $stderr_output"
+  exit 1
+fi
+
+echo "OK: setup failure prompt was surfaced in stderr"


### PR DESCRIPTION
### Background

- Linear (client-side): https://linear.app/rwx-cloud/issue/RWX-676/surface-setup-failures-in-cli-when-sandbox-connection-polling
- Linear (server-side): https://linear.app/rwx-cloud/issue/RWX-677/return-explicit-failure-payload-from-getsandboxconnectioninfo-on-setup
- Server-side PR (deployed): https://github.com/rwx-cloud/cloud/pull/7332
- RFC 168: https://www.notion.so/rwx/RFC-168-Sandbox-setup-syncing-337c3a490d98803ea3d2c45a50bba14b

### Problem

When a sandbox run fails before reaching the sandbox task (e.g. a broken setup step), the CLI returned a generic error with no actionable output. Agents had no way to self-heal because they couldn't see what went wrong.

### Solution

- Added `FailureReason string` (omitempty) to `SandboxConnectionInfo` in `internal/api/sandbox_connection_info.go`, consuming the `failure_reason` field now returned by the server (RWX-677).
- Extracted `sandboxCompletedError` helper in `service_sandbox.go` to deduplicate the two `Polling.Completed` check points in `waitForSandboxReadyWithToken`. Error wording adapts naturally: `timed_out` → "timed out", `cancelled` → "was cancelled", `failed` → "failed".
- Added `printSandboxRunPrompt` helper that fetches the run prompt via `GetRunPrompt` and prints it to stderr (best-effort, silently skipped if unavailable). Called at every failure exit point in `waitForSandboxReadyWithToken` — both the `Polling.Completed` path and the `GetSandboxConnectionInfo` error path.

#### Further confirmation needed

- [ ] Verify the `FailureReason`-based error wording (`timed_out`, `cancelled`, `failed`) appears correctly in practice once a run hits each case end-to-end.