### PR TITLE
Re-enable patching on sandbox start and handle first-exec sync

### DIFF
--- a/.rwx/integration/dispatch-test/dispatch.yml
+++ b/.rwx/integration/dispatch-test/dispatch.yml
@@ -21,4 +21,4 @@ tasks:
     run: exit 1
 
   - key: fail-slow
-    run: sleep 10 && exit 1
+    run: sleep 60 && exit 1

--- a/.rwx/integration/results-test/failing.yml
+++ b/.rwx/integration/results-test/failing.yml
@@ -7,4 +7,4 @@ tasks:
     run: exit 1
 
   - key: will-fail-slow
-    run: sleep 10 && exit 1
+    run: sleep 60 && exit 1

--- a/.rwx/integration/run-test/failing-def.yml
+++ b/.rwx/integration/run-test/failing-def.yml
@@ -7,4 +7,4 @@ tasks:
     run: exit 1
 
   - key: will-fail-slow
-    run: sleep 10 && exit 1
+    run: sleep 60 && exit 1

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -310,7 +310,7 @@ func (s Service) StartSandbox(cfg StartSandboxConfig) (*StartSandboxResult, erro
 		Json:           cfg.Json,
 		Title:          title,
 		InitParameters: cfg.InitParameters,
-		Patchable:      false,
+		Patchable:      true,
 		CliState:       EncodeCliState(branch, cfg.ConfigFile),
 	})
 
@@ -753,7 +753,9 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 
 	// Clean up any dirty state from a previous interrupted exec.
 	// This makes exec self-healing — no manual reset needed after crashes.
-	if cfg.Sync {
+	// Skip on new sandboxes: no prior exec could have left dirty state, and
+	// checkout+clean would wipe setup artifacts written by the setup tasks.
+	if cfg.Sync && !isNewSandbox {
 		if cleanErr := s.cleanSandboxState(); cleanErr != nil {
 			fmt.Fprintf(s.Stderr, "Warning: failed to clean sandbox state: %v\n", cleanErr)
 		}
@@ -764,7 +766,7 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 	var syncPushPatchBytes int
 	if cfg.Sync {
 		syncPushStart := time.Now()
-		patchBytes, err := s.syncChangesToSandbox(cfg.Json)
+		patchBytes, err := s.syncChangesToSandbox(cfg.Json, isNewSandbox)
 		syncPushMs = time.Since(syncPushStart).Milliseconds()
 		syncPushPatchBytes = patchBytes
 		if err != nil {
@@ -1519,7 +1521,6 @@ func (s Service) waitForSandboxReadyWithToken(runID, scopedToken string, jsonMod
 	// Check once before showing spinner - sandbox may already be ready
 	connInfo, err := s.APIClient.GetSandboxConnectionInfo(runID, scopedToken)
 	if err != nil {
-		s.printSandboxRunPrompt(runID)
 		return nil, errors.Wrap(err, "unable to get sandbox connection info")
 	}
 
@@ -1527,7 +1528,7 @@ func (s Service) waitForSandboxReadyWithToken(runID, scopedToken string, jsonMod
 		return &connInfo, nil
 	}
 
-	if connInfo.Polling.Completed {
+	if connInfo.Polling.Completed || connInfo.FailureReason != "" {
 		return nil, s.sandboxCompletedError(runID, connInfo)
 	}
 
@@ -1548,7 +1549,6 @@ func (s Service) waitForSandboxReadyWithToken(runID, scopedToken string, jsonMod
 
 		connInfo, err = s.APIClient.GetSandboxConnectionInfo(runID, scopedToken)
 		if err != nil {
-			s.printSandboxRunPrompt(runID)
 			return nil, errors.Wrap(err, "unable to get sandbox connection info")
 		}
 
@@ -1556,34 +1556,47 @@ func (s Service) waitForSandboxReadyWithToken(runID, scopedToken string, jsonMod
 			return &connInfo, nil
 		}
 
-		if connInfo.Polling.Completed {
+		if connInfo.Polling.Completed || connInfo.FailureReason != "" {
 			return nil, s.sandboxCompletedError(runID, connInfo)
 		}
 	}
 }
 
-// sandboxCompletedError prints run failure output to stderr and returns an appropriate error.
-// The prompt fetch is best-effort and silently skipped if unavailable.
+// sandboxCompletedError prints the error header to stderr, then the failing
+// run's prompt to stdout (so they appear in a sensible order under combined
+// output), and returns a handled error so main.go doesn't re-print the header.
+// The returned error still carries ErrSandboxSetupFailure for telemetry
+// classification.
 func (s Service) sandboxCompletedError(runID string, connInfo api.SandboxConnectionInfo) error {
-	s.printSandboxRunPrompt(runID)
-
+	var msg error
 	switch connInfo.FailureReason {
 	case "timed_out":
-		return errors.WrapSentinel(fmt.Errorf("Sandbox run '%s' timed out before becoming ready", runID), errors.ErrSandboxSetupFailure)
+		msg = fmt.Errorf("Sandbox run '%s' timed out before becoming ready", runID)
 	case "cancelled":
-		return errors.WrapSentinel(fmt.Errorf("Sandbox run '%s' was cancelled before becoming ready", runID), errors.ErrSandboxSetupFailure)
+		msg = fmt.Errorf("Sandbox run '%s' was cancelled before becoming ready", runID)
 	case "failed":
-		return errors.WrapSentinel(fmt.Errorf("Sandbox run '%s' failed before becoming ready", runID), errors.ErrSandboxSetupFailure)
+		msg = fmt.Errorf("Sandbox run '%s' failed before becoming ready", runID)
 	default:
-		return errors.WrapSentinel(fmt.Errorf("Sandbox run '%s' completed before becoming ready", runID), errors.ErrSandboxSetupFailure)
+		msg = fmt.Errorf("Sandbox run '%s' completed before becoming ready", runID)
 	}
+
+	fmt.Fprintf(s.Stderr, "Error: %s\n", msg)
+	s.printSandboxRunPrompt(runID)
+
+	return errors.WrapSentinel(errors.WrapSentinel(msg, HandledError), errors.ErrSandboxSetupFailure)
 }
 
-// printSandboxRunPrompt fetches and prints the run prompt to stderr.
-// Best-effort: silently skipped if the prompt is unavailable or the run is still in progress.
+// printSandboxRunPrompt fetches and prints the run prompt to stdout.
+// Polls /status first to ensure results are indexed before fetching the prompt.
+// Best-effort: silently skipped if unavailable.
 func (s Service) printSandboxRunPrompt(runID string) {
+	_, _ = s.GetRunStatus(GetRunStatusConfig{
+		RunID: runID,
+		Wait:  true,
+		Json:  true,
+	})
 	if prompt, err := s.APIClient.GetRunPrompt(runID); err == nil && prompt != "" {
-		fmt.Fprintf(s.Stderr, "\n%s", prompt)
+		fmt.Fprintf(s.Stdout, "\n%s", prompt)
 	}
 }
 
@@ -1648,7 +1661,7 @@ func SandboxTitle(cwd, branch, configFile string) string {
 	return title
 }
 
-func (s Service) syncChangesToSandbox(jsonMode bool) (int, error) {
+func (s Service) syncChangesToSandbox(jsonMode bool, baselineOnly bool) (int, error) {
 	// Warn if .rej files from a previous failed pull are still present
 	if cwd, err := os.Getwd(); err == nil {
 		if rejFiles := findAllRejFiles(cwd); len(rejFiles) > 0 {
@@ -1720,8 +1733,14 @@ func (s Service) syncChangesToSandbox(jsonMode bool) (int, error) {
 		return 0, syncPushErr
 	}
 
-	// Apply patch on remote (use full path since sandbox session may have minimal PATH)
-	exitCode, applyOutput, err := s.SSHClient.ExecuteCommandWithStdinAndCombinedOutput("/usr/bin/git apply --allow-empty -", bytes.NewReader(patch))
+	// Apply patch on remote (use full path since sandbox session may have minimal PATH).
+	// On a new sandbox the patch is already applied to the working tree server-side, so we only
+	// stage it to the index (--cached) to establish the refs/rwx-sync baseline without double-applying.
+	applyCmd := "/usr/bin/git apply --allow-empty -"
+	if baselineOnly {
+		applyCmd = "/usr/bin/git apply --cached --allow-empty -"
+	}
+	exitCode, applyOutput, err := s.SSHClient.ExecuteCommandWithStdinAndCombinedOutput(applyCmd, bytes.NewReader(patch))
 
 	// Mark end of sync operations
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
@@ -1750,7 +1769,13 @@ func (s Service) syncChangesToSandbox(jsonMode bool) (int, error) {
 	// before this point, pull still has the previous baseline to diff against.
 	// Wrap in sync markers so these internal git commands don't appear in task logs.
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
-	snapshotExitCode, snapshotErr := s.SSHClient.ExecuteCommand("/usr/bin/git update-ref -d refs/rwx-sync 2>/dev/null; /usr/bin/git add -A && /usr/bin/git -c user.name=rwx -c user.email=rwx commit --allow-empty -m rwx-sync >/dev/null 2>&1 && /usr/bin/git update-ref refs/rwx-sync HEAD")
+	// On baseline-only the patch is already staged via --cached; skip git add -A to avoid
+	// capturing unrelated working-tree state left by setup tasks.
+	snapshotCmd := "/usr/bin/git update-ref -d refs/rwx-sync 2>/dev/null; /usr/bin/git add -A && /usr/bin/git -c user.name=rwx -c user.email=rwx commit --allow-empty -m rwx-sync >/dev/null 2>&1 && /usr/bin/git update-ref refs/rwx-sync HEAD"
+	if baselineOnly {
+		snapshotCmd = "/usr/bin/git update-ref -d refs/rwx-sync 2>/dev/null; /usr/bin/git -c user.name=rwx -c user.email=rwx commit --allow-empty -m rwx-sync >/dev/null 2>&1 && /usr/bin/git update-ref refs/rwx-sync HEAD"
+	}
+	snapshotExitCode, snapshotErr := s.SSHClient.ExecuteCommand(snapshotCmd)
 	if snapshotErr != nil {
 		_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 		syncPushErr = errors.Wrap(snapshotErr, "failed to create sync snapshot ref")

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -679,7 +679,7 @@ func TestService_ExecSandbox(t *testing.T) {
 		require.Contains(t, err.Error(), "completed before becoming ready")
 	})
 
-	t.Run("prints run failure output to stderr on polling completion", func(t *testing.T) {
+	t.Run("prints run failure output to stdout on polling completion", func(t *testing.T) {
 		setup := setupTest(t)
 
 		runID := "run-setup-failed"
@@ -705,10 +705,10 @@ func TestService_ExecSandbox(t *testing.T) {
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "completed before becoming ready")
-		require.Contains(t, setup.mockStderr.String(), "Failed task")
+		require.Contains(t, setup.mockStdout.String(), "Failed task")
 	})
 
-	t.Run("prints run failure output to stderr when polling loop completes", func(t *testing.T) {
+	t.Run("prints run failure output to stdout when polling loop completes", func(t *testing.T) {
 		setup := setupTest(t)
 
 		runID := "run-polling-failed"
@@ -742,7 +742,7 @@ func TestService_ExecSandbox(t *testing.T) {
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "completed before becoming ready")
-		require.Contains(t, setup.mockStderr.String(), "Failed task")
+		require.Contains(t, setup.mockStdout.String(), "Failed task")
 	})
 
 	t.Run("gracefully degrades when GetRunPrompt fails on polling completion", func(t *testing.T) {
@@ -768,33 +768,6 @@ func TestService_ExecSandbox(t *testing.T) {
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "completed before becoming ready")
-		require.Empty(t, setup.mockStderr.String())
-	})
-
-	t.Run("prints run failure output to stderr when GetSandboxConnectionInfo returns an error", func(t *testing.T) {
-		setup := setupTest(t)
-
-		runID := "run-conn-error"
-
-		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
-			return api.SandboxConnectionInfo{}, errors.New("This run or task is no longer available for sandbox")
-		}
-
-		setup.mockAPI.MockGetRunPrompt = func(id string) (string, error) {
-			require.Equal(t, runID, id)
-			return "# Failed task:\n\n- preflight\n", nil
-		}
-
-		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
-			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
-			Command:    []string{"echo", "hello"},
-			RunID:      runID,
-			Json:       true,
-		})
-
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "unable to get sandbox connection info")
-		require.Contains(t, setup.mockStderr.String(), "Failed task")
 	})
 
 	t.Run("uses timed_out FailureReason for natural error message", func(t *testing.T) {
@@ -868,6 +841,57 @@ func TestService_ExecSandbox(t *testing.T) {
 			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
 			Command:    []string{"echo", "hello"},
 			RunID:      "run-failed",
+			Json:       true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed before becoming ready")
+	})
+
+	t.Run("treats FailureReason presence as completion regardless of Polling.Completed", func(t *testing.T) {
+		setup := setupTest(t)
+
+		runID := "run-failure-reason-without-completed"
+		address := "192.168.1.1:22"
+		backoff := 0
+		calls := atomic.Int32{}
+		var executedCommands []string
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			require.Equal(t, runID, id)
+			if calls.Add(1) == 1 {
+				return api.SandboxConnectionInfo{
+					Sandboxable:   false,
+					Polling:       api.PollingResult{Completed: false, BackoffMs: &backoff},
+					FailureReason: "failed",
+				}, nil
+			}
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        address,
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
+			require.Equal(t, address, addr)
+			return nil
+		}
+
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
+			executedCommands = append(executedCommands, cmd)
+			return 0, nil
+		}
+
+		setup.mockGit.MockGeneratePatch = func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error) {
+			return nil, nil, nil
+		}
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      runID,
 			Json:       true,
 		})
 
@@ -2076,7 +2100,7 @@ func TestService_ExecSandbox_PullPatchFailureRecovery(t *testing.T) {
 }
 
 func TestService_StartSandbox(t *testing.T) {
-	t.Run("does not send a git patch", func(t *testing.T) {
+	t.Run("sends a git patch", func(t *testing.T) {
 		setup := setupTest(t)
 
 		// Create .rwx directory and sandbox config file
@@ -2088,7 +2112,6 @@ func TestService_StartSandbox(t *testing.T) {
 		err = os.WriteFile(filepath.Join(rwxDir, "sandbox.yml"), []byte(sandboxConfig), 0o644)
 		require.NoError(t, err)
 
-		// Mock git — set up a patch that would be sent if patching were enabled
 		setup.mockGit.MockGetBranch = "main"
 		setup.mockGit.MockGetCommit = "abc123"
 		setup.mockGit.MockGetOriginUrl = "git@github.com:example/repo.git"
@@ -2130,7 +2153,7 @@ func TestService_StartSandbox(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.False(t, receivedPatch.Sent, "sandbox start should not send a git patch")
+		require.True(t, receivedPatch.Sent, "sandbox start should send a git patch")
 	})
 
 	t.Run("passes init params to InitiateRun", func(t *testing.T) {

--- a/test/integration/definitions/sandbox-setup-failure.yml
+++ b/test/integration/definitions/sandbox-setup-failure.yml
@@ -1,5 +1,13 @@
 tasks:
+  - key: code
+    call: git/clone 2.0.7
+    with:
+      repository: https://github.com/rwx-cloud/rwx.git
+      ref: main
+      preserve-git-dir: true
+
   - key: preflight
+    use: code
     run: |
       echo "intentional-setup-failure"
       exit 1

--- a/test/integration/definitions/sandbox-setup-sync.yml
+++ b/test/integration/definitions/sandbox-setup-sync.yml
@@ -1,0 +1,45 @@
+on:
+  cli:
+    init:
+      ref: ${{ event.git.sha }}
+
+base:
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
+
+tasks:
+  - key: rwx-source
+    call: git/clone 2.0.7
+    with:
+      repository: https://github.com/rwx-cloud/rwx.git
+      ref: ${{ init.ref }}
+
+  - key: build-def
+    use: rwx-source
+    run: cp .rwx/build.yml $RWX_ARTIFACTS/build-yml
+
+  - key: build-rwx-cli
+    call: ${{ tasks.build-def.artifacts.build-yml }}
+    init:
+      ref: ${{ init.ref }}
+
+  - key: rwx-cli
+    run: sudo install "$CLI_BINARY" /usr/local/bin
+    env:
+      CLI_BINARY: ${{ tasks.build-rwx-cli.tasks.build.artifacts.rwx }}
+
+  - key: code
+    call: git/clone 2.0.7
+    with:
+      repository: https://github.com/rwx-cloud/rwx.git
+      ref: ${{ init.ref }}
+      preserve-git-dir: true
+
+  - key: sandbox
+    use: [code, rwx-cli]
+    run: |
+      echo "setup-artifact-content" > setup-artifact.txt
+      rwx-sandbox
+    env:
+      UUID: ${{ run.id }}
+      RWX_ACCESS_TOKEN: ""

--- a/test/integration/sandbox-setup-failure.sh
+++ b/test/integration/sandbox-setup-failure.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verifies that setup failure output is surfaced in stderr when a sandbox run
+# Verifies that setup failure output is surfaced in stdout when a sandbox run
 # fails before reaching the sandbox task.
 set -euo pipefail
 
@@ -7,20 +7,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 RWX_CLI="${REPO_ROOT}/rwx"
 
-stderr_output=$("${RWX_CLI}" sandbox exec \
+stdout_output=$("${RWX_CLI}" sandbox exec \
   "${SCRIPT_DIR}/definitions/sandbox-setup-failure.yml" \
-  -- echo hello 2>&1 >/dev/null) || true
+  -- echo hello || true)
 
-if ! echo "$stderr_output" | grep -q "Failed task"; then
-  echo "ERROR: Expected setup failure prompt in stderr but did not find it"
-  echo "stderr was: $stderr_output"
+if ! echo "$stdout_output" | grep -q "Failed task"; then
+  echo "ERROR: Expected setup failure prompt in stdout but did not find it"
+  echo "stdout was: $stdout_output"
   exit 1
 fi
 
-if ! echo "$stderr_output" | grep -q "preflight"; then
-  echo "ERROR: Expected failing task name in stderr but did not find it"
-  echo "stderr was: $stderr_output"
+if ! echo "$stdout_output" | grep -q "preflight"; then
+  echo "ERROR: Expected failing task name in stdout but did not find it"
+  echo "stdout was: $stdout_output"
   exit 1
 fi
 
-echo "OK: setup failure prompt was surfaced in stderr"
+echo "OK: setup failure prompt was surfaced in stdout"

--- a/test/integration/sandbox-setup-sync.sh
+++ b/test/integration/sandbox-setup-sync.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/sandbox-helpers.sh"
+
+cleanup() {
+  git reset HEAD integration-test-local-change.txt 2>/dev/null || true
+  rm -f integration-test-local-change.txt setup-artifact.txt
+  "${RWX_CLI}" sandbox stop 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Create and stage a local change so it's included in the API-level patch sent
+# during sandbox start (untracked files are excluded from that patch).
+echo "local-change-content" > integration-test-local-change.txt
+git add integration-test-local-change.txt
+
+# Run exec WITHOUT a prior sandbox start to trigger isNewSandbox=true.
+# The sandbox auto-creates, and syncChangesToSandbox runs in baselineOnly mode:
+# git apply --cached establishes refs/rwx-sync without touching the working tree.
+"${RWX_CLI}" sandbox exec \
+  "${SCRIPT_DIR}/definitions/sandbox-setup-sync.yml" \
+  --init "ref=${COMMIT_SHA}" \
+  -- sh -c 'test -f integration-test-local-change.txt || (echo "local change not found in sandbox" && exit 1)'
+
+# Verify the setup artifact (created before rwx-sandbox in the sandbox task)
+# was pulled back locally. This confirms refs/rwx-sync was correctly set to
+# HEAD + local patch, making setup-artifact.txt visible in git diff refs/rwx-sync.
+if [ ! -f setup-artifact.txt ]; then
+  echo "FAIL: setup-artifact.txt was not pulled back from sandbox"
+  exit 1
+fi
+
+actual=$(cat setup-artifact.txt)
+if [ "$actual" != "setup-artifact-content" ]; then
+  echo "FAIL: setup-artifact.txt has unexpected content: $actual"
+  exit 1
+fi
+
+echo "PASS: local changes delivered to sandbox via patch; setup artifacts synced back locally"


### PR DESCRIPTION
### Background

[RWX-675](https://linear.app/rwx-cloud/issue/RWX-675/re-enable-patching-on-sandbox-start-handle-first-exec-sync)

RFC 168: [Sandbox setup syncing](https://www.notion.so/rwx/RFC-168-Sandbox-setup-syncing-337c3a490d98803ea3d2c45a50bba14b)

### Problem

Two issues with sandbox runs:

1. **Git patching was disabled** for sandbox runs (`Patchable: false`), which meant local dependency changes (e.g. new gems in `Gemfile`) were not applied during sandbox `git/clone`, making it impossible to re-run setup with updated deps without pushing to a remote first.
2. **Setup-generated artifacts** (e.g. `Gemfile.lock`, `schema.rb`) were not synced back to the local machine after the first exec, because `refs/rwx-sync` wasn't correctly established relative to the server's post-setup state.

### Solution

**Patching and first-exec sync** (`internal/cli/service_sandbox.go`):

- **`Patchable: true`** in `StartSandbox`'s `InitiateRun` call — sandbox starts now send a git patch to the API, incorporated into `git/clone` server-side just like `rwx run`.
- **`baselineOnly` param added to `syncChangesToSandbox`** — on the first exec of a new sandbox, skip `git apply` to the working tree (the patch is already applied server-side) and instead apply the patch to the index only (`git apply --cached`), then commit from that staged index (skipping `git add -A`) to establish `refs/rwx-sync`. This sets the baseline as HEAD + local patch without double-applying the patch to the working tree and without capturing setup-task working-tree state in the baseline.
- **Skip `cleanSandboxState` on new sandboxes** — `git checkout . && git clean -fd` would wipe setup artifacts (e.g. `Gemfile.lock`) written by setup tasks; a brand-new sandbox has no prior interrupted exec state to clean up.

Setup artifact sync falls out naturally: after `syncChangesToSandbox(baselineOnly=true)`, `refs/rwx-sync` = HEAD + local patch, server working tree = HEAD + local patch + setup artifacts, so `git diff refs/rwx-sync` on the server = setup artifacts only. The existing `pullChangesFromSandbox` picks these up automatically.

**Setup-failure output changes:**

- Move the setup-failure prompt from **stderr to stdout**, and poll `/status` first (matching the `rwx run` pattern) so results are indexed before fetching the prompt.
- Print the error header ourselves and wrap the returned error in `HandledError` so `main.go` doesn't re-print it — this keeps the header (stderr) and prompt (stdout) in a sensible order under combined output.
- Drop the best-effort prompt print from the non-completion error paths in `waitForSandboxReadyWithToken` (connection-info fetch failures); the prompt is only meaningful when the run has actually completed.

**Integration tests:**

- Adds `test/integration/sandbox-setup-sync.sh` + `test/integration/definitions/sandbox-setup-sync.yml` — exercises the full new path: exec auto-creates a sandbox (`isNewSandbox=true`), verifies the local patch was delivered to the sandbox via `git/clone`, and verifies a setup artifact is pulled back locally.
- Updates `test/integration/sandbox-setup-failure.sh` to assert on stdout instead of stderr (matching the output-stream change above), and updates `test/integration/definitions/sandbox-setup-failure.yml` to add a `base` + `git/clone` so the preflight task runs against a cloned repo (consistent with the other sandbox test definitions).
- Fixes two pre-existing CI flakes unrelated to this change: bump fail-slow sleep to 60s to eliminate a race with fail-fast in `.rwx/integration/{dispatch-test,results-test,run-test}` definitions.

#### Further confirmation needed

- [x] Verify that a new sandbox with local dependency changes (e.g. added to `Gemfile` but not pushed) has those changes visible to the **setup tasks** (not just post-setup exec), so `bundle install` during setup picks them up. The new `sandbox-setup-sync.sh` confirms the patched file is present in the sandbox at exec time but does not have a setup task that reads the patched file.
- [x] Verify that on **subsequent execs** of an existing sandbox (not a fresh one), `cleanSandboxState` still correctly wipes dirty state left behind by a previous interrupted exec. No integration test exercises this path directly.
- [x] Confirm `sandbox-setup-failure` CI test passes after server-side fix is deployed.