### PR TITLE
Treat Sandboxable runs as alive even when Polling.Completed=true

### DIFF
--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -179,8 +179,8 @@ func (s Service) CheckExistingSandbox(configFile string) (*CheckExistingSandboxR
 		}, nil
 	}
 
-	if connInfo.Polling.Completed {
-		// Run has completed, not active
+	if connInfo.Polling.Completed && !connInfo.Sandboxable {
+		// Run finished without becoming sandboxable — not active
 		return &CheckExistingSandboxResult{
 			Exists:     true,
 			Active:     false,
@@ -226,7 +226,7 @@ func (s Service) StartSandbox(cfg StartSandboxConfig) (*StartSandboxResult, erro
 			return nil, errors.Wrapf(err, "unable to get sandbox info for %s", cfg.RunID)
 		}
 
-		if connInfo.Polling.Completed {
+		if connInfo.Polling.Completed && !connInfo.Sandboxable {
 			return nil, fmt.Errorf("Run '%s' is no longer active (timed out or cancelled).\nRun 'rwx sandbox start %s' to create a new sandbox.", cfg.RunID, cfg.ConfigFile)
 		}
 
@@ -489,13 +489,15 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 				}
 			}
 			if found {
-				// Check if session is still valid (use scoped token if available)
+				// Check if session is still valid (use scoped token if available).
+				// Polling.Completed=true with Sandboxable=true is a ready sandbox,
+				// not an expired one; only prune when the run finished without becoming sandboxable.
 				connInfo, err := s.APIClient.GetSandboxConnectionInfo(session.RunID, session.ScopedToken)
 				if err != nil {
 					storage.DeleteSession(branch, cfg.ConfigFile)
 					_ = storage.Save()
 					found = false
-				} else if connInfo.Polling.Completed {
+				} else if connInfo.Polling.Completed && !connInfo.Sandboxable {
 					storage.DeleteSession(branch, cfg.ConfigFile)
 					_ = storage.Save()
 					found = false
@@ -520,11 +522,13 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 				}
 			}
 
-			// Filter to only active sessions
+			// Filter to only active sessions. A ready sandbox reports
+			// Polling.Completed=true with Sandboxable=true; only prune when
+			// the run finished without becoming sandboxable.
 			var activeSessions []SandboxSession
 			for _, sess := range sessions {
 				connInfo, err := s.APIClient.GetSandboxConnectionInfo(sess.RunID, sess.ScopedToken)
-				if err == nil && !connInfo.Polling.Completed {
+				if err == nil && (connInfo.Sandboxable || !connInfo.Polling.Completed) {
 					activeSessions = append(activeSessions, sess)
 				} else {
 					// Clean up expired session
@@ -575,9 +579,11 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 						}
 					}
 					if branchMatch && state.ConfigFile == cfgFile {
-						// Verify the remote sandbox is still alive before reusing
+						// Verify the remote sandbox is still alive before reusing.
+						// A ready sandbox reports Polling.Completed=true with Sandboxable=true;
+						// only skip when the run finished without becoming sandboxable.
 						connInfo, connErr := s.APIClient.GetSandboxConnectionInfo(run.ID, "")
-						if connErr != nil || connInfo.Polling.Completed {
+						if connErr != nil || (connInfo.Polling.Completed && !connInfo.Sandboxable) {
 							continue
 						}
 
@@ -923,10 +929,11 @@ func (s Service) ListSandboxes(cfg ListSandboxesConfig) (*ListSandboxesResult, e
 		} else {
 			// Not in the bulk list — could be initializing or genuinely expired.
 			// Verify individually: only keep as active if the API positively
-			// confirms the run is still alive (200 OK, not completed).
+			// confirms the run is still alive. A ready sandbox reports
+			// Polling.Completed=true with Sandboxable=true.
 			status := "expired"
 			connInfo, connErr := s.APIClient.GetSandboxConnectionInfo(session.RunID, session.ScopedToken)
-			if connErr == nil && !connInfo.Polling.Completed {
+			if connErr == nil && (connInfo.Sandboxable || !connInfo.Polling.Completed) {
 				status = "active"
 			}
 
@@ -1127,7 +1134,9 @@ func (s Service) waitForSandboxCompletion(runID, scopedToken string) {
 			// Error (404, 410, etc.) means the run is no longer active
 			return
 		}
-		if connInfo.Polling.Completed {
+		// Polling.Completed=true with Sandboxable=true means the sandbox is
+		// ready, not ended; keep waiting until it transitions to Sandboxable=false.
+		if connInfo.Polling.Completed && !connInfo.Sandboxable {
 			return
 		}
 

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -448,6 +448,41 @@ func TestService_ListSandboxes_PrunesExpired(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, storage.Sandboxes)
 	})
+
+	t.Run("keeps sandbox as active when fallback reports Sandboxable=true with Polling.Completed=true", func(t *testing.T) {
+		setup := setupTest(t)
+		seedSandboxStorageMulti(t, setup.tmp, map[string]cli.SandboxSession{
+			"main:" + setup.absConfig(".rwx/sandbox.yml"): {
+				RunID:       "run-ready",
+				ConfigFile:  setup.absConfig(".rwx/sandbox.yml"),
+				ScopedToken: "token-ready",
+			},
+		})
+
+		// Bulk API hasn't picked up the run yet, forcing the fallback path
+		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
+			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+		}
+
+		// Ready sandbox: Sandboxable=true, Polling.Completed=true
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, scopedToken string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable: true,
+				Polling:     api.PollingResult{Completed: true},
+			}, nil
+		}
+
+		result, err := setup.service.ListSandboxes(cli.ListSandboxesConfig{Json: true})
+
+		require.NoError(t, err)
+		require.Len(t, result.Sandboxes, 1)
+		require.Equal(t, "run-ready", result.Sandboxes[0].RunID)
+		require.Equal(t, "active", result.Sandboxes[0].Status)
+
+		storage, err := cli.LoadSandboxStorage()
+		require.NoError(t, err)
+		require.Len(t, storage.Sandboxes, 1)
+	})
 }
 
 func seedSandboxStorageMulti(t *testing.T, tmpHome string, sessions map[string]cli.SandboxSession) {
@@ -2515,6 +2550,163 @@ func TestService_ExecSandbox_RecoverFromAPI(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "run-new", result.RunID)
 		require.True(t, initiatedRun, "should have initiated a new run")
+	})
+}
+
+func TestService_ExecSandbox_SessionReuse(t *testing.T) {
+	// A ready sandbox reports Sandboxable=true with Polling.Completed=true.
+	// The session must be reused, not pruned as expired.
+
+	mockReadySandbox := func(setup *testSetup) {
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+				Polling:        api.PollingResult{Completed: true},
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(string, ssh.ClientConfig) error { return nil }
+		setup.mockSSH.MockExecuteCommand = func(string) (int, error) { return 0, nil }
+		setup.mockGit.MockGeneratePatch = func([]string) ([]byte, *git.LFSChangedFilesMetadata, error) {
+			return nil, nil, nil
+		}
+	}
+
+	t.Run("config-provided lookup reuses ready sandbox (Polling.Completed=true, Sandboxable=true)", func(t *testing.T) {
+		setup := setupTest(t)
+
+		configFile := setup.absConfig(".rwx/sandbox.yml")
+		runID := "run-ready-config"
+		seedSandboxStorageMulti(t, setup.tmp, map[string]cli.SandboxSession{
+			"detached:" + configFile: {
+				RunID:       runID,
+				ConfigFile:  configFile,
+				ScopedToken: "token-ready",
+			},
+		})
+
+		mockReadySandbox(setup)
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"echo", "hello"},
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, runID, result.RunID)
+
+		// Session should still be in storage
+		storage, err := cli.LoadSandboxStorage()
+		require.NoError(t, err)
+		_, found := storage.GetSession("detached", configFile)
+		require.True(t, found, "session should not have been pruned")
+	})
+
+	t.Run("branch-only lookup reuses ready sandbox (Polling.Completed=true, Sandboxable=true)", func(t *testing.T) {
+		setup := setupTest(t)
+
+		configFile := setup.absConfig(".rwx/sandbox.yml")
+		runID := "run-ready-branch"
+		seedSandboxStorageMulti(t, setup.tmp, map[string]cli.SandboxSession{
+			"detached:" + configFile: {
+				RunID:       runID,
+				ConfigFile:  configFile,
+				ScopedToken: "token-ready",
+			},
+		})
+
+		mockReadySandbox(setup)
+
+		// No ConfigFile — exercises the branch-only session lookup path
+		// that the CI regression landed in.
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			Command: []string{"echo", "hello"},
+			Json:    true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, runID, result.RunID)
+
+		storage, err := cli.LoadSandboxStorage()
+		require.NoError(t, err)
+		_, found := storage.GetSession("detached", configFile)
+		require.True(t, found, "session should not have been pruned")
+	})
+
+	t.Run("config-provided lookup prunes session when run finished without becoming sandboxable", func(t *testing.T) {
+		setup := setupTest(t)
+
+		// Provide a config file on disk so auto-create can succeed after pruning.
+		rwxDir := filepath.Join(setup.tmp, ".rwx")
+		require.NoError(t, os.MkdirAll(rwxDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(rwxDir, "sandbox.yml"), []byte("tasks:\n  - key: sandbox\n    run: rwx-sandbox\n"), 0o644))
+
+		configFile := setup.absConfig(".rwx/sandbox.yml")
+		staleRunID := "run-finished"
+		seedSandboxStorageMulti(t, setup.tmp, map[string]cli.SandboxSession{
+			"detached:" + configFile: {
+				RunID:       staleRunID,
+				ConfigFile:  configFile,
+				ScopedToken: "token-stale",
+			},
+		})
+
+		// Return stale-run connection info on the first call (for the session
+		// health check) and a fresh sandbox on subsequent calls (auto-create).
+		connCalls := atomic.Int32{}
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			if connCalls.Add(1) == 1 {
+				require.Equal(t, staleRunID, id)
+				return api.SandboxConnectionInfo{
+					Sandboxable:   false,
+					Polling:       api.PollingResult{Completed: true},
+					FailureReason: "failed",
+				}, nil
+			}
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+
+		// Auto-create mocks
+		setup.mockGit.MockGetBranch = "main"
+		setup.mockGit.MockGetCommit = "abc123"
+		setup.mockGit.MockGetOriginUrl = "git@github.com:example/repo.git"
+		setup.mockAPI.MockGetDefaultBase = func() (api.DefaultBaseResult, error) {
+			return api.DefaultBaseResult{Image: "ubuntu:24.04", Config: "rwx/base 1.0.0", Arch: "x86_64"}, nil
+		}
+		setup.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+			return &api.PackageVersionsResult{LatestMajor: map[string]string{}, LatestMinor: map[string]map[string]string{}}, nil
+		}
+		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
+			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+		}
+		setup.mockAPI.MockInitiateRun = func(api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+			return &api.InitiateRunResult{RunID: "run-fresh", RunURL: "https://cloud.rwx.com/mint/runs/run-fresh"}, nil
+		}
+		setup.mockAPI.MockCreateSandboxToken = func(api.CreateSandboxTokenConfig) (*api.CreateSandboxTokenResult, error) {
+			return &api.CreateSandboxTokenResult{Token: "token-fresh"}, nil
+		}
+		setup.mockSSH.MockConnect = func(string, ssh.ClientConfig) error { return nil }
+		setup.mockSSH.MockExecuteCommand = func(string) (int, error) { return 0, nil }
+		setup.mockGit.MockGeneratePatch = func([]string) ([]byte, *git.LFSChangedFilesMetadata, error) {
+			return nil, nil, nil
+		}
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"echo", "hello"},
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "run-fresh", result.RunID, "stale session should be pruned and a new run created")
 	})
 }
 


### PR DESCRIPTION
### Background

- Related CLI PR (where the regression surfaced in CI): https://github.com/rwx-cloud/rwx/pull/486
- The server-side sandbox_connection_info change that exposed this bug has since been reverted.

### Problem

A recent server-side change to `sandbox_connection_info` started returning `Polling.Completed=true` once polling is done — true both for ready sandboxes (`Sandboxable=true`) and for runs that finished without becoming sandboxable. Previously the endpoint always returned `false`, which masked a latent bug in the CLI: several call sites treated `Polling.Completed=true` alone as "session expired" and pruned live sessions immediately after `sandbox start`, so `sandbox exec` fell through to auto-create and failed with `run definition file ".rwx/sandbox.yml" not found`.

The server-side change has since been reverted, so CI is green today. This PR fixes the CLI so the server-side change can be re-instated safely.

### Solution

- Only prune a session when `Polling.Completed && !Sandboxable`. A ready sandbox reports both flags true simultaneously and must be treated as alive.
- Mirror the corrected check at every call site that assumed the old (false-only) semantics:
  - `CheckExistingSandbox`
  - `StartSandbox` `--id` reattach path
  - `ExecSandbox` config-provided session lookup
  - `ExecSandbox` branch-only session lookup (the path that surfaced in CI)
  - `ExecSandbox` remote-recovery via `ListSandboxRuns`
  - `ListSandboxes` per-run fallback after the bulk API miss
  - `waitForSandboxCompletion`
- Added unit tests covering the three most impactful paths (exec config-provided, exec branch-only, list fallback) plus a regression guard that still prunes when the run finished without becoming sandboxable. Verified the new tests fail against the pre-fix service file with the same "run definition file not found" error seen in CI.

#### Further confirmation needed

- [ ] Re-deploy the server-side `sandbox_connection_info` change after this lands and confirm `sandbox start` → `sandbox exec` flow stays green in CI and locally.