### PR TITLE
Surface run prompt when sandbox connection info fetch fails

### DIFF
--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1521,6 +1521,10 @@ func (s Service) waitForSandboxReadyWithToken(runID, scopedToken string, jsonMod
 	// Check once before showing spinner - sandbox may already be ready
 	connInfo, err := s.APIClient.GetSandboxConnectionInfo(runID, scopedToken)
 	if err != nil {
+		// The run may have failed before becoming sandboxable (e.g. preflight task failed),
+		// in which case the API returns an error here rather than a Polling.Completed result.
+		// Surface the run prompt so the user can see what failed.
+		s.printSandboxRunPrompt(runID)
 		return nil, errors.Wrap(err, "unable to get sandbox connection info")
 	}
 
@@ -1549,6 +1553,9 @@ func (s Service) waitForSandboxReadyWithToken(runID, scopedToken string, jsonMod
 
 		connInfo, err = s.APIClient.GetSandboxConnectionInfo(runID, scopedToken)
 		if err != nil {
+			// As above: a mid-poll failure (e.g. preflight task failure) can surface as an
+			// API error rather than Polling.Completed. Best-effort surface the run prompt.
+			s.printSandboxRunPrompt(runID)
 			return nil, errors.Wrap(err, "unable to get sandbox connection info")
 		}
 

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -745,6 +745,68 @@ func TestService_ExecSandbox(t *testing.T) {
 		require.Contains(t, setup.mockStdout.String(), "Failed task")
 	})
 
+	t.Run("prints run failure output to stdout when connection info fetch fails", func(t *testing.T) {
+		setup := setupTest(t)
+
+		runID := "run-conn-info-gone"
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{}, errors.New("This run is no longer available for sandbox")
+		}
+
+		setup.mockAPI.MockGetRunPrompt = func(id string) (string, error) {
+			require.Equal(t, runID, id)
+			return "# Failed task:\n\n- preflight\n", nil
+		}
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      runID,
+			Json:       true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unable to get sandbox connection info")
+		require.Contains(t, setup.mockStdout.String(), "Failed task")
+		require.Contains(t, setup.mockStdout.String(), "preflight")
+	})
+
+	t.Run("prints run failure output to stdout when polling-loop connection info fetch fails", func(t *testing.T) {
+		setup := setupTest(t)
+
+		runID := "run-conn-info-gone-mid-poll"
+		calls := atomic.Int32{}
+		backoff := 0
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			if calls.Add(1) == 1 {
+				return api.SandboxConnectionInfo{
+					Sandboxable: false,
+					Polling:     api.PollingResult{Completed: false, BackoffMs: &backoff},
+				}, nil
+			}
+			return api.SandboxConnectionInfo{}, errors.New("This run is no longer available for sandbox")
+		}
+
+		setup.mockAPI.MockGetRunPrompt = func(id string) (string, error) {
+			require.Equal(t, runID, id)
+			return "# Failed task:\n\n- preflight\n", nil
+		}
+
+		_, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      runID,
+			Json:       true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unable to get sandbox connection info")
+		require.Contains(t, setup.mockStdout.String(), "Failed task")
+		require.Contains(t, setup.mockStdout.String(), "preflight")
+	})
+
 	t.Run("gracefully degrades when GetRunPrompt fails on polling completion", func(t *testing.T) {
 		setup := setupTest(t)
 


### PR DESCRIPTION
### Problem

The `ci.sandbox-setup-failure` integration test on main is flaky.

The integration test runs a sandbox definition whose `preflight` task intentionally exits 1, then asserts that the CLI surfaces "Failed task" and "preflight" in stdout. After a setup task fails, the Cloud API can respond to `GetSandboxConnectionInfo` in one of two ways depending on timing:

- **Polling-completed path:** While the run record is still live, the API returns `200` with `Polling.Completed=true` and `FailureReason="failed"`. The CLI routes this through `sandboxCompletedError`, which calls `printSandboxRunPrompt` and surfaces the failing task in stdout.
- **Gone path:** Once the Cloud has marked the run "no longer available for sandbox", the API returns `410`. Until #486, the CLI also called `printSandboxRunPrompt` on this err branch, but that call was inadvertently dropped when the function was restructured for the new `FailureReason` polling path. The user only sees `Error: unable to get sandbox connection info: This run is no longer available for sandbox.` with no indication of which task failed.

This is the race that explains why CI was green on #486 but red on main: PR CI happened to land in the polling-completed window (~13s after sandbox start), while the main run landed in the gone window (~21s). Same code, different API timing — the test became silently flaky rather than broken outright.

We should also explore whether the server can keep returning the polling-completed response for a longer/predictable window so the CLI doesn't have to handle two paths for the same logical event.

### Solution

Restore the best-effort `s.printSandboxRunPrompt(runID)` call on both err branches in `waitForSandboxReadyWithToken` (the pre-spinner check and the polling loop). The function is best-effort — if the prompt is unavailable it silently no-ops, so this is safe for unrelated API errors (auth, network, etc.).

Added two unit tests covering both err branches.

#### Further confirmation needed

- [x] Verify the `ci.sandbox-setup-failure` integration test passes on this branch