### PR TITLE
Classify common CLI errors for alerting signal

### DIFF
--- a/cmd/rwx/main.go
+++ b/cmd/rwx/main.go
@@ -88,10 +88,16 @@ func classifyError(err error) string {
 	switch {
 	case errors.Is(err, internalerrors.ErrBadRequest):
 		return "bad_request"
+	case errors.Is(err, internalerrors.ErrUnauthenticated):
+		return "unauthenticated"
 	case errors.Is(err, internalerrors.ErrNotFound):
 		return "not_found"
+	case errors.Is(err, internalerrors.ErrFileNotExists):
+		return "file_not_found"
 	case errors.Is(err, internalerrors.ErrGone):
 		return "gone"
+	case errors.Is(err, internalerrors.ErrInternalServerError):
+		return "internal_server_error"
 	case errors.Is(err, internalerrors.ErrSSH):
 		return "ssh_failed"
 	case errors.Is(err, internalerrors.ErrPatch):
@@ -102,10 +108,14 @@ func classifyError(err error) string {
 		return "lsp_error"
 	case errors.Is(err, internalerrors.ErrAmbiguousTaskKey):
 		return "ambiguous_task_key"
+	case errors.Is(err, internalerrors.ErrAmbiguousDefinitionPath):
+		return "ambiguous_definition_path"
 	case errors.Is(err, internalerrors.ErrNetworkTransient):
 		return "network_transient_error"
 	case errors.Is(err, internalerrors.ErrSandboxSetupFailure):
 		return "sandbox_setup_failure"
+	case errors.Is(err, internalerrors.ErrSandboxNoGitDir):
+		return "sandbox_no_git_dir"
 	default:
 		return "unknown"
 	}

--- a/cmd/rwx/main_test.go
+++ b/cmd/rwx/main_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyError(t *testing.T) {
+	t.Run("returns unknown for nil and bare errors", func(t *testing.T) {
+		require.Equal(t, "unknown", classifyError(errors.New("something went wrong")))
+	})
+
+	cases := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{"bad_request", errors.ErrBadRequest, "bad_request"},
+		{"unauthenticated", errors.ErrUnauthenticated, "unauthenticated"},
+		{"not_found", errors.ErrNotFound, "not_found"},
+		{"file_not_found", errors.ErrFileNotExists, "file_not_found"},
+		{"gone", errors.ErrGone, "gone"},
+		{"internal_server_error", errors.ErrInternalServerError, "internal_server_error"},
+		{"ssh_failed", errors.ErrSSH, "ssh_failed"},
+		{"patch_failed", errors.ErrPatch, "patch_failed"},
+		{"timeout", errors.ErrTimeout, "timeout"},
+		{"lsp_error", errors.ErrLSP, "lsp_error"},
+		{"ambiguous_task_key", errors.ErrAmbiguousTaskKey, "ambiguous_task_key"},
+		{"ambiguous_definition_path", errors.ErrAmbiguousDefinitionPath, "ambiguous_definition_path"},
+		{"network_transient_error", errors.ErrNetworkTransient, "network_transient_error"},
+		{"sandbox_setup_failure", errors.ErrSandboxSetupFailure, "sandbox_setup_failure"},
+		{"sandbox_no_git_dir", errors.ErrSandboxNoGitDir, "sandbox_no_git_dir"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+"/bare", func(t *testing.T) {
+			require.Equal(t, tc.expected, classifyError(tc.err))
+		})
+
+		t.Run(tc.name+"/wrapped", func(t *testing.T) {
+			wrapped := errors.WrapSentinel(fmt.Errorf("some context: inner"), tc.err)
+			require.Equal(t, tc.expected, classifyError(wrapped))
+		})
+	}
+
+	t.Run("file_not_found matches os.ErrNotExist wrappers", func(t *testing.T) {
+		// os.Open of a missing file returns a *PathError that Is(os.ErrNotExist)
+		_, err := os.Open("/this/path/definitely/does/not/exist/rwx-684")
+		require.Error(t, err)
+		require.Equal(t, "file_not_found", classifyError(err))
+	})
+}
+
+func TestClassifyErrorFromHTTPResponses(t *testing.T) {
+	// Exercises the full path: HTTP response -> api.decodeResponseJSON -> sentinel -> classifyError.
+	// This is the seam the CLI telemetry actually runs through, so regression here matters more
+	// than the unit-level sentinel check above.
+	cases := []struct {
+		name       string
+		statusCode int
+		expected   string
+	}{
+		{"401 unauthorized", http.StatusUnauthorized, "unauthenticated"},
+		{"403 forbidden", http.StatusForbidden, "unauthenticated"},
+		{"404 not found", http.StatusNotFound, "not_found"},
+		{"500 internal server error", http.StatusInternalServerError, "internal_server_error"},
+		{"502 bad gateway", http.StatusBadGateway, "internal_server_error"},
+		{"503 service unavailable", http.StatusServiceUnavailable, "internal_server_error"},
+		{"418 teapot falls through", http.StatusTeapot, "unknown"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				_, _ = io.WriteString(w, `{"error":"boom"}`)
+			}))
+			defer server.Close()
+
+			c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+				req.URL.Scheme = "http"
+				req.URL.Host = strings.TrimPrefix(server.URL, "http://")
+				return http.DefaultClient.Do(req)
+			})
+
+			_, err := c.GetSandboxInitTemplate()
+			require.Error(t, err)
+			require.Equal(t, tc.expected, classifyError(err))
+		})
+	}
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -17,7 +17,9 @@ import (
 	"github.com/rwx-cloud/rwx/internal/versions"
 )
 
-var ErrNotFound = errors.New("not found")
+// ErrNotFound aliases the shared sentinel so existing api.ErrNotFound callers
+// also satisfy errors.Is(err, internalerrors.ErrNotFound) for telemetry classification.
+var ErrNotFound = errors.ErrNotFound
 
 // httpClient uses a transport with a reduced idle connection timeout to avoid
 // reusing connections that the load balancer has already closed (default ALB
@@ -173,7 +175,7 @@ func (c Client) GetDebugConnectionInfo(debugKey string) (DebugConnectionInfo, er
 		if msg == "" {
 			msg = fmt.Sprintf("Unable to call RWX API - %s", resp.Status)
 		}
-		return connectionInfo, errors.New(msg)
+		return connectionInfo, classifyHTTPStatusError(resp.StatusCode, msg)
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&connectionInfo); err != nil {
@@ -234,7 +236,7 @@ func (c Client) GetSandboxConnectionInfo(runID, scopedToken string) (SandboxConn
 		if msg == "" {
 			msg = fmt.Sprintf("Unable to call RWX API - %s", resp.Status)
 		}
-		return connectionInfo, errors.New(msg)
+		return connectionInfo, classifyHTTPStatusError(resp.StatusCode, msg)
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&connectionInfo); err != nil {
@@ -1593,10 +1595,21 @@ func decodeResponseJSON(resp *http.Response, result any) error {
 		errMsg = fmt.Sprintf("Unable to call RWX API - %s", resp.Status)
 	}
 
-	if resp.StatusCode == http.StatusNotFound {
-		return errors.Wrap(ErrNotFound, errMsg)
-	}
+	return classifyHTTPStatusError(resp.StatusCode, errMsg)
+}
 
+// classifyHTTPStatusError returns an error wrapped with a sentinel that matches
+// the HTTP status class, so CLI telemetry can distinguish user-actionable
+// failures (401/403/404) from server-side issues (5xx).
+func classifyHTTPStatusError(statusCode int, errMsg string) error {
+	switch {
+	case statusCode == http.StatusUnauthorized, statusCode == http.StatusForbidden:
+		return errors.WrapSentinel(errors.New(errMsg), errors.ErrUnauthenticated)
+	case statusCode == http.StatusNotFound:
+		return errors.Wrap(ErrNotFound, errMsg)
+	case statusCode >= 500 && statusCode < 600:
+		return errors.WrapSentinel(errors.New(errMsg), errors.ErrInternalServerError)
+	}
 	return errors.New(errMsg)
 }
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -72,6 +72,8 @@ var (
 	ErrAmbiguousTaskKey        = errors.New("ambiguous task key")
 	ErrAmbiguousDefinitionPath = errors.New("ambiguous definition path")
 	ErrNetworkTransient        = errors.New("network transient error")
+	ErrUnauthenticated         = errors.New("unauthenticated")
+	ErrInternalServerError     = errors.New("internal server error")
 
 	// WrapSentinel wraps an error so that errors.Is returns true for the sentinel.
 	WrapSentinel = wrapSentinel


### PR DESCRIPTION
### Background

- [RWX-684](https://linear.app/rwx-cloud/issue/RWX-684/improve-error-classification-for-common-command-errors)
- Slack thread about alert noise from `cli.error`: https://rwxhq.slack.com/archives/C0ANPT2842Z/p1776701392741069?thread_ts=1776701392.741069&cid=C0ANPT2842Z

### Problem

The `cli.error` telemetry alert fires at 2 errors per command per version. Today everything that isn't one of ~10 known sentinels lands in `error_type=unknown`, so we can't distinguish human-actionable failures (bad path, not authenticated) from system failures (server 5xx). Result: a lot of alert noise with no way to tune thresholds per failure class.

### Solution

Split five new buckets out of `unknown`:

| bucket | trigger | class |
| --- | --- | --- |
| `unauthenticated` | 401 / 403 API responses | human |
| `internal_server_error` | 5xx API responses | system |
| `file_not_found` | `os.ErrNotExist` (missing `.rwx.yaml` et al) | human |
| `ambiguous_definition_path` | already-defined sentinel, previously unwired | human |
| `sandbox_no_git_dir` | already-defined sentinel, previously unwired | human |

Mechanics:
- New sentinels `ErrUnauthenticated` and `ErrInternalServerError` in `internal/errors/errors.go`.
- New `classifyHTTPStatusError` helper in `internal/api/client.go`. `decodeResponseJSON` and the two bespoke switch blocks (`GetDebugConnectionInfo`, `GetSandboxConnectionInfo`) now route through it. 404 handling is preserved.
- Five new cases in `cmd/rwx/main.go:classifyError`.
- New `cmd/rwx/main_test.go` with table-driven coverage for every case (bare + `WrapSentinel`-wrapped), end-to-end HTTP coverage for 401/403/404/500/502/503, and an `os.ErrNotExist` path test.

**Incidental fix:** `api.ErrNotFound` and `internalerrors.ErrNotFound` were two distinct sentinels with the same string, so API 404s never matched `classifyError`'s `not_found` case — they were bucketed as `unknown`. The new HTTP-response test caught this. Aliased `api.ErrNotFound = errors.ErrNotFound`; existing `errors.Is(err, api.ErrNotFound)` callers continue to work.

**Scoped out, deliberately:**
- The ~30 endpoint functions in `client.go` that don't route through `decodeResponseJSON` (e.g. `GetSkillContent`, token endpoints) still `errors.New(msg)` on non-success. Touching all of them is a larger mechanical refactor; if `unknown` volume is still high after this ships, that's the next cut.
- No new `invalid_input` bucket for flag/arg validation errors — those are free-form strings scattered across dozens of call sites with no sentinel. Wiring them would mean introducing sentinels everywhere; larger than the alerting win warrants.

#### Further confirmation needed

- [ ] Verify in production telemetry that the new buckets actually appear (especially `unauthenticated` and `internal_server_error`) and that `unknown` volume drops meaningfully.
- [ ] Confirm alert thresholds in Datadog should be re-tuned per bucket (human-error buckets can probably have much higher thresholds than system-error buckets).