### PR TITLE
Attach scrubbed error_message on unclassified cli.error events

### DIFF
--- a/cmd/rwx/main.go
+++ b/cmd/rwx/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -73,15 +74,49 @@ func recordTelemetry(err error, start time.Time) {
 	})
 
 	if err != nil {
-		telem.Record("cli.error", map[string]any{
+		errType := classifyError(err)
+		handled := errors.Is(err, HandledError)
+		props := map[string]any{
 			"command":    commandName,
 			"flags":      flagNames,
-			"error_type": classifyError(err),
-			"handled":    errors.Is(err, HandledError),
-		})
+			"error_type": errType,
+			"handled":    handled,
+		}
+		// Only attach the raw message for unclassified, non-handled errors:
+		// classified buckets already carry signal via the tag, and handled
+		// errors expose the sentinel string rather than what the user saw.
+		if errType == "unknown" && !handled {
+			props["error_message"] = scrubErrorMessage(err.Error())
+		}
+		telem.Record("cli.error", props)
 	}
 
 	telem.Flush()
+}
+
+const errorMessageMaxRunes = 200
+
+var (
+	// urlCredentialRe matches a URL userinfo segment (e.g. user:token@host).
+	urlCredentialRe = regexp.MustCompile(`://[^@\s/]+@`)
+	// jwtRe matches three base64url-shaped segments separated by dots. Segment
+	// minimum of 10 chars keeps dotted Java-style identifiers out of the match.
+	jwtRe = regexp.MustCompile(`[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}`)
+	// tokenRe matches standalone token-shaped runs (hex/base64/UUID-ish).
+	tokenRe = regexp.MustCompile(`[A-Za-z0-9_\-]{32,}`)
+)
+
+func scrubErrorMessage(msg string) string {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		msg = strings.ReplaceAll(msg, home, "~")
+	}
+	msg = urlCredentialRe.ReplaceAllString(msg, "://<redacted>@")
+	msg = jwtRe.ReplaceAllString(msg, "<redacted>")
+	msg = tokenRe.ReplaceAllString(msg, "<redacted>")
+	if runes := []rune(msg); len(runes) > errorMessageMaxRunes {
+		msg = string(runes[:errorMessageMaxRunes]) + "..."
+	}
+	return msg
 }
 
 func classifyError(err error) string {

--- a/cmd/rwx/main_test.go
+++ b/cmd/rwx/main_test.go
@@ -60,6 +60,75 @@ func TestClassifyError(t *testing.T) {
 	})
 }
 
+func TestScrubErrorMessage(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	require.NotEmpty(t, home)
+
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "plain message passes through",
+			input:    "failed to open task.yaml",
+			expected: "failed to open task.yaml",
+		},
+		{
+			name:     "replaces home directory with tilde",
+			input:    "failed to open " + home + "/project/.rwx.yaml",
+			expected: "failed to open ~/project/.rwx.yaml",
+		},
+		{
+			name:     "redacts URL userinfo",
+			input:    "clone failed at https://user:secret@github.com/rwx/repo",
+			expected: "clone failed at https://<redacted>@github.com/rwx/repo",
+		},
+		{
+			name:     "redacts JWT-shaped token",
+			input:    "bad auth: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+			expected: "bad auth: <redacted>",
+		},
+		{
+			name:     "does not redact short dotted identifiers",
+			input:    "parse error at com.example.Foo",
+			expected: "parse error at com.example.Foo",
+		},
+		{
+			name:     "redacts long hex-like token",
+			input:    "invalid token abcdef0123456789abcdef0123456789abcdef01",
+			expected: "invalid token <redacted>",
+		},
+		{
+			name:     "redacts UUID-shaped run",
+			input:    "run 550e8400e29b41d4a716446655440000 not found",
+			expected: "run <redacted> not found",
+		},
+		{
+			name:     "truncates very long messages",
+			input:    strings.Repeat("foo bar ", 40),
+			expected: strings.Repeat("foo bar ", 40)[:errorMessageMaxRunes] + "...",
+		},
+		{
+			name:     "composite: home path + token",
+			input:    "cache miss at " + home + "/.rwx/cache/abcdef0123456789abcdef0123456789abcdef.json",
+			expected: "cache miss at ~/.rwx/cache/<redacted>.json",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, scrubErrorMessage(tc.input))
+		})
+	}
+}
+
 func TestClassifyErrorFromHTTPResponses(t *testing.T) {
 	// Exercises the full path: HTTP response -> api.decodeResponseJSON -> sentinel -> classifyError.
 	// This is the seam the CLI telemetry actually runs through, so regression here matters more


### PR DESCRIPTION
### Background

- [RWX-713](https://linear.app/rwx-cloud/issue/RWX-713/emit-scrubbed-error-message-on-unknown-clierror-telemetry-events)
- Follow-up to #489 per [this review comment](https://github.com/rwx-cloud/rwx/pull/489#discussion_r3132938356)

### Problem

#489 split five new buckets out of `error_type=unknown` on `cli.error`, but anything still landing in `unknown` is a black hole — we know the rate, not the content. Without visibility into recurring raw messages in that bucket, we can't prioritize which sentinels to wire up next (the ~30 bespoke `errors.New(msg)` handlers in `client.go`, flag validation errors, etc.).

### Solution

Attach `err.Error()` as a new `error_message` field on `cli.error` events, gated on `error_type == "unknown" && handled == false`. Classified buckets already carry signal via the tag. Handled errors are excluded because `err.Error()` on them returns the sentinel string (`"handled error"`, `"lint failure: handled error"`) rather than what the user actually saw printed to stderr — useless for correlation.

Under that gate, `err.Error()` is exactly the string `cmd/rwx/main.go:39` prints on exit, so what lands in Datadog matches what the user would copy-paste into Slack.

**Scrubbing**, applied in order before the field is set:

1. `$HOME` → `~` (strips `/Users/<name>/...`)
2. URL userinfo: `://user:token@host` → `://<redacted>@host`
3. JWT-shaped triples (three base64url segments ≥10 chars joined by dots) → `<redacted>`
4. Long token-shaped runs (`[A-Za-z0-9_-]{32,}`, catches UUIDs, hex digests, API tokens) → `<redacted>`
5. Truncate to 200 runes + `...`

Order matters: URL creds first so we don't partially mangle them; JWT before the generic catchall so the whole token is one replacement instead of three; truncation last so secrets past char 200 still get redacted.

**Tradeoffs / caveats:**

- JWT segment floor of 10 chars skips natural dotted identifiers like `com.example.Foo` (covered by a negative test) at the cost of missing unusually short test tokens.
- Token floor of 32 chars catches UUIDs (tested) and real API tokens without matching common long-ish English words. Going lower risks false positives in normal error prose.
- No refactor of `recordTelemetry` to make the gate unit-testable on its own — the gate is two lines, and `classifyError` + `scrubErrorMessage` are both directly covered. If we want explicit coverage of the gate, happy to extract a `classifyErrorForTelemetry` helper in a follow-up.

#### Further confirmation needed

- [ ] Verify in production telemetry that `error_message` appears on `unknown` events and that no message contains obvious secrets / raw `/Users/<name>` paths after scrubbing.
- [ ] Audit the top recurring messages in the `unknown` bucket after a few days and file follow-ups to classify the common ones into new sentinels.
- [x] Confirm the Datadog telemetry schema accepts a free-form `error_message` attribute without cardinality warnings (field is only set on `unknown`, which should be a minority of events).