### PR TITLE
Emit telemetry for unknown commands and subcommands

### DIFF
--- a/cmd/rwx/main.go
+++ b/cmd/rwx/main.go
@@ -19,6 +19,11 @@ var HandledError = cli.HandledError
 
 func main() {
 	start := time.Now()
+
+	// Init telemetry before Execute so errors that bypass PersistentPreRunE
+	// (e.g. unknown commands, bad global flags) are still recorded.
+	initTelemetry()
+
 	err := rootCmd.Execute()
 
 	recordTelemetry(err, start)
@@ -65,15 +70,21 @@ func recordTelemetry(err error, start time.Time) {
 		})
 	}
 
+	// Cobra shows help and returns nil when a non-runnable parent command is
+	// invoked with extra positional args (e.g. `rwx sandbox push`). Treat that
+	// as an unknown_command so we don't silently drop the signal.
+	unknownSubcommand := err == nil && cmd != nil && !cmd.Runnable() && len(cmd.Flags().Args()) > 0
+
 	telem.Record("cli.command", map[string]any{
 		"command":       commandName,
 		"flags":         flagNames,
 		"output_format": Output,
 		"duration_ms":   time.Since(start).Milliseconds(),
-		"success":       err == nil,
+		"success":       err == nil && !unknownSubcommand,
 	})
 
-	if err != nil {
+	switch {
+	case err != nil:
 		errType := classifyError(err)
 		handled := errors.Is(err, HandledError)
 		props := map[string]any{
@@ -89,6 +100,13 @@ func recordTelemetry(err error, start time.Time) {
 			props["error_message"] = scrubErrorMessage(err.Error())
 		}
 		telem.Record("cli.error", props)
+	case unknownSubcommand:
+		telem.Record("cli.error", map[string]any{
+			"command":    commandName,
+			"flags":      flagNames,
+			"error_type": "unknown_command",
+			"handled":    false,
+		})
 	}
 
 	telem.Flush()
@@ -120,6 +138,14 @@ func scrubErrorMessage(msg string) string {
 }
 
 func classifyError(err error) string {
+	// Cobra emits unknown-command errors as a plain fmt.Errorf with no sentinel,
+	// so match by message prefix. The error is surfaced before any PreRun hook
+	// fires, which is why telemetry is initialized in main() rather than in
+	// rootCmd.PersistentPreRunE.
+	if err != nil && strings.HasPrefix(err.Error(), "unknown command ") {
+		return "unknown_command"
+	}
+
 	switch {
 	case errors.Is(err, internalerrors.ErrBadRequest):
 		return "bad_request"

--- a/cmd/rwx/main_test.go
+++ b/cmd/rwx/main_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rwx-cloud/rwx/internal/api"
 	"github.com/rwx-cloud/rwx/internal/errors"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,6 +59,33 @@ func TestClassifyError(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, "file_not_found", classifyError(err))
 	})
+
+	t.Run("unknown_command matches Cobra's unknown-command error", func(t *testing.T) {
+		// Cobra emits this via fmt.Errorf("unknown command %q for %q...") with no sentinel.
+		// These errors bypass PersistentPreRunE, which is why we match by string.
+		require.Equal(t, "unknown_command", classifyError(fmt.Errorf(`unknown command "bogus" for "rwx"`)))
+		require.Equal(t, "unknown_command", classifyError(fmt.Errorf(`unknown command "bogus" for "rwx"`+"\n\nDid you mean this?\n\tbogon")))
+	})
+}
+
+// Invoking a non-runnable parent command with unrecognized positional args
+// (e.g. `rwx sandbox push`) doesn't produce an error — Cobra shows help and
+// returns nil. recordTelemetry detects this case via cmd.Flags().Args() after
+// Execute has run. This test pins that signal so a Cobra upgrade can't silently
+// regress the detection.
+func TestUnknownSubcommandSignal(t *testing.T) {
+	parent := &cobra.Command{Use: "parent"}
+	parent.AddCommand(&cobra.Command{Use: "valid", Run: func(*cobra.Command, []string) {}})
+
+	root := &cobra.Command{Use: "root", SilenceErrors: true, SilenceUsage: true}
+	root.AddCommand(parent)
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"parent", "notacmd"})
+
+	require.NoError(t, root.Execute())
+	require.False(t, parent.Runnable())
+	require.Equal(t, []string{"notacmd"}, parent.Flags().Args())
 }
 
 func TestScrubErrorMessage(t *testing.T) {

--- a/cmd/rwx/root.go
+++ b/cmd/rwx/root.go
@@ -34,6 +34,7 @@ var (
 	service            cli.Service
 	accessTokenBackend accesstoken.Backend
 	telem              *telemetry.Telemetry
+	telemetryCollector *telemetry.Collector
 
 	// rootCmd represents the main `rwx` command
 	rootCmd = &cobra.Command{
@@ -66,12 +67,6 @@ var (
 				return errors.Wrap(err, "unable to initialize API client")
 			}
 
-			collector := telemetry.NewCollector()
-			retryRT := retry.NewRoundTripper(c)
-			statsRT := telemetry.NewStatsRoundTripper(retryRT)
-			sender := telemetry.NewSender(collector, statsRT)
-			telem = telemetry.New(collector, sender, statsRT)
-
 			dir, err := os.Getwd()
 			if err != nil {
 				return errors.Wrap(err, "unable to initialize CLI")
@@ -99,7 +94,7 @@ var (
 				AccessTokenBackend:   accessTokenBackend,
 				VersionsBackend:      versionsBackend,
 				SkillVersionsBackend: skillVersionsBackend,
-				TelemetryCollector:   collector,
+				TelemetryCollector:   telemetryCollector,
 				Stdin:                os.Stdin,
 				Stdout:               os.Stdout,
 				StdoutIsTTY:          term.IsTerminal(int(os.Stdout.Fd())),
@@ -114,6 +109,43 @@ var (
 		},
 	}
 )
+
+// initTelemetry builds the telemetry pipeline before Execute() runs so events
+// are recorded for invocations that bypass PersistentPreRunE (e.g. unknown
+// commands). Silent on failure — telemetry is best-effort and must never block
+// the CLI.
+func initTelemetry() {
+	accessToken := AccessToken
+	if accessToken == "$RWX_ACCESS_TOKEN" {
+		accessToken = os.Getenv("RWX_ACCESS_TOKEN")
+	}
+
+	fileBackend, err := internalconfig.NewFileBackend([]string{
+		filepath.Join("~", ".config", "rwx"),
+		filepath.Join("~", ".mint"),
+	})
+	if err != nil {
+		return
+	}
+
+	c, err := api.NewClient(api.Config{
+		AccessToken:          accessToken,
+		Host:                 rwxHost,
+		AccessTokenBackend:   accesstoken.NewFileBackend(fileBackend),
+		VersionsBackend:      versions.NewFileBackend(fileBackend),
+		SkillVersionsBackend: versions.NewSkillFileBackend(fileBackend),
+	})
+	if err != nil {
+		return
+	}
+
+	collector := telemetry.NewCollector()
+	retryRT := retry.NewRoundTripper(c)
+	statsRT := telemetry.NewStatsRoundTripper(retryRT)
+	sender := telemetry.NewSender(collector, statsRT)
+	telem = telemetry.New(collector, sender, statsRT)
+	telemetryCollector = collector
+}
 
 func addRwxDirFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&RwxDirectory, "dir", "d", "", "the directory your RWX configuration files are located in, typically `.rwx`. By default, the CLI traverses up until it finds a `.rwx` directory.")


### PR DESCRIPTION
### Background

- Linear: [RWX-712](https://linear.app/rwx-cloud/issue/RWX-712/emit-telemetry-for-unknowninvalid-cli-commands)
- Follow-up to #489 (common CLI error classification).

### Problem

There are three shapes of "user typed something the CLI can't act on":

1. **Unknown root command** — `rwx bogus`. Cobra rejects during arg validation and returns an error before any PreRun fires. The `telem` singleton is only built inside `rootCmd.PersistentPreRunE`, so `recordTelemetry` short-circuits on the nil guard and nothing is emitted. **Invisible today.**
2. **Unknown subcommand on a non-runnable parent** — `rwx sandbox push`. Cobra's `legacyArgs` only complains about unknown commands at the root, so `Find` returns `(sandboxCmd, ["push"], nil)`. `sandboxCmd.execute` hits `if !c.Runnable() { return flag.ErrHelp }`, ExecuteC catches it, prints help, returns nil. Exit 0, no error to classify. **Invisible today.**
3. **Bad positional arg to a runnable command** — `rwx run bogus`. `runCmd` accepts positionals (treats arg 0 as a config file path), so Cobra happily runs it and the user's input is indistinguishable from a valid invocation until the command's own logic fails. **Cannot be solved generically** — from the telemetry layer there's no way to tell "the user fat-fingered a task name" from "the user ran a valid config file." If we want finer-grained signal here, it belongs inside each runnable command's error surface (e.g. `FindRunDefinitionFile` could wrap with `ErrFileNotExists` so it buckets as `file_not_found` instead of the current `unknown`), not in the shared telemetry path.

This PR covers (1) and (2). (3) is left to each command to classify its own errors.

### Solution

- Pull telemetry pipeline construction out of `PersistentPreRunE` into an `initTelemetry()` helper called from `main()` before `Execute()`. Covers case (1) and any other pre-PreRun failure (bad global flags, etc.) uniformly.
- In `recordTelemetry`, detect case (2) after the fact: if Execute returned nil but the resolved command is non-runnable and `cmd.Flags().Args()` is non-empty, emit `cli.error` with `error_type: "unknown_command"` and flip `cli.command.success` to `false`. Same bucket as (1) — the `command` property (`"rwx"` vs `"sandbox"`) distinguishes them.
- Classify Cobra's "unknown command %q for %q..." error from case (1) as `unknown_command` via prefix match (Cobra doesn't expose a sentinel).

What we **do not** include in the telemetry payload:

- The offending token the user typed (`"bogus"`, `"push"`, or any positional arg) — the issue specifically flagged this as a privacy question. Only the resolved command path (`"rwx"` for case 1, `"sandbox"` for case 2) and flag **names** are emitted. No flag values, no `os.Args`, no `err.Error()` string.
- What we send today for any command is: `command` (cobra path), `flags` (flag names visited), `output_format` (bounded enum from `--output`), `duration_ms`, `success`, and on error `error_type` (fixed classification label) + `handled`. This change doesn't add any new fields.

Tradeoffs:

- `--help`/`--version`/malformed invocations now pay the file-backend + api.Client construction cost. No HTTP at init — only on Flush — so it's cheap.
- The `--access-token` CLI flag isn't parsed until Execute runs, so if a user passes `--access-token xyz` with no env var / saved token, the telemetry POST will flush unauthenticated. Env var and on-disk token cases are unaffected.
- The `unknown_command` prefix check in `classifyError` is string-based. If Cobra ever reworks the message, the bucket falls back to `"unknown"` and the `TestUnknownSubcommandSignal` test catches the subcommand-detection regression separately.

#### Further confirmation needed

- [x] CI passes
- [x] Smoke-checked locally: `rwx bogus` → exit 1, `rwx sandbox push` → exit 0 help shown, `rwx sandbox` → exit 0 help shown (unchanged), `rwx --help` → exit 0 (unchanged). Worth sanity-checking telemetry events land on the server side in a test env.