### PR TITLE
Preserve untracked local files across first sandbox exec

### DIFF
--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1428,6 +1428,26 @@ func parsePatchFiles(patch string) []string {
 	return files
 }
 
+// parseNewFilePaths returns the b/ paths from each diff block that has a
+// `new file mode` header — i.e. additions only, not modifications or deletions.
+func parseNewFilePaths(patch []byte) []string {
+	var paths []string
+	var current string
+	for _, line := range strings.Split(string(patch), "\n") {
+		if strings.HasPrefix(line, "diff --git") {
+			current = ""
+			parts := strings.Split(line, " ")
+			if len(parts) >= 4 {
+				current = strings.TrimPrefix(parts[3], "b/")
+			}
+		} else if strings.HasPrefix(line, "new file mode") && current != "" {
+			paths = append(paths, current)
+			current = ""
+		}
+	}
+	return paths
+}
+
 // saveRejectedPatch writes the patch to .rwx/sandboxes/patch-rejected.diff for manual inspection.
 func saveRejectedPatch(patch []byte) string {
 	rwxDir, err := findRwxDirectoryPath("")
@@ -1761,6 +1781,36 @@ func (s Service) syncChangesToSandbox(jsonMode bool, baselineOnly bool) (int, er
 		}
 		syncPushErr = errors.WrapSentinel(fmt.Errorf("failed to sync changes to sandbox: git apply failed with exit code %d", exitCode), errors.ErrPatch)
 		return patchBytes, syncPushErr
+	}
+
+	// In baselineOnly mode, --cached only stages new-file additions in the index. The sandbox-creation
+	// patch (from GeneratePatchFile) excludes untracked files, so the working tree never received them.
+	// Without materializing them here, refs/rwx-sync ends up ahead of the WT, and pull's
+	// `git diff refs/rwx-sync` reports them as deletions — wiping local untracked files.
+	if baselineOnly {
+		if newFilePaths := parseNewFilePaths(patch); len(newFilePaths) > 0 {
+			_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
+			quoted := make([]string, len(newFilePaths))
+			for i, f := range newFilePaths {
+				quoted[i] = fmt.Sprintf("'%s'", strings.ReplaceAll(f, "'", "'\\''"))
+			}
+			checkoutCmd := fmt.Sprintf("/usr/bin/git checkout-index --force -- %s", strings.Join(quoted, " "))
+			checkoutExitCode, checkoutOutput, checkoutErr := s.SSHClient.ExecuteCommandWithOutput(checkoutCmd)
+			_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
+			if checkoutErr != nil {
+				syncPushErr = errors.Wrap(checkoutErr, "failed to materialize new files in sandbox")
+				return patchBytes, syncPushErr
+			}
+			if checkoutExitCode != 0 {
+				errMsg := strings.TrimSpace(checkoutOutput)
+				if errMsg != "" {
+					syncPushErr = fmt.Errorf("failed to materialize new files in sandbox: %s", errMsg)
+				} else {
+					syncPushErr = fmt.Errorf("failed to materialize new files in sandbox (exit code %d)", checkoutExitCode)
+				}
+				return patchBytes, syncPushErr
+			}
+		}
 	}
 
 	// Snapshot the synced state as a detached ref so pull can diff against it (exec-only changes).

--- a/internal/cli/service_sandbox_internal_test.go
+++ b/internal/cli/service_sandbox_internal_test.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNewFilePaths(t *testing.T) {
+	t.Run("returns paths only for new-file additions", func(t *testing.T) {
+		patch := []byte(`diff --git a/tracked.txt b/tracked.txt
+index abc..def 100644
+--- a/tracked.txt
++++ b/tracked.txt
+@@ -1 +1 @@
+-old
++new
+diff --git a/added.txt b/added.txt
+new file mode 100644
+index 0000000..abc1234
+--- /dev/null
++++ b/added.txt
+@@ -0,0 +1 @@
++content
+diff --git a/removed.txt b/removed.txt
+deleted file mode 100644
+index abc1234..0000000
+--- a/removed.txt
++++ /dev/null
+@@ -1 +0,0 @@
+-content
+`)
+		require.Equal(t, []string{"added.txt"}, parseNewFilePaths(patch))
+	})
+
+	t.Run("handles multiple new files", func(t *testing.T) {
+		patch := []byte(`diff --git a/one.txt b/one.txt
+new file mode 100644
+index 0000000..abc1234
+--- /dev/null
++++ b/one.txt
+@@ -0,0 +1 @@
++one
+diff --git a/two.txt b/two.txt
+new file mode 100644
+index 0000000..def5678
+--- /dev/null
++++ b/two.txt
+@@ -0,0 +1 @@
++two
+`)
+		require.Equal(t, []string{"one.txt", "two.txt"}, parseNewFilePaths(patch))
+	})
+
+	t.Run("handles nested paths", func(t *testing.T) {
+		patch := []byte(`diff --git a/dir/sub/file.txt b/dir/sub/file.txt
+new file mode 100644
+index 0000000..abc1234
+--- /dev/null
++++ b/dir/sub/file.txt
+@@ -0,0 +1 @@
++content
+`)
+		require.Equal(t, []string{"dir/sub/file.txt"}, parseNewFilePaths(patch))
+	})
+
+	t.Run("returns nil for empty patch", func(t *testing.T) {
+		require.Nil(t, parseNewFilePaths(nil))
+		require.Nil(t, parseNewFilePaths([]byte("")))
+	})
+
+	t.Run("returns nil when no new files in patch", func(t *testing.T) {
+		patch := []byte(`diff --git a/tracked.txt b/tracked.txt
+index abc..def 100644
+--- a/tracked.txt
++++ b/tracked.txt
+@@ -1 +1 @@
+-old
++new
+`)
+		require.Nil(t, parseNewFilePaths(patch))
+	})
+}

--- a/test/integration/sandbox-untracked-pull.sh
+++ b/test/integration/sandbox-untracked-pull.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/sandbox-helpers.sh"
+
+UNTRACKED_FILE="integration-test-untracked-survives.txt"
+UNTRACKED_CONTENT="untracked-survives-content"
+
+cleanup() {
+  rm -f "${UNTRACKED_FILE}" setup-artifact.txt
+  "${RWX_CLI}" sandbox stop 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Create an untracked file. Deliberately do NOT `git add` it — this exercises
+# the regression where syncChangesToSandbox in baselineOnly mode applies the
+# patch with `git apply --cached`. New-file additions land only in the index,
+# never in the working tree, so refs/rwx-sync ends up ahead of the sandbox WT.
+# On pull, `git diff refs/rwx-sync` reports the file as a deletion, which the
+# CLI then applies locally, removing the user's untracked file.
+echo "${UNTRACKED_CONTENT}" > "${UNTRACKED_FILE}"
+
+# Run exec WITHOUT a prior sandbox start to trigger isNewSandbox=true.
+"${RWX_CLI}" sandbox exec \
+  "${SCRIPT_DIR}/definitions/sandbox-setup-sync.yml" \
+  --init "ref=${COMMIT_SHA}" \
+  -- sh -c 'true'
+
+if [ ! -f "${UNTRACKED_FILE}" ]; then
+  echo "FAIL: local untracked file ${UNTRACKED_FILE} was deleted by sandbox patch-back"
+  exit 1
+fi
+
+actual=$(cat "${UNTRACKED_FILE}")
+if [ "${actual}" != "${UNTRACKED_CONTENT}" ]; then
+  echo "FAIL: local untracked file ${UNTRACKED_FILE} has unexpected content: ${actual}"
+  exit 1
+fi
+
+echo "PASS: untracked local file survived sandbox exec"


### PR DESCRIPTION
### Background

- Slack thread: https://rwxhq.slack.com/archives/C044VB13K6G/p1777385003270449
- RWX-723: https://linear.app/rwx-cloud/issue/RWX-723/sandbox-patch-back-deletes-local-untracked-files-on-first-exec

### Problem

On the first `rwx sandbox exec` against a freshly-created sandbox, locally-untracked files were getting removed from the user's working tree by the patch-back step.

`syncChangesToSandbox` runs in `baselineOnly` mode when `isNewSandbox=true` and applies the local patch with `git apply --cached`, on the assumption that the sandbox working tree already contains everything in the patch (the API-level patch from `GeneratePatchFile` was applied during sandbox creation). That holds for tracked-file changes, but `GeneratePatch` (used by sync) also includes untracked files via `-N`-staging — those new-file hunks land only in the index, never the working tree. The snapshot commit captures them in `refs/rwx-sync`, then `git reset HEAD~1` clears the index. The result: `refs/rwx-sync` ends up ahead of the sandbox WT. On pull, `git diff refs/rwx-sync` reports the missing files as deletions, which get applied locally — wiping the user's untracked files.

### Solution

In the `baselineOnly` branch of `syncChangesToSandbox`, after `git apply --cached` succeeds and before the snapshot commit, run `git checkout-index --force -- <new-file paths>` on the sandbox to materialize the new-file additions in the working tree, keeping `refs/rwx-sync` consistent with the WT.

- New `parseNewFilePaths` helper extracts the `b/<path>` from each diff block that has a `new file mode` header.
- Tracked-file behavior unchanged: their content was already applied to the WT by the API-level patch during sandbox creation, and `--cached` still stages them in the index.
- New integration test `test/integration/sandbox-untracked-pull.sh` reproduces the bug:
  - **Failing run before fix:** https://cloud.rwx.com/mint/rwx/runs/9969ca52813c41a88a076b244e8bcc36 (`sandbox-untracked-pull` failed with `FAIL: local untracked file integration-test-untracked-survives.txt was deleted by sandbox patch-back`)
  - **Passing run after fix:** https://cloud.rwx.com/mint/rwx/runs/9783f21630b34c4e9485a7e9db4d3863 (`sandbox-untracked-pull` passed alongside the existing `sandbox-setup-sync` regression coverage)

#### Further confirmation needed

- [ ] Reproduce the original Slack-thread scenario (Claude Code workflow with an untracked file, fresh sandbox exec) end-to-end on a real sandbox after merge to confirm the user-facing behavior is restored.