### PR TITLE
Enforce Node 18 minimum for `rwx lint`

### DIFF
--- a/.rwx/integration/lint-test.yml
+++ b/.rwx/integration/lint-test.yml
@@ -41,6 +41,16 @@ tasks:
     with:
       node-version: ${{ tasks.tool-versions.values.nodejs }}
 
+  - key: min-supported-node
+    call: nodejs/install 1.1.13
+    with:
+      node-version: 18.0.0
+
+  - key: unsupported-node
+    call: nodejs/install 1.1.13
+    with:
+      node-version: 17.0.0
+
   - key: lsp-code
     call: git/clone 2.0.7
     with:
@@ -159,5 +169,106 @@ tasks:
 
       if ! rwx lint -d "$tmpdir" "$tmpdir/.rwx/ci.yml" --warnings-as-errors; then
         echo "Lint failed when given a specific file argument"
+        exit 1
+      fi
+
+  - key: test-lint-node-version-unsupported
+    use: [unsupported-node, rwx-cli]
+    run: |
+      set -euo pipefail
+
+      echo "node version: $(node --version)"
+
+      tmpdir=$(mktemp -d)
+      mkdir -p "$tmpdir/.rwx"
+
+      cat > "$tmpdir/.rwx/ci.yml" << 'EOF'
+      base:
+        image: ubuntu:24.04
+        config: rwx/base 1.0.0
+
+      tasks:
+        - key: hello
+          run: echo "hello"
+      EOF
+
+      set +e
+      output=$(rwx lint -d "$tmpdir" 2>&1)
+      exit_code=$?
+      set -e
+
+      if [ "$exit_code" -eq 0 ]; then
+        echo "Lint should have failed on Node 17 but exited 0"
+        echo "Output:"
+        echo "$output"
+        exit 1
+      fi
+
+      if ! echo "$output" | grep -q "node 18+ is required"; then
+        echo "Expected lint output to mention 'node 18+ is required'"
+        echo "Output:"
+        echo "$output"
+        exit 1
+      fi
+
+      if ! echo "$output" | grep -q "v17"; then
+        echo "Expected lint output to include the actual Node 17 version string"
+        echo "Output:"
+        echo "$output"
+        exit 1
+      fi
+
+      if ! echo "$output" | grep -qF "npx -y -p node@18 -- rwx lint"; then
+        echo "Expected lint output to suggest the npx workaround"
+        echo "Output:"
+        echo "$output"
+        exit 1
+      fi
+
+  - key: test-lint-node-version-min-supported
+    use: [min-supported-node, rwx-cli]
+    run: |
+      set -euo pipefail
+
+      echo "node version: $(node --version)"
+
+      # Lint the cli repo's own top-level .rwx configs to exercise a wide range
+      # of parser code paths against the floor-supported Node version. The
+      # embedded run definitions under .rwx/integration are excluded since they
+      # are not standalone configs.
+      tmpdir=$(mktemp -d)
+      mkdir -p "$tmpdir/.rwx"
+      cp .rwx/build.yml \
+         .rwx/ci.yml \
+         .rwx/main.yml \
+         .rwx/release.yml \
+         .rwx/language-server-update.yml \
+         "$tmpdir/.rwx/"
+
+      set +e
+      output=$(rwx lint -d "$tmpdir" --warnings-as-errors 2>&1)
+      exit_code=$?
+      set -e
+
+      if [ "$exit_code" -ne 0 ]; then
+        echo "Lint failed on the cli repo's own top-level .rwx configs with Node 18.0.0"
+        echo "Output:"
+        echo "$output"
+        exit 1
+      fi
+
+      # Node 18 is below recommendedNodeMajor (22), so the CLI should print a
+      # non-blocking EOL warning to stderr.
+      if ! echo "$output" | grep -q "end-of-life"; then
+        echo "Expected EOL warning for Node 18 to appear in stderr"
+        echo "Output:"
+        echo "$output"
+        exit 1
+      fi
+
+      if ! echo "$output" | grep -qF "https://nodejs.org/en/about/previous-releases"; then
+        echo "Expected EOL warning to link to nodejs.org/en/about/previous-releases"
+        echo "Output:"
+        echo "$output"
         exit 1
       fi

--- a/cmd/rwx/lint.go
+++ b/cmd/rwx/lint.go
@@ -43,6 +43,7 @@ var (
 					if err != nil {
 						return nil, err
 					}
+					cfg.TelemetryCollector = telemetryCollector
 
 					checkResult, err := lsp.Check(cmd.Context(), cfg, os.Stdout)
 					if err != nil {

--- a/cmd/rwx/lsp.go
+++ b/cmd/rwx/lsp.go
@@ -18,7 +18,7 @@ var (
 		Use:   "serve",
 		Short: "Start an LSP server",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			exitCode, err := lsp.Serve()
+			exitCode, err := lsp.Serve(telemetryCollector)
 			if err != nil {
 				return err
 			}

--- a/internal/lsp/check.go
+++ b/internal/lsp/check.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rwx-cloud/rwx/internal/cli"
 	"github.com/rwx-cloud/rwx/internal/errors"
 	"github.com/rwx-cloud/rwx/internal/messages"
+	"github.com/rwx-cloud/rwx/internal/telemetry"
 )
 
 type CheckOutputFormat int
@@ -28,11 +29,12 @@ const (
 )
 
 type CheckConfig struct {
-	RwxDirectory string
-	OutputFormat CheckOutputFormat
-	Timeout      time.Duration
-	Files        []string
-	Fix          bool
+	RwxDirectory       string
+	OutputFormat       CheckOutputFormat
+	Timeout            time.Duration
+	Files              []string
+	Fix                bool
+	TelemetryCollector *telemetry.Collector
 }
 
 type CheckResult struct {
@@ -91,9 +93,12 @@ func NewCheckConfig(rwxDir string, formatString string, timeout time.Duration, f
 }
 
 func Check(ctx context.Context, cfg CheckConfig, stdout io.Writer) (*CheckResult, error) {
-	nodePath, err := findNode()
+	nodePath, warning, err := findNode(cfg.TelemetryCollector)
 	if err != nil {
 		return nil, err
+	}
+	if warning != "" {
+		fmt.Fprintln(os.Stderr, warning)
 	}
 
 	serverJS, err := ensureBundle()

--- a/internal/lsp/serve.go
+++ b/internal/lsp/serve.go
@@ -8,16 +8,31 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/rwx-cloud/rwx/cmd/rwx/config"
 	"github.com/rwx-cloud/rwx/internal/errors"
+	"github.com/rwx-cloud/rwx/internal/telemetry"
 )
 
-func Serve() (int, error) {
-	nodePath, err := findNode()
+// minNodeMajor is the minimum supported Node.js major version. The embedded
+// language-server bundle is built with esbuild --target=node18, so anything
+// older fails at runtime with confusing parser/syntax errors.
+const minNodeMajor = 18
+
+// recommendedNodeMajor is the lowest non-EOL Node major. Anything below this
+// (but >= minNodeMajor) is allowed but produces a non-blocking warning.
+const recommendedNodeMajor = 22
+
+func Serve(collector *telemetry.Collector) (int, error) {
+	nodePath, warning, err := findNode(collector)
 	if err != nil {
 		return 0, err
+	}
+	if warning != "" {
+		fmt.Fprintln(os.Stderr, warning)
 	}
 
 	serverJS, err := ensureBundle()
@@ -28,12 +43,70 @@ func Serve() (int, error) {
 	return runServer(nodePath, serverJS)
 }
 
-func findNode() (string, error) {
+// findNode resolves the node binary on PATH and validates its major version.
+// It returns the resolved path, an optional non-blocking warning (empty when
+// none applies), and an error if node is missing, unparsable, or below
+// minNodeMajor. An lsp.node_check telemetry event is recorded on every call.
+func findNode(collector *telemetry.Collector) (string, string, error) {
+	record := func(props map[string]any) {
+		if collector == nil {
+			return
+		}
+		collector.Record("lsp.node_check", props)
+	}
+
 	path, err := exec.LookPath("node")
 	if err != nil {
-		return "", errors.New("node is required but was not found on PATH. Install Node.js from https://nodejs.org")
+		record(map[string]any{"status": "missing"})
+		return "", "", errors.New("node is required but was not found on PATH. Install Node.js from https://nodejs.org")
 	}
-	return path, nil
+
+	out, err := exec.Command(path, "--version").Output()
+	if err != nil {
+		record(map[string]any{"status": "version_check_failed"})
+		return "", "", errors.Wrapf(err, "unable to determine node version by running %q --version", path)
+	}
+
+	version := strings.TrimSpace(string(out))
+	major, err := parseNodeMajor(version)
+	if err != nil {
+		record(map[string]any{"status": "unparsable", "version": version})
+		return "", "", errors.Wrapf(err, "unable to parse node version %q", version)
+	}
+
+	if major < minNodeMajor {
+		record(map[string]any{"status": "too_old", "version": version, "major": major})
+		return "", "", errors.Errorf(
+			"node %d+ is required (found %s). Upgrade from https://nodejs.org, or run a one-off without upgrading via: npx -y -p node@%d -- rwx lint",
+			minNodeMajor, version, minNodeMajor,
+		)
+	}
+
+	var warning string
+	status := "ok"
+	if major < recommendedNodeMajor {
+		warning = fmt.Sprintf(
+			"warning: Node %s has reached end-of-life. See https://nodejs.org/en/about/previous-releases for more information.",
+			version,
+		)
+		status = "eol_warning"
+	}
+
+	record(map[string]any{"status": status, "version": version, "major": major})
+	return path, warning, nil
+}
+
+func parseNodeMajor(version string) (int, error) {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(version), "v")
+	if trimmed == "" {
+		return 0, errors.New("empty version string")
+	}
+	majorPart, _, _ := strings.Cut(trimmed, ".")
+	major, err := strconv.Atoi(majorPart)
+	if err != nil {
+		return 0, errors.Wrapf(err, "major component %q is not an integer", majorPart)
+	}
+	return major, nil
 }
 
 func bundleHash() (string, error) {

--- a/internal/lsp/serve_test.go
+++ b/internal/lsp/serve_test.go
@@ -1,19 +1,232 @@
 package lsp
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
+	"github.com/rwx-cloud/rwx/internal/telemetry"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFindNode_ReturnsErrorWhenNotOnPath(t *testing.T) {
 	t.Setenv("PATH", "")
 
-	_, err := findNode()
+	_, _, err := findNode(nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "node is required but was not found on PATH")
+}
+
+func TestFindNode_ReturnsErrorWhenVersionTooOld(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX shebang scripts")
+	}
+	dir := writeFakeNode(t, "v16.20.2")
+	t.Setenv("PATH", dir)
+
+	_, _, err := findNode(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "node 18+ is required")
+	require.Contains(t, err.Error(), "v16.20.2")
+	require.Contains(t, err.Error(), "https://nodejs.org")
+	require.Contains(t, err.Error(), "npx -y -p node@18 -- rwx lint")
+}
+
+func TestFindNode_AcceptsNode18WithEOLWarning(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX shebang scripts")
+	}
+	dir := writeFakeNode(t, "v18.0.0")
+	t.Setenv("PATH", dir)
+
+	resolved, warning, err := findNode(nil)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dir, "node"), resolved)
+	require.Contains(t, warning, "v18.0.0")
+	require.Contains(t, warning, "end-of-life")
+	require.Contains(t, warning, "https://nodejs.org/en/about/previous-releases")
+}
+
+func TestFindNode_AcceptsNode20WithEOLWarning(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX shebang scripts")
+	}
+	dir := writeFakeNode(t, "v20.10.0")
+	t.Setenv("PATH", dir)
+
+	resolved, warning, err := findNode(nil)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dir, "node"), resolved)
+	require.Contains(t, warning, "v20.10.0")
+	require.Contains(t, warning, "end-of-life")
+}
+
+func TestFindNode_AcceptsNode22WithoutWarning(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX shebang scripts")
+	}
+	dir := writeFakeNode(t, "v22.4.1")
+	t.Setenv("PATH", dir)
+
+	resolved, warning, err := findNode(nil)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dir, "node"), resolved)
+	require.Empty(t, warning)
+}
+
+func TestFindNode_AcceptsNode24WithoutWarning(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX shebang scripts")
+	}
+	dir := writeFakeNode(t, "v24.0.0")
+	t.Setenv("PATH", dir)
+
+	resolved, warning, err := findNode(nil)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dir, "node"), resolved)
+	require.Empty(t, warning)
+}
+
+func TestFindNode_ReturnsErrorOnUnparsableVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX shebang scripts")
+	}
+	dir := writeFakeNode(t, "not-a-version")
+	t.Setenv("PATH", dir)
+
+	_, _, err := findNode(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unable to parse node version")
+}
+
+func TestFindNode_RecordsTelemetry_OK(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX shebang scripts")
+	}
+	dir := writeFakeNode(t, "v22.4.1")
+	t.Setenv("PATH", dir)
+
+	collector := telemetry.NewCollector()
+	_, _, err := findNode(collector)
+	require.NoError(t, err)
+
+	events := collector.Drain()
+	require.Len(t, events, 1)
+	require.Equal(t, "lsp.node_check", events[0].Event)
+	require.Equal(t, "ok", events[0].Props["status"])
+	require.Equal(t, "v22.4.1", events[0].Props["version"])
+	require.Equal(t, 22, events[0].Props["major"])
+}
+
+func TestFindNode_RecordsTelemetry_EOLWarning(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX shebang scripts")
+	}
+	dir := writeFakeNode(t, "v18.0.0")
+	t.Setenv("PATH", dir)
+
+	collector := telemetry.NewCollector()
+	_, warning, err := findNode(collector)
+	require.NoError(t, err)
+	require.NotEmpty(t, warning)
+
+	events := collector.Drain()
+	require.Len(t, events, 1)
+	require.Equal(t, "lsp.node_check", events[0].Event)
+	require.Equal(t, "eol_warning", events[0].Props["status"])
+	require.Equal(t, "v18.0.0", events[0].Props["version"])
+	require.Equal(t, 18, events[0].Props["major"])
+}
+
+func TestFindNode_RecordsTelemetry_TooOld(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX shebang scripts")
+	}
+	dir := writeFakeNode(t, "v17.0.0")
+	t.Setenv("PATH", dir)
+
+	collector := telemetry.NewCollector()
+	_, _, err := findNode(collector)
+	require.Error(t, err)
+
+	events := collector.Drain()
+	require.Len(t, events, 1)
+	require.Equal(t, "lsp.node_check", events[0].Event)
+	require.Equal(t, "too_old", events[0].Props["status"])
+	require.Equal(t, "v17.0.0", events[0].Props["version"])
+	require.Equal(t, 17, events[0].Props["major"])
+}
+
+func TestFindNode_RecordsTelemetry_Missing(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	collector := telemetry.NewCollector()
+	_, _, err := findNode(collector)
+	require.Error(t, err)
+
+	events := collector.Drain()
+	require.Len(t, events, 1)
+	require.Equal(t, "lsp.node_check", events[0].Event)
+	require.Equal(t, "missing", events[0].Props["status"])
+}
+
+func TestFindNode_RecordsTelemetry_Unparsable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on POSIX shebang scripts")
+	}
+	dir := writeFakeNode(t, "not-a-version")
+	t.Setenv("PATH", dir)
+
+	collector := telemetry.NewCollector()
+	_, _, err := findNode(collector)
+	require.Error(t, err)
+
+	events := collector.Drain()
+	require.Len(t, events, 1)
+	require.Equal(t, "lsp.node_check", events[0].Event)
+	require.Equal(t, "unparsable", events[0].Props["status"])
+	require.Equal(t, "not-a-version", events[0].Props["version"])
+}
+
+func TestParseNodeMajor(t *testing.T) {
+	cases := []struct {
+		input   string
+		major   int
+		wantErr bool
+	}{
+		{"v18.0.0", 18, false},
+		{"v22.4.1", 22, false},
+		{"v16.20.2", 16, false},
+		{"18.0.0", 18, false},
+		{"v18.0.0\n", 18, false},
+		{"", 0, true},
+		{"v", 0, true},
+		{"vfoo.bar", 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			major, err := parseNodeMajor(c.input)
+			if c.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.major, major)
+		})
+	}
+}
+
+// writeFakeNode creates a temporary directory containing an executable `node`
+// script that prints the supplied version string. It returns the directory so
+// callers can prepend it to PATH.
+func writeFakeNode(t *testing.T, version string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := fmt.Sprintf("#!/bin/sh\necho %q\n", version)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "node"), []byte(script), 0o755))
+	return dir
 }
 
 func TestBundleHash_ReturnsDeterministicNonEmptyHash(t *testing.T) {


### PR DESCRIPTION
### Background

[RWX-769](https://linear.app/rwx-cloud/issue/RWX-769/enforce-node-18-minimum-for-rwx-lint)

The customer hit by the original `Parser error: n.values(...).filter is not a function` report was actually on Node 20, and the underlying parser bug has since been fixed in the language-server. So this PR is no longer about that specific incident.

### Problem

We have no mechanism for declaring or enforcing a minimum Node version for the embedded language-server bundle, no CI signal if a `language-server-ref` bump introduces a regression in the linter against the floor-supported Node, and no telemetry visibility into which Node versions our users actually run `rwx lint` / `rwx lsp serve` against. Today, `findNode()` in `internal/lsp/serve.go` only checks for the presence of `node` on `PATH` — pre-v18 (or any future floor we set) would surface as a confusing runtime/syntax error from the bundle rather than a clear actionable message.

### Solution

- Add a `minNodeMajor` constant (currently `18`, matching the bundle's `esbuild --target=node18`) and enforce it in `findNode()`. After `exec.LookPath("node")`, run `node --version`, parse the major component, and reject anything below the floor with `node 18+ is required (found vXX.YY.ZZ). Upgrade from https://nodejs.org, or run a one-off without upgrading via: npx -y -p node@18 -- rwx lint`. Users who can't bump their system Node immediately get a copy-pasteable workaround. The hint is only attached when Node is present-but-old (the not-on-PATH branch returns earlier with its own message).
- Add a `recommendedNodeMajor` constant (currently `22`, the lowest non-EOL Node major). Anything in `[18, 22)` is allowed but `findNode()` returns a non-blocking warning that callers print to stderr: `warning: Node vXX.YY.ZZ has reached end-of-life. See https://nodejs.org/en/about/previous-releases for more information.`
- Record an `lsp.node_check` telemetry event on every `findNode()` call with a `status` bucket (`missing` / `version_check_failed` / `unparsable` / `too_old` / `eol_warning` / `ok`) and, when known, the `version` string and parsed `major`. Gives us aggregate visibility into the Node-version distribution in the wild and the data we need to time future floor bumps. Wired through `CheckConfig.TelemetryCollector` and a new `Serve` parameter; nil-tolerant.
- All three behaviors apply to `rwx lint` and `rwx lsp serve`, since both call `findNode()`.
- Wire two integration tests into `.rwx/integration/lint-test.yml`:
  - **`test-lint-node-version-unsupported`** — runs against Node 17.0.0 and asserts the error fires, includes the actual `v17` version, and surfaces the `npx -y -p node@18 -- rwx lint` workaround.
  - **`test-lint-node-version-min-supported`** — runs against Node 18.0.0 and lints the cli repo's own top-level `.rwx/*.yml` files (`build.yml`, `ci.yml`, `main.yml`, `release.yml`, `language-server-update.yml`) — a real-world set of complex configs covering init params, expression interpolation, package calls, multi-task dependencies, filters, etc. Exit must be 0 *and* stderr must contain the EOL warning. This is the CI signal we wanted: any future `language-server-ref` bump that breaks the linter against the floor Node will fail this job.

When we need to raise the floor (e.g. esbuild target moves to node20), bumping `minNodeMajor` in Go and the two `node-version` values in the integration config is the whole change. Bumping `recommendedNodeMajor` follows the same pattern as Node majors EOL upstream.

#### Notes / tradeoffs

- Source of truth is hardcoded in Go (option (a) from the ticket) with a comment linking it to the upstream esbuild target. Simplest path; if duplication ever bites we can bake it into the bundle at build time.
- `node --version` adds ~30–80ms per `rwx lint` / `rwx lsp serve` invocation. Not caching for now.
- The EOL warning prints on every invocation while the user remains on a < 22 Node; that's intentional — we want it to be visible until they upgrade.

#### Further confirmation needed

- [ ] CI passes both new integration tests (`test-lint-node-version-unsupported`, `test-lint-node-version-min-supported`).
- [ ] `lsp.node_check` events show up in the telemetry pipeline once this lands.