### PR TITLE
Explicitly set linear release version before trying to complete it

### DIFF
--- a/.rwx/release.yml
+++ b/.rwx/release.yml
@@ -344,6 +344,8 @@ tasks:
     use: [code, linear-release-cli]
     if: ${{ init.kind == "production" }}
     after: publish-production-release
-    run: linear-release complete --release-version=${{ init.version }}
+    run: |
+      linear-release sync --release-version=${{ init.version }} --name="RWX CLI ${{ init.version }}"
+      linear-release complete --release-version=${{ init.version }}
     env:
       LINEAR_ACCESS_KEY: ${{ vaults.rwx_cli_development.secrets.linear-release-access-key }}


### PR DESCRIPTION
Follows #498

The Linear docs were a bit unclear on this, but you have to give a schedule release a version number before you can mark it as complete, so this PR does that (verified with the last production build via rwx-breakpoint).
