### PR TITLE
Expose sandbox commands in --help

### DIFF
--- a/cmd/rwx/sandbox.go
+++ b/cmd/rwx/sandbox.go
@@ -16,7 +16,6 @@ var sandboxCmd = &cobra.Command{
 	GroupID: "execution",
 	Use:     "sandbox",
 	Short:   "Run commands in persistent sandboxes",
-	Hidden:  true,
 }
 
 var sandboxStartCmd = &cobra.Command{


### PR DESCRIPTION
### Problem

The `sandbox` command tree has been hidden from `rwx --help` while it was under development. It's ready to be surfaced to users now.

### Solution

Removed `Hidden: true` from `sandboxCmd` in `cmd/rwx/sandbox.go`. Subcommands (`start`, `exec`, `list`, `stop`, `init`, `reset`) inherit visibility from the parent, so they now appear under `rwx sandbox --help` automatically.