### PR TITLE
Capture attempted command name in unknown_command telemetry

### DIFF
--- a/cmd/rwx/main.go
+++ b/cmd/rwx/main.go
@@ -99,14 +99,23 @@ func recordTelemetry(err error, start time.Time) {
 		if errType == "unknown" && !handled {
 			props["error_message"] = scrubErrorMessage(err.Error())
 		}
+		if errType == "unknown_command" {
+			if attempt := extractUnknownCommandAttempt(err); attempt != "" {
+				props["attempted_command"] = scrubErrorMessage(attempt)
+			}
+		}
 		telem.Record("cli.error", props)
 	case unknownSubcommand:
-		telem.Record("cli.error", map[string]any{
+		props := map[string]any{
 			"command":    commandName,
 			"flags":      flagNames,
 			"error_type": "unknown_command",
 			"handled":    false,
-		})
+		}
+		if extras := cmd.Flags().Args(); len(extras) > 0 {
+			props["attempted_command"] = scrubErrorMessage(extras[0])
+		}
+		telem.Record("cli.error", props)
 	}
 
 	telem.Flush()
@@ -122,6 +131,10 @@ var (
 	jwtRe = regexp.MustCompile(`[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}`)
 	// tokenRe matches standalone token-shaped runs (hex/base64/UUID-ish).
 	tokenRe = regexp.MustCompile(`[A-Za-z0-9_\-]{32,}`)
+	// unknownCommandRe pulls the attempted name out of Cobra's
+	// `unknown command "X" for "Y"` error. Cobra formats X with %q, so
+	// embedded quotes are escaped and the simple [^"] match is safe.
+	unknownCommandRe = regexp.MustCompile(`^unknown command "([^"]+)"`)
 )
 
 func scrubErrorMessage(msg string) string {
@@ -135,6 +148,17 @@ func scrubErrorMessage(msg string) string {
 		msg = string(runes[:errorMessageMaxRunes]) + "..."
 	}
 	return msg
+}
+
+func extractUnknownCommandAttempt(err error) string {
+	if err == nil {
+		return ""
+	}
+	m := unknownCommandRe.FindStringSubmatch(err.Error())
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
 }
 
 func classifyError(err error) string {

--- a/cmd/rwx/main_test.go
+++ b/cmd/rwx/main_test.go
@@ -68,6 +68,26 @@ func TestClassifyError(t *testing.T) {
 	})
 }
 
+func TestExtractUnknownCommandAttempt(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{"nil", nil, ""},
+		{"plain", fmt.Errorf(`unknown command "signup" for "rwx"`), "signup"},
+		{"with suggestion", fmt.Errorf(`unknown command "signup" for "rwx"` + "\n\nDid you mean this?\n\tsignuptest"), "signup"},
+		{"unrelated error", fmt.Errorf("some other failure"), ""},
+		{"different prefix", fmt.Errorf(`Error: unknown command "signup" for "rwx"`), ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, extractUnknownCommandAttempt(tc.err))
+		})
+	}
+}
+
 // Invoking a non-runnable parent command with unrecognized positional args
 // (e.g. `rwx sandbox push`) doesn't produce an error — Cobra shows help and
 // returns nil. recordTelemetry detects this case via cmd.Flags().Args() after


### PR DESCRIPTION
### Problem

Today's `cli.error` event with `error_type: "unknown_command"` records `command: "rwx"` and `flags: null`, so the payload looks identical whether the user ran `rwx signup`, `rwx asdf`, or any other unrecognized token. We can see that *something* unknown was tried, but not what.

### Solution

Extract the attempted name from Cobra's `unknown command "X" for "Y"` error string and attach it as `attempted_command` on the `cli.error` event. The non-runnable-parent path (e.g. `rwx sandbox push`) pulls the same field from `cmd.Flags().Args()[0]`.

The value is run through the existing `scrubErrorMessage` helper, which redacts JWTs, URL userinfo, and long token-shaped runs, and truncates at 200 chars. Multi-arg cases like `rwx signup mypassword` are not at risk: Cobra only quotes the first unknown token in its error, and the parent-path code only reads `extras[0]`.

Tradeoff: a short sensitive string typed *as* the command itself (e.g. `rwx hunter2`) would be captured verbatim, since we can't reliably distinguish "password-shaped" from "real subcommand name". Accepted as a small, unusual risk.

#### Further confirmation needed

- [ ] Spot-check telemetry once deployed to confirm `attempted_command` appears on the expected events and contains plausible values.