### PR TITLE
Remove redundant outputs.values declarations

### DIFF
--- a/.rwx/integration/image-test.yml
+++ b/.rwx/integration/image-test.yml
@@ -58,8 +58,6 @@ tasks:
       AWS_OIDC_TOKEN:
         value: ${{ vaults.rwx_cli_development.oidc.aws }}
         cache-key: excluded
-    outputs:
-      values: [ecr-image]
 
   - key: push-image-gzip
     use: [rwx-cli, aws-role]

--- a/.rwx/release.yml
+++ b/.rwx/release.yml
@@ -60,8 +60,6 @@ tasks:
 
   - key: extract-version-details
     after: verify-inputs
-    outputs:
-      values: [full-version, aliased-version]
     run: |
       kind="${{ init.kind }}"
 


### PR DESCRIPTION
### Problem

Two tasks declare `outputs.values:` for values that are written to `$RWX_VALUES`. RWX auto-discovers task values from `$RWX_VALUES` writes, so these declarations are redundant. A recent RWX release started emitting a deprecation warning for this pattern.

### Solution

Removed the `outputs.values` block from:
- `.rwx/release.yml` — `extract-version-details` task (`full-version`, `aliased-version`)
- `.rwx/integration/image-test.yml` — `build-image` task (`ecr-image`)

Downstream references via `tasks.X.values.Y` continue to work via auto-discovery.

#### Further confirmation needed

- [ ] Confirm the deprecation warnings are gone in a CI run