### PR TITLE
Prompt repo vs user on skill install

### DIFF
--- a/.rwx/integration/skill-test.yml
+++ b/.rwx/integration/skill-test.yml
@@ -337,8 +337,14 @@ tasks:
         exit 1
       fi
 
-      if ! echo "$output" | grep -q "project"; then
-        echo "Expected 'project' scope in status output, got:"
+      if ! echo "$output" | grep -q "repo"; then
+        echo "Expected 'repo' scope in status output, got:"
+        echo "$output"
+        exit 1
+      fi
+
+      if echo "$output" | grep -q "project"; then
+        echo "Stale 'project' terminology still present in status output:"
         echo "$output"
         exit 1
       fi
@@ -351,3 +357,88 @@ tasks:
         echo "$json"
         exit 1
       fi
+
+      scope=$(echo "$json" | jq -r '[.Installations[] | select(.Detected == true and .Source == "agents")][0].Scope')
+      if [ "$scope" != "repo" ]; then
+        echo "Expected JSON Scope 'repo' for repo-level install, got '$scope'"
+        echo "$json"
+        exit 1
+      fi
+
+  # --yes always prints the user-level handoff (npx skills + docs link)
+  - key: test-install-yes-prints-handoff
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      tmpdir=$(mktemp -d)
+      cd "$tmpdir"
+
+      stderr=$(rwx skill install --yes 2>&1 >/dev/null)
+
+      if ! echo "$stderr" | grep -q "npx skills add rwx-cloud/skills"; then
+        echo "Expected 'npx skills add rwx-cloud/skills' handoff in stderr after --yes install, got:"
+        echo "$stderr"
+        exit 1
+      fi
+
+      if ! echo "$stderr" | grep -q "https://www.rwx.com/docs/ai"; then
+        echo "Expected docs link in stderr after --yes install, got:"
+        echo "$stderr"
+        exit 1
+      fi
+
+  # --yes over an existing repo install: confirms automatically and uses
+  # the renamed "repo" terminology in the existing-install notice.
+  - key: test-install-yes-existing-uses-repo-terminology
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      tmpdir=$(mktemp -d)
+      cd "$tmpdir"
+
+      mkdir -p "$tmpdir/.agents/skills/rwx"
+      cat > "$tmpdir/.agents/skills/rwx/SKILL.md" << 'EOF'
+      ---
+      metadata:
+        version: "0.0.1"
+      ---
+      Stale content
+      EOF
+
+      stderr=$(rwx skill install --yes 2>&1 >/dev/null)
+
+      if ! echo "$stderr" | grep -q "An existing repo installation"; then
+        echo "Expected 'An existing repo installation' in stderr, got:"
+        echo "$stderr"
+        exit 1
+      fi
+
+      if echo "$stderr" | grep -q "project level"; then
+        echo "Stale 'project level' terminology still present in stderr:"
+        echo "$stderr"
+        exit 1
+      fi
+
+      # Install should still have succeeded (stale content overwritten).
+      if grep -q "Stale content" "$tmpdir/.agents/skills/rwx/SKILL.md"; then
+        echo "SKILL.md still contains stale content after --yes install"
+        exit 1
+      fi
+
+  # Help text reflects the repo/user prompt and `npx skills` handoff
+  - key: test-skill-install-help-text
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      output=$(rwx skill install --help)
+
+      for needle in repo user "npx skills"; do
+        if ! echo "$output" | grep -q "$needle"; then
+          echo "Expected --help output to mention '$needle', got:"
+          echo "$output"
+          exit 1
+        fi
+      done

--- a/cmd/rwx/skill.go
+++ b/cmd/rwx/skill.go
@@ -55,13 +55,17 @@ var (
 
 	skillInstallCmd = &cobra.Command{
 		Use:   "install",
-		Short: "Install the RWX agent skill at the project level (.agents/skills/rwx/SKILL.md)",
+		Short: "Install the RWX agent skill (prompts repo vs user; repo writes to .agents/skills/rwx/SKILL.md, user defers to `npx skills`)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			yes, _ := cmd.Flags().GetBool("yes")
 			symlink, _ := cmd.Flags().GetString("symlink")
 			result, err := service.SkillInstall(yes, symlink)
 			if err != nil {
 				return err
+			}
+
+			if result.Path == "" {
+				return nil
 			}
 
 			fmt.Fprintf(os.Stdout, "Installed RWX agent skill at %s\n", shortenPath(result.Path))

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -295,10 +295,13 @@ func (s Service) SkillUpdate(symlink string) (*SkillUpdateResult, error) {
 }
 
 type SkillInstallResult struct {
+	// Path is the location of the installed SKILL.md, or "" if no install
+	// was performed (e.g. the user chose a user-level handoff).
 	Path string
 }
 
-// SkillInstall installs the RWX agent skill at the project level. The
+// SkillInstall installs the RWX agent skill at the repo level, or prints a
+// handoff to the `skills` CLI for a user-level install. The repo-level
 // install location and symlink behavior are inferred from the project:
 //   - Neither .agents nor .claude exists: install to .agents, prompt for .claude symlink
 //   - Both exist: install to .agents, auto-symlink to .claude
@@ -306,16 +309,30 @@ type SkillInstallResult struct {
 //   - Only .agents exists: install to .agents, no symlink
 //
 // The --symlink claude flag forces symlink creation (useful in non-TTY).
+// With --yes, install to repo and always print the user-level handoff.
 func (s Service) SkillInstall(yes bool, symlink string) (*SkillInstallResult, error) {
 	detected, err := skill.Detect()
 	if err != nil {
 		return nil, err
 	}
 
+	// In interactive mode, prompt for repo vs user before doing anything.
+	// `--yes` and non-TTY both default to repo without prompting.
+	if !yes && s.StderrIsTTY {
+		choice, err := s.promptForInstallLocation()
+		if err != nil {
+			return nil, err
+		}
+		if choice == installLocationUser {
+			s.printUserLevelHandoff()
+			return &SkillInstallResult{}, nil
+		}
+	}
+
 	for _, inst := range detected.Installations {
 		if skill.IsDetected(inst) && inst.Source == "agents" {
 			fmt.Fprintf(s.Stderr, "An existing %s installation was found at %s\n", inst.Scope, inst.Path)
-			if err := s.confirmDestruction("Install at the project level anyway?", yes); err != nil {
+			if err := s.confirmDestruction("Install at the repo level anyway?", yes); err != nil {
 				return nil, err
 			}
 			break
@@ -371,7 +388,55 @@ func (s Service) SkillInstall(yes bool, symlink string) (*SkillInstallResult, er
 		return nil, errors.Wrap(err, "unable to write skill file")
 	}
 
+	// `--yes` always prints the handoff so non-interactive users learn about
+	// the user-level install path; we don't try to detect existing user-level
+	// installs here.
+	if yes {
+		s.printUserLevelHandoff()
+	}
+
 	return &SkillInstallResult{Path: skillPath}, nil
+}
+
+const (
+	installLocationRepo = "repo"
+	installLocationUser = "user"
+)
+
+// promptForInstallLocation asks the user whether to install the skill at the
+// repo or user level. Defaults to repo on empty input. Returns the user's
+// choice; errors only on IO failures.
+func (s Service) promptForInstallLocation() (string, error) {
+	fmt.Fprintln(s.Stderr, "Where would you like to install the RWX skill?")
+	fmt.Fprintln(s.Stderr, "1 - repo (recommended, best practice is to commit skills to share with your team)")
+	fmt.Fprintln(s.Stderr, "2 - user (installs the skill on this machine, available across projects)")
+	fmt.Fprintf(s.Stderr, "Choose [1]: ")
+
+	scanner := bufio.NewScanner(s.Stdin)
+	if !scanner.Scan() {
+		return installLocationRepo, nil
+	}
+
+	answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+	switch answer {
+	case "", "1", "repo":
+		return installLocationRepo, nil
+	case "2", "user":
+		return installLocationUser, nil
+	default:
+		return "", errors.New("invalid choice; expected 1 (repo) or 2 (user)")
+	}
+}
+
+// printUserLevelHandoff prints instructions for installing the RWX skill at
+// the user (machine-wide) level via the `skills` CLI.
+func (s Service) printUserLevelHandoff() {
+	fmt.Fprintln(s.Stderr, "")
+	fmt.Fprintln(s.Stderr, "To install the RWX skill at the user level, use the `skills` CLI:")
+	fmt.Fprintln(s.Stderr, "")
+	fmt.Fprintln(s.Stderr, "  npx skills add rwx-cloud/skills")
+	fmt.Fprintln(s.Stderr, "")
+	fmt.Fprintln(s.Stderr, "For more details, see https://www.rwx.com/docs/ai")
 }
 
 // promptForClaudeSymlink asks the user whether to create a Claude Code symlink.

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -383,4 +383,205 @@ func TestSkillInstall(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, skillContent, string(written))
 	})
+
+	t.Run("--yes installs to repo and prints user-level handoff", func(t *testing.T) {
+		s := setupSkillTest(t)
+
+		s.mockAPI.MockGetSkillContent = func() (string, error) {
+			return "---\nmetadata:\n  version: 2.0.0\n---\nSkill content\n", nil
+		}
+
+		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+
+		var err error
+		s.service, err = cli.NewService(s.config)
+		require.NoError(t, err)
+
+		result, err := s.service.SkillInstall(true, "")
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(s.tmp, ".agents", "skills", "rwx", "SKILL.md"), result.Path)
+
+		stderr := s.mockStderr.String()
+		require.Contains(t, stderr, "npx skills add rwx-cloud/skills")
+		require.Contains(t, stderr, "https://www.rwx.com/docs/ai")
+	})
+
+	t.Run("non-TTY without --yes installs to repo without handoff", func(t *testing.T) {
+		s := setupSkillTest(t)
+
+		s.mockAPI.MockGetSkillContent = func() (string, error) {
+			return "---\nmetadata:\n  version: 2.0.0\n---\nSkill content\n", nil
+		}
+
+		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+
+		var err error
+		s.service, err = cli.NewService(s.config)
+		require.NoError(t, err)
+
+		result, err := s.service.SkillInstall(false, "")
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(s.tmp, ".agents", "skills", "rwx", "SKILL.md"), result.Path)
+
+		require.NotContains(t, s.mockStderr.String(), "npx skills")
+	})
+
+	t.Run("interactive picks repo and installs", func(t *testing.T) {
+		s := setupSkillTest(t)
+		s.config.StderrIsTTY = true
+		s.mockStdin = bytes.NewBufferString("1\n")
+		s.config.Stdin = s.mockStdin
+
+		s.mockAPI.MockGetSkillContent = func() (string, error) {
+			return "---\nmetadata:\n  version: 2.0.0\n---\nSkill content\n", nil
+		}
+
+		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+
+		var err error
+		s.service, err = cli.NewService(s.config)
+		require.NoError(t, err)
+
+		result, err := s.service.SkillInstall(false, "")
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(s.tmp, ".agents", "skills", "rwx", "SKILL.md"), result.Path)
+
+		stderr := s.mockStderr.String()
+		require.Contains(t, stderr, "Where would you like to install the RWX skill?")
+		require.NotContains(t, stderr, "npx skills")
+	})
+
+	t.Run("interactive default (empty) installs to repo", func(t *testing.T) {
+		s := setupSkillTest(t)
+		s.config.StderrIsTTY = true
+		s.mockStdin = bytes.NewBufferString("\n")
+		s.config.Stdin = s.mockStdin
+
+		s.mockAPI.MockGetSkillContent = func() (string, error) {
+			return "---\nmetadata:\n  version: 2.0.0\n---\nSkill content\n", nil
+		}
+
+		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+
+		var err error
+		s.service, err = cli.NewService(s.config)
+		require.NoError(t, err)
+
+		result, err := s.service.SkillInstall(false, "")
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(s.tmp, ".agents", "skills", "rwx", "SKILL.md"), result.Path)
+	})
+
+	t.Run("interactive picks user and prints handoff without installing", func(t *testing.T) {
+		s := setupSkillTest(t)
+		s.config.StderrIsTTY = true
+		s.mockStdin = bytes.NewBufferString("2\n")
+		s.config.Stdin = s.mockStdin
+
+		s.mockAPI.MockGetSkillContent = func() (string, error) {
+			t.Fatal("API should not be called when user picks user-level install")
+			return "", nil
+		}
+
+		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+
+		var err error
+		s.service, err = cli.NewService(s.config)
+		require.NoError(t, err)
+
+		result, err := s.service.SkillInstall(false, "")
+		require.NoError(t, err)
+		require.Empty(t, result.Path)
+
+		stderr := s.mockStderr.String()
+		require.Contains(t, stderr, "npx skills add rwx-cloud/skills")
+		require.Contains(t, stderr, "https://www.rwx.com/docs/ai")
+
+		_, statErr := os.Stat(filepath.Join(s.tmp, ".agents", "skills", "rwx", "SKILL.md"))
+		require.True(t, os.IsNotExist(statErr), "no SKILL.md should be written")
+	})
+
+	t.Run("interactive accepts word form 'repo'", func(t *testing.T) {
+		s := setupSkillTest(t)
+		s.config.StderrIsTTY = true
+		s.mockStdin = bytes.NewBufferString("repo\n")
+		s.config.Stdin = s.mockStdin
+
+		s.mockAPI.MockGetSkillContent = func() (string, error) {
+			return "---\nmetadata:\n  version: 2.0.0\n---\nSkill content\n", nil
+		}
+
+		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+
+		var err error
+		s.service, err = cli.NewService(s.config)
+		require.NoError(t, err)
+
+		result, err := s.service.SkillInstall(false, "")
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(s.tmp, ".agents", "skills", "rwx", "SKILL.md"), result.Path)
+	})
+
+	t.Run("interactive accepts word form 'user'", func(t *testing.T) {
+		s := setupSkillTest(t)
+		s.config.StderrIsTTY = true
+		s.mockStdin = bytes.NewBufferString("user\n")
+		s.config.Stdin = s.mockStdin
+
+		s.mockAPI.MockGetSkillContent = func() (string, error) {
+			t.Fatal("API should not be called when user picks user-level install")
+			return "", nil
+		}
+
+		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+
+		var err error
+		s.service, err = cli.NewService(s.config)
+		require.NoError(t, err)
+
+		result, err := s.service.SkillInstall(false, "")
+		require.NoError(t, err)
+		require.Empty(t, result.Path)
+		require.Contains(t, s.mockStderr.String(), "npx skills add rwx-cloud/skills")
+	})
+
+	t.Run("--yes with existing install confirms with renamed prompt copy", func(t *testing.T) {
+		s := setupSkillTest(t)
+		seedSkillFile(t, s.tmp, "1.0.0")
+
+		s.mockAPI.MockGetSkillContent = func() (string, error) {
+			return "---\nmetadata:\n  version: 2.0.0\n---\nSkill content\n", nil
+		}
+
+		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+
+		var err error
+		s.service, err = cli.NewService(s.config)
+		require.NoError(t, err)
+
+		result, err := s.service.SkillInstall(true, "")
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(s.tmp, ".agents", "skills", "rwx", "SKILL.md"), result.Path)
+
+		stderr := s.mockStderr.String()
+		require.Contains(t, stderr, "An existing")
+		require.Contains(t, stderr, "installation was found")
+		require.NotContains(t, stderr, "project level")
+	})
+
+	t.Run("interactive invalid choice errors", func(t *testing.T) {
+		s := setupSkillTest(t)
+		s.config.StderrIsTTY = true
+		s.mockStdin = bytes.NewBufferString("nope\n")
+		s.config.Stdin = s.mockStdin
+
+		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+
+		var err error
+		s.service, err = cli.NewService(s.config)
+		require.NoError(t, err)
+
+		_, err = s.service.SkillInstall(false, "")
+		require.Error(t, err)
+	})
 }

--- a/internal/skill/detector.go
+++ b/internal/skill/detector.go
@@ -44,28 +44,28 @@ func Detect() (*DetectResult, error) {
 
 	var installations []Installation
 
-	// Check global agents installation
-	globalPath := filepath.Join(homeDir, ".agents", "skills", "rwx", "SKILL.md")
-	globalInst, err := checkSkillFile("global", "agents", globalPath)
+	// Check user-level agents installation
+	userPath := filepath.Join(homeDir, ".agents", "skills", "rwx", "SKILL.md")
+	userInst, err := checkSkillFile("user", "agents", userPath)
 	if err != nil {
 		return nil, err
 	}
-	installations = append(installations, globalInst)
+	installations = append(installations, userInst)
 
-	// Check project agents installation (walk cwd up), skipping if it resolves
-	// to the same file as the global installation.
+	// Check repo-level agents installation (walk cwd up), skipping if it resolves
+	// to the same file as the user-level installation.
 	skillSubdir := filepath.Join(".agents", "skills", "rwx", "SKILL.md")
-	if projectPath := findFileWalkingUp(cwd, skillSubdir); projectPath != "" {
+	if repoPath := findFileWalkingUp(cwd, skillSubdir); repoPath != "" {
 		skip := false
-		if globalInst.Detected {
-			globalReal, err1 := filepath.EvalSymlinks(globalPath)
-			projectReal, err2 := filepath.EvalSymlinks(projectPath)
-			if err1 == nil && err2 == nil && globalReal == projectReal {
+		if userInst.Detected {
+			userReal, err1 := filepath.EvalSymlinks(userPath)
+			repoReal, err2 := filepath.EvalSymlinks(repoPath)
+			if err1 == nil && err2 == nil && userReal == repoReal {
 				skip = true
 			}
 		}
 		if !skip {
-			inst, err := checkSkillFile("project", "agents", projectPath)
+			inst, err := checkSkillFile("repo", "agents", repoPath)
 			if err != nil {
 				return nil, err
 			}
@@ -75,7 +75,7 @@ func Detect() (*DetectResult, error) {
 
 	// Check Claude Code marketplace installation
 	marketplacePath := filepath.Join(homeDir, ".claude", "plugins", "marketplaces", "rwx", "plugins", "rwx", "skills", "rwx", "SKILL.md")
-	marketplaceInst, err := checkSkillFile("global", "marketplace", marketplacePath)
+	marketplaceInst, err := checkSkillFile("user", "marketplace", marketplacePath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/skill/detector_test.go
+++ b/internal/skill/detector_test.go
@@ -90,7 +90,7 @@ func TestDetect(t *testing.T) {
 		require.False(t, result.AnyFound)
 	})
 
-	t.Run("agents global only", func(t *testing.T) {
+	t.Run("agents user only", func(t *testing.T) {
 		tmp := t.TempDir()
 		t.Setenv("HOME", tmp)
 		t.Chdir(tmp)
@@ -109,12 +109,12 @@ func TestDetect(t *testing.T) {
 			}
 		}
 		require.NotNil(t, found)
-		require.Equal(t, "global", found.Scope)
+		require.Equal(t, "user", found.Scope)
 		require.Equal(t, "agents", found.Source)
 		require.Equal(t, "1.0.0", found.Version)
 	})
 
-	t.Run("agents project only", func(t *testing.T) {
+	t.Run("agents repo only", func(t *testing.T) {
 		tmp := t.TempDir()
 		t.Setenv("HOME", tmp)
 
@@ -136,7 +136,7 @@ func TestDetect(t *testing.T) {
 			}
 		}
 		require.NotNil(t, found)
-		require.Equal(t, "project", found.Scope)
+		require.Equal(t, "repo", found.Scope)
 		require.Equal(t, "agents", found.Source)
 		require.Equal(t, "2.0.0", found.Version)
 	})
@@ -160,7 +160,7 @@ func TestDetect(t *testing.T) {
 			}
 		}
 		require.NotNil(t, found)
-		require.Equal(t, "global", found.Scope)
+		require.Equal(t, "user", found.Scope)
 		require.Equal(t, "marketplace", found.Source)
 		require.Equal(t, "0.1.3", found.Version)
 	})


### PR DESCRIPTION
### Background

- Linear: [RWX-873](https://linear.app/rwx-cloud/issue/RWX-873/add-repo-vs-local-choice-to-skill-install)
- Slack thread: https://rwxhq.slack.com/archives/C044VB13K6G/p1778862892326169

### Problem

`rwx skill install` currently only knows how to install at the repo level (`.agents/skills/rwx/SKILL.md`). Users who want a machine-wide install are SOL, even though `npx skills` already ships a wizard that targets a dozen different coding agents. We also use inconsistent terminology — `global` / `project level` — across `rwx skill *` copy.

### Solution

- Add an interactive prompt to `rwx skill install` that asks **repo vs user** before any other prompts. Default is repo (the recommended path for sharing skills with the team).
- If the user picks **repo**, the existing flow runs (replace check + `.claude/skills` symlink prompt).
- If the user picks **user**, print a handoff to `npx skills add rwx-cloud/skills` with a link to https://www.rwx.com/docs/ai and exit without installing — we don't reinvent the skills CLI for user-level installs in this iteration.
- With `-y/--yes`: install to repo *and* always print the `npx skills` handoff. No scope flag in this iteration (the spec defers that to `npx skills`).
- Rename `Scope` values: `global` → `user`, `project` → `repo`. Applies to user-facing `skill status` output **and** the `--output json` payload.
- Update `Install at the project level anyway?` → `Install at the repo level anyway?`, and the `skill install` `Short` description to reflect the new prompt.

#### Example CLI copy

Help text:

```
$ rwx skill install --help
Install the RWX agent skill (prompts repo vs user; repo writes to .agents/skills/rwx/SKILL.md, user defers to `npx skills`)

Usage:
  rwx skill install [flags]

Flags:
  -h, --help             help for install
      --symlink string   force a .claude/skills symlink even if .claude doesn't exist yet (use "claude")
  -y, --yes              skip confirmation prompt
```

Interactive location prompt (TTY, no `-y`):

```
$ rwx skill install
Where would you like to install the RWX skill?
1 - repo (recommended, best practice is to commit skills to share with your team)
2 - user (installs the skill on this machine, available across projects)
Choose [1]:
```

User-level handoff (printed when the user picks `2`, or unconditionally with `-y`):

```
To install the RWX skill at the user level, use the `skills` CLI:

  npx skills add rwx-cloud/skills

For more details, see https://www.rwx.com/docs/ai
```

Renamed destruction prompt (when a repo-level install already exists):

```
An existing repo installation was found at /path/.agents/skills/rwx/SKILL.md
Install at the repo level anyway? [y/N]:
```

#### Caveats

- **JSON breaking change**: `rwx skill status --output json` now emits `"Scope": "user"` / `"Scope": "repo"` instead of `"global"` / `"project"`. Confirmed there are no internal consumers; flagging here in case any external automation parses these literals.
- Non-TTY without `-y` (e.g. piped stdin in a script): skips the location prompt and installs to repo silently. This matches prior behavior for scripted setups.

#### Further confirmation needed

Unit + integration tests cover the non-interactive surface. The items below require a real terminal:

- [x] Interactive prompt renders cleanly above the existing symlink prompt; Enter, `1`, `repo` all install to repo; `2` and `user` print the handoff and exit without writing.
- [x] Typing garbage at the prompt errors out with a clear message; Ctrl-C aborts cleanly with no half-written `.agents/`.
- [x] Picking `1` over a pre-existing repo install fires the renamed `An existing repo installation was found …` notice and the `Install at the repo level anyway?` prompt.
- [x] `mkdir .claude && rwx skill install` → picking `1` installs to `.claude/skills/rwx/SKILL.md` (preserves the `.claude`-only branch).
- [x] `npx skills add rwx-cloud/skills` actually works and https://www.rwx.com/docs/ai is a useful landing page for someone trying to install at the user level.
- [x] `rwx skill install -y | tee out.log` — prompts/handoff stay on stderr, install line lands in `out.log`.
- [x] `rwx skill status` column alignment still reads well now that scope labels are 4 chars (was up to 7).