### PR TITLE
Throttle concurrent `rwx results` calls

### DIFF
--- a/cmd/rwx/results.go
+++ b/cmd/rwx/results.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"github.com/rwx-cloud/rwx/internal/cli"
 	"github.com/rwx-cloud/rwx/internal/errors"
 	"github.com/rwx-cloud/rwx/internal/git"
+	"github.com/rwx-cloud/rwx/internal/throttle"
 
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
@@ -35,6 +37,9 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			useJson := useJsonOutput()
 			taskKeySet := cmd.Flags().Changed("task")
+
+			slot := acquireResultsSlot(cmd.Context())
+			defer slot.Release()
 
 			var runID string
 			runIDFromGit := false
@@ -171,6 +176,43 @@ func handleResultsTaskKeyError(err error) error {
 	}
 
 	return err
+}
+
+// acquireResultsSlot gates concurrent `rwx results` invocations so the API
+// isn't hammered when many short-lived CLI processes (typically from coding
+// agents or scripts) run in parallel. Always returns — failures and timeouts
+// fall through unthrottled so the user's command is never blocked by the
+// throttle itself. The returned Slot is always safe to defer Release on.
+func acquireResultsSlot(ctx context.Context) *throttle.Slot {
+	cfg := throttle.Config{MaxConcurrency: throttle.MaxConcurrencyFromEnv()}
+	maxInUse := cfg.MaxConcurrency
+	if maxInUse <= 0 {
+		maxInUse = throttle.DefaultMaxConcurrency
+	}
+
+	result, err := throttle.Acquire(ctx, "results", cfg)
+	if err != nil {
+		if telemetryCollector != nil {
+			telemetryCollector.Record("cli.results.throttled", map[string]any{
+				"acquired":   false,
+				"wait_ms":    result.WaitDuration.Milliseconds(),
+				"error":      err.Error(),
+				"max_in_use": maxInUse,
+			})
+		}
+		return nil
+	}
+
+	if telemetryCollector != nil && (result.Waited || result.TimedOut) {
+		telemetryCollector.Record("cli.results.throttled", map[string]any{
+			"acquired":   result.Slot != nil,
+			"timed_out":  result.TimedOut,
+			"wait_ms":    result.WaitDuration.Milliseconds(),
+			"max_in_use": maxInUse,
+		})
+	}
+
+	return result.Slot
 }
 
 func HandleAmbiguousDefinitionPathError(err error, branch, repo string) error {

--- a/internal/throttle/throttle.go
+++ b/internal/throttle/throttle.go
@@ -1,0 +1,168 @@
+// Package throttle provides a cross-process semaphore that caps how many `rwx`
+// invocations can hold a given resource at once. It is intended to apply
+// natural backpressure when many short-lived CLI processes are spawned in
+// parallel (typically by coding agents or scripts) and would otherwise hammer
+// the RWX API.
+package throttle
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gofrs/flock"
+	"github.com/rwx-cloud/rwx/internal/errors"
+)
+
+const (
+	DefaultMaxConcurrency = 4
+	DefaultWaitTimeout    = 5 * time.Minute
+	pollInterval          = 100 * time.Millisecond
+)
+
+// Slot is an acquired throttle slot. Call Release when the throttled work is
+// done. The OS releases the underlying file lock on process exit, so a missed
+// Release does not strand a slot indefinitely.
+type Slot struct {
+	lock *flock.Flock
+}
+
+// Release frees the slot. Safe to call on a nil Slot.
+func (s *Slot) Release() {
+	if s == nil || s.lock == nil {
+		return
+	}
+	_ = s.lock.Unlock()
+}
+
+// Config controls Acquire's behavior. Zero values use sensible defaults.
+type Config struct {
+	// LockDir is the directory holding the slot files. Defaults to
+	// ~/.config/rwx/locks.
+	LockDir string
+	// MaxConcurrency is the number of slots. Defaults to DefaultMaxConcurrency.
+	MaxConcurrency int
+	// WaitTimeout caps how long Acquire blocks. Defaults to DefaultWaitTimeout.
+	// On timeout, Acquire returns a nil Slot and TimedOut=true so the caller can
+	// proceed unthrottled rather than failing the user's command.
+	WaitTimeout time.Duration
+	// Stderr receives the "waiting for slot…" message. Defaults to os.Stderr.
+	Stderr io.Writer
+}
+
+// Result describes the outcome of an Acquire call.
+type Result struct {
+	// Slot is the acquired slot, or nil if the caller should proceed unthrottled
+	// (TimedOut).
+	Slot *Slot
+	// WaitDuration is how long Acquire blocked before returning.
+	WaitDuration time.Duration
+	// Waited is true if Acquire had to block (vs. acquiring on the first try).
+	Waited bool
+	// TimedOut is true if Acquire gave up because WaitTimeout elapsed.
+	TimedOut bool
+}
+
+// MaxConcurrencyFromEnv reads RWX_RESULTS_MAX_CONCURRENCY. Returns 0 if unset
+// or invalid; callers should fall back to DefaultMaxConcurrency.
+func MaxConcurrencyFromEnv() int {
+	raw := strings.TrimSpace(os.Getenv("RWX_RESULTS_MAX_CONCURRENCY"))
+	if raw == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return 0
+	}
+	return n
+}
+
+// DefaultLockDir is ~/.config/rwx/locks.
+func DefaultLockDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.Wrap(err, "unable to resolve home directory")
+	}
+	return filepath.Join(home, ".config", "rwx", "locks"), nil
+}
+
+// Acquire blocks until a slot is acquired, the wait times out, or ctx is
+// cancelled. `prefix` names the resource being throttled (e.g. "results") and
+// becomes the slot-file prefix on disk.
+//
+// On timeout, Result.Slot is nil and Result.TimedOut is true so the caller can
+// proceed unthrottled — a stalled throttle should never block real work.
+func Acquire(ctx context.Context, prefix string, cfg Config) (Result, error) {
+	if cfg.MaxConcurrency <= 0 {
+		cfg.MaxConcurrency = DefaultMaxConcurrency
+	}
+	if cfg.WaitTimeout <= 0 {
+		cfg.WaitTimeout = DefaultWaitTimeout
+	}
+	if cfg.Stderr == nil {
+		cfg.Stderr = os.Stderr
+	}
+	if cfg.LockDir == "" {
+		dir, err := DefaultLockDir()
+		if err != nil {
+			return Result{}, err
+		}
+		cfg.LockDir = dir
+	}
+
+	if err := os.MkdirAll(cfg.LockDir, 0o755); err != nil {
+		return Result{}, errors.Wrapf(err, "unable to create lock directory %q", cfg.LockDir)
+	}
+
+	locks := make([]*flock.Flock, cfg.MaxConcurrency)
+	for i := range locks {
+		path := filepath.Join(cfg.LockDir, fmt.Sprintf("%s-%d.lock", prefix, i))
+		locks[i] = flock.New(path)
+	}
+
+	start := time.Now()
+
+	if slot := tryAcquireAny(locks); slot != nil {
+		return Result{Slot: slot}, nil
+	}
+
+	fmt.Fprintf(cfg.Stderr,
+		"Waiting for an `rwx %s` slot (concurrency limit: %d). "+
+			"Set RWX_RESULTS_MAX_CONCURRENCY to raise the cap.\n",
+		prefix, cfg.MaxConcurrency)
+
+	deadline := start.Add(cfg.WaitTimeout)
+	for {
+		if slot := tryAcquireAny(locks); slot != nil {
+			return Result{Slot: slot, WaitDuration: time.Since(start), Waited: true}, nil
+		}
+
+		if time.Now().After(deadline) {
+			fmt.Fprintf(cfg.Stderr,
+				"Gave up waiting for an `rwx %s` slot after %s; proceeding without throttle.\n",
+				prefix, cfg.WaitTimeout)
+			return Result{WaitDuration: time.Since(start), Waited: true, TimedOut: true}, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return Result{WaitDuration: time.Since(start), Waited: true}, ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+func tryAcquireAny(locks []*flock.Flock) *Slot {
+	for _, lock := range locks {
+		locked, err := lock.TryLock()
+		if err == nil && locked {
+			return &Slot{lock: lock}
+		}
+	}
+	return nil
+}

--- a/internal/throttle/throttle_test.go
+++ b/internal/throttle/throttle_test.go
@@ -1,0 +1,163 @@
+package throttle
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxConcurrencyFromEnv(t *testing.T) {
+	t.Run("returns 0 when unset so caller can default", func(t *testing.T) {
+		t.Setenv("RWX_RESULTS_MAX_CONCURRENCY", "")
+		require.Equal(t, 0, MaxConcurrencyFromEnv())
+	})
+
+	t.Run("parses a valid integer", func(t *testing.T) {
+		t.Setenv("RWX_RESULTS_MAX_CONCURRENCY", "7")
+		require.Equal(t, 7, MaxConcurrencyFromEnv())
+	})
+
+	t.Run("rejects non-integer", func(t *testing.T) {
+		t.Setenv("RWX_RESULTS_MAX_CONCURRENCY", "abc")
+		require.Equal(t, 0, MaxConcurrencyFromEnv())
+	})
+
+	t.Run("rejects zero and negatives", func(t *testing.T) {
+		t.Setenv("RWX_RESULTS_MAX_CONCURRENCY", "0")
+		require.Equal(t, 0, MaxConcurrencyFromEnv())
+		t.Setenv("RWX_RESULTS_MAX_CONCURRENCY", "-1")
+		require.Equal(t, 0, MaxConcurrencyFromEnv())
+	})
+}
+
+func TestAcquire_FirstSlotIsFree(t *testing.T) {
+	cfg := Config{LockDir: t.TempDir(), MaxConcurrency: 2, Stderr: &bytes.Buffer{}}
+
+	result, err := Acquire(context.Background(), "test", cfg)
+	require.NoError(t, err)
+	require.NotNil(t, result.Slot)
+	require.False(t, result.Waited)
+	require.False(t, result.TimedOut)
+	result.Slot.Release()
+}
+
+func TestAcquire_WaitsForSlotToFree(t *testing.T) {
+	cfg := Config{LockDir: t.TempDir(), MaxConcurrency: 1, Stderr: &bytes.Buffer{}}
+
+	first, err := Acquire(context.Background(), "test", cfg)
+	require.NoError(t, err)
+	require.NotNil(t, first.Slot)
+
+	releaseAfter := 150 * time.Millisecond
+	go func() {
+		time.Sleep(releaseAfter)
+		first.Slot.Release()
+	}()
+
+	second, err := Acquire(context.Background(), "test", cfg)
+	require.NoError(t, err)
+	require.NotNil(t, second.Slot)
+	require.True(t, second.Waited)
+	require.False(t, second.TimedOut)
+	require.GreaterOrEqual(t, second.WaitDuration, releaseAfter)
+	second.Slot.Release()
+}
+
+func TestAcquire_TimesOutWhenAllSlotsHeld(t *testing.T) {
+	cfg := Config{
+		LockDir:        t.TempDir(),
+		MaxConcurrency: 1,
+		WaitTimeout:    150 * time.Millisecond,
+		Stderr:         &bytes.Buffer{},
+	}
+
+	first, err := Acquire(context.Background(), "test", cfg)
+	require.NoError(t, err)
+	defer first.Slot.Release()
+
+	start := time.Now()
+	second, err := Acquire(context.Background(), "test", cfg)
+	require.NoError(t, err)
+	require.Nil(t, second.Slot)
+	require.True(t, second.TimedOut)
+	require.True(t, second.Waited)
+	require.GreaterOrEqual(t, time.Since(start), cfg.WaitTimeout)
+}
+
+func TestAcquire_RespectsContextCancellation(t *testing.T) {
+	cfg := Config{LockDir: t.TempDir(), MaxConcurrency: 1, Stderr: &bytes.Buffer{}}
+
+	first, err := Acquire(context.Background(), "test", cfg)
+	require.NoError(t, err)
+	defer first.Slot.Release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err = Acquire(ctx, "test", cfg)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestAcquire_EmitsWaitAndTimeoutMessages(t *testing.T) {
+	var stderr bytes.Buffer
+	cfg := Config{
+		LockDir:        t.TempDir(),
+		MaxConcurrency: 1,
+		WaitTimeout:    150 * time.Millisecond,
+		Stderr:         &stderr,
+	}
+
+	first, err := Acquire(context.Background(), "test", cfg)
+	require.NoError(t, err)
+	defer first.Slot.Release()
+
+	_, err = Acquire(context.Background(), "test", cfg)
+	require.NoError(t, err)
+	require.Contains(t, stderr.String(), "Waiting for an `rwx test` slot")
+	require.Contains(t, stderr.String(), "Gave up waiting")
+}
+
+func TestAcquire_ConcurrentRequestsRespectCap(t *testing.T) {
+	cfg := Config{LockDir: t.TempDir(), MaxConcurrency: 2, Stderr: &bytes.Buffer{}}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var holdersAtPeak int
+	current := 0
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result, err := Acquire(context.Background(), "test", cfg)
+			require.NoError(t, err)
+			require.NotNil(t, result.Slot)
+
+			mu.Lock()
+			current++
+			if current > holdersAtPeak {
+				holdersAtPeak = current
+			}
+			mu.Unlock()
+
+			time.Sleep(50 * time.Millisecond)
+
+			mu.Lock()
+			current--
+			mu.Unlock()
+
+			result.Slot.Release()
+		}()
+	}
+
+	wg.Wait()
+	require.LessOrEqual(t, holdersAtPeak, cfg.MaxConcurrency,
+		"more slots were held simultaneously than the configured cap")
+}


### PR DESCRIPTION
### Background

[RWX-876](https://linear.app/rwx-cloud/issue/RWX-876/throttle-concurrent-rwx-results-calls-from-coding-agents)

### Problem

When a coding agent (Claude Code, Cursor, etc.) drives the `rwx` CLI, it can spawn many `rwx results` invocations in parallel. Each is a separate short-lived process, so there's no in-process semaphore to coordinate them, and the API gets hammered.

### Solution

- New `internal/throttle` package implementing a cross-process semaphore on top of `github.com/gofrs/flock`. N slot files live under `~/.config/rwx/locks/results-{0..N-1}.lock`; each invocation tries each slot non-blocking, then polls until one frees, with a stderr "Waiting for an `rwx results` slot…" message and a 5 minute wait cap.
- Wired into `resultsCmd.RunE` (cmd/rwx/results.go:41-42). Slot is released on process exit; the OS releases the underlying flock if a process crashes, so slots can never be stranded.
- **No agent detection** — applies uniformly. A single interactive invocation acquires the first slot immediately with no wait and no observable behavior change. Parallel callers (human or agent) all get backpressure.
- Default cap of 4; override via `RWX_RESULTS_MAX_CONCURRENCY`.
- On wait-timeout or any internal error, the throttle proceeds unthrottled rather than failing the user's command — a stalled throttle should never block real work.
- Emits `cli.results.throttled` telemetry with `wait_ms`, `acquired`, `timed_out`, and `max_in_use`.

#### Further confirmation needed

- [ ] Confirm flock behavior on Windows in practice (gofrs/flock supports it via `LockFileEx`, but I don't have a Windows host to smoke-test on).
- [ ] Confirm the default cap of 4 is appropriate by watching `cli.results.throttled` telemetry once this lands.
- [ ] Decide whether to extend the same throttle to `rwx logs` / `rwx runs` (deferred per issue scoping).