### PR TITLE
Fix logs and artifacts output dirs

### DIFF
--- a/.rwx/integration/artifacts-test.yml
+++ b/.rwx/integration/artifacts-test.yml
@@ -122,9 +122,14 @@ tasks:
 
       echo "$RUN_URL" > "$RWX_LINKS/Run URL"
 
-      rwx artifacts download "$RUN_ID" --task artifact-producer test-file --output-file /tmp/artifacts-single-file.txt
-      if [ ! -f /tmp/artifacts-single-file.txt ]; then
+      rwx artifacts download "$RUN_ID" --task artifact-producer test-dir --output-file /tmp/artifacts-raw-dir.tar
+      if [ ! -f /tmp/artifacts-raw-dir.tar ]; then
         echo "Artifact not downloaded to --output-file path"
+        exit 1
+      fi
+      if ! tar -tf /tmp/artifacts-raw-dir.tar | grep -q "nested-file.txt"; then
+        echo "Raw artifact tar does not contain expected nested file"
+        tar -tf /tmp/artifacts-raw-dir.tar || true
         exit 1
       fi
     env:

--- a/.rwx/integration/artifacts-test.yml
+++ b/.rwx/integration/artifacts-test.yml
@@ -97,6 +97,31 @@ tasks:
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
       RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
 
+  - key: test-download-single-artifact-default-output
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      echo "$RUN_URL" > "$RWX_LINKS/Run URL"
+
+      download_output=$(rwx --output json artifacts download "$RUN_ID" --task artifact-producer test-file)
+      downloaded_file=$(echo "$download_output" | jq -r '.OutputFiles[0]')
+      if [ -z "$downloaded_file" ] || [ "$downloaded_file" = "null" ] || [ ! -f "$downloaded_file" ]; then
+        echo "test-file artifact not downloaded with default output destination"
+        echo "$download_output"
+        exit 1
+      fi
+      if ! grep -q "integration-test-content" "$downloaded_file"; then
+        echo "Downloaded test-file does not contain expected content"
+        echo "$download_output"
+        cat "$downloaded_file" || true
+        exit 1
+      fi
+    env:
+      RUN_ID: ${{ tasks.rwx-run.values.run-id }}
+      RUN_URL: ${{ tasks.rwx-run.values.run-url }}
+      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+
   - key: test-download-all-artifacts
     use: rwx-cli
     run: |
@@ -108,6 +133,31 @@ tasks:
       if [ ! -d /tmp/artifacts-all ] || [ "$(ls /tmp/artifacts-all | wc -l)" -lt 2 ]; then
         echo "Expected at least 2 artifacts downloaded"
         ls -la /tmp/artifacts-all/ || true
+        exit 1
+      fi
+    env:
+      RUN_ID: ${{ tasks.rwx-run.values.run-id }}
+      RUN_URL: ${{ tasks.rwx-run.values.run-url }}
+      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+
+  - key: test-download-directory-artifact-default-output
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      echo "$RUN_URL" > "$RWX_LINKS/Run URL"
+
+      download_output=$(rwx --output json artifacts download "$RUN_ID" --task artifact-producer test-dir)
+      downloaded_tar=$(echo "$download_output" | jq -r '.OutputFiles[0]')
+      if [ -z "$downloaded_tar" ] || [ "$downloaded_tar" = "null" ] || [ ! -f "$downloaded_tar" ]; then
+        echo "test-dir raw artifact not downloaded with default output destination"
+        echo "$download_output"
+        exit 1
+      fi
+      if ! tar -tf "$downloaded_tar" | grep -q "nested-file.txt"; then
+        echo "Default raw artifact tar does not contain expected nested file"
+        echo "$download_output"
+        tar -tf "$downloaded_tar" || true
         exit 1
       fi
     env:

--- a/.rwx/integration/logs-test.yml
+++ b/.rwx/integration/logs-test.yml
@@ -73,6 +73,30 @@ tasks:
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
       RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
 
+  - key: test-download-and-extract-logs-default-output
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      echo "$RUN_URL" > "$RWX_LINKS/Run URL"
+
+      download_output=$(rwx --output json logs "$RUN_ID" --task log-producer)
+      first_file=$(echo "$download_output" | jq -r '.OutputFiles[0]')
+      if [ -z "$first_file" ] || [ "$first_file" = "null" ] || [ ! -f "$first_file" ]; then
+        echo "No log files extracted with default output destination"
+        echo "$download_output"
+        exit 1
+      fi
+      if ! echo "$download_output" | jq -r '.OutputFiles[]' | xargs grep -q "integration-test-log-marker"; then
+        echo "Log marker not found in default extracted logs"
+        echo "$download_output"
+        exit 1
+      fi
+    env:
+      RUN_ID: ${{ tasks.rwx-run.values.run-id }}
+      RUN_URL: ${{ tasks.rwx-run.values.run-url }}
+      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+
   - key: test-download-logs-as-zip
     use: rwx-cli
     run: |

--- a/cmd/rwx/artifacts/download.go
+++ b/cmd/rwx/artifacts/download.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	downloadOutputDir   string
+	downloadOutputFile  string
 	downloadAutoExtract bool
 	downloadOpen        bool
 	downloadAll         bool
@@ -63,14 +64,22 @@ func InitDownload(requireAccessToken func() error, getService func() cli.Service
 			svc := getService()
 
 			outputDirSet := cmd.Flags().Changed("output-dir")
+			outputFileSet := cmd.Flags().Changed("output-file")
+			if outputDirSet && outputFileSet {
+				return errors.New("output-dir and output-file cannot be used together")
+			}
 
 			if taskKeySet {
-				return runDownloadWithTaskKey(svc, args, outputDirSet, useJsonOutput())
+				return runDownloadWithTaskKey(svc, args, outputDirSet, outputFileSet, useJsonOutput())
 			}
 
 			taskID := args[0]
 
 			if downloadAll {
+				if outputFileSet {
+					return errors.New("--output-file cannot be used with --all")
+				}
+
 				absOutputDir, err := resolveDownloadOutputDir(outputDirSet)
 				if err != nil {
 					return err
@@ -90,7 +99,7 @@ func InitDownload(requireAccessToken func() error, getService func() cli.Service
 
 			artifactKey := args[1]
 
-			absOutputDir, err := resolveDownloadOutputDir(outputDirSet)
+			absOutputDir, absOutputFile, err := resolveDownloadOutputDestination(outputDirSet, outputFileSet)
 			if err != nil {
 				return err
 			}
@@ -100,6 +109,7 @@ func InitDownload(requireAccessToken func() error, getService func() cli.Service
 				TaskID:                 taskID,
 				ArtifactKey:            artifactKey,
 				OutputDir:              absOutputDir,
+				OutputFile:             absOutputFile,
 				OutputDirExplicitlySet: outputDirSet,
 				Json:                   useJson,
 				AutoExtract:            downloadAutoExtract,
@@ -112,18 +122,23 @@ func InitDownload(requireAccessToken func() error, getService func() cli.Service
 	}
 
 	DownloadCmd.Flags().StringVar(&downloadOutputDir, "output-dir", "", "output directory for downloaded artifacts (defaults to .rwx/downloads folder)")
+	DownloadCmd.Flags().StringVar(&downloadOutputFile, "output-file", "", "output file path for the downloaded tar archive; only valid when not extracting")
 	DownloadCmd.Flags().BoolVar(&downloadAutoExtract, "auto-extract", false, "automatically extract directory tar archives")
 	DownloadCmd.Flags().BoolVar(&downloadOpen, "open", false, "automatically open the downloaded file(s)")
 	DownloadCmd.Flags().BoolVar(&downloadAll, "all", false, "download all artifacts for the task")
 	DownloadCmd.Flags().StringVar(&downloadTaskKey, "task", "", "task key (e.g., ci.checks.lint); resolves the task by key instead of ID")
 }
 
-func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirSet bool, useJson bool) error {
+func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirSet, outputFileSet bool, useJson bool) error {
 	var runID string
 	var artifactKey string
 	var err error
 
 	if downloadAll {
+		if outputFileSet {
+			return errors.New("--output-file cannot be used with --all")
+		}
+
 		if len(args) > 0 {
 			runID = args[0]
 		} else {
@@ -165,7 +180,7 @@ func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirSet bool, u
 		}
 	}
 
-	absOutputDir, err := resolveDownloadOutputDir(outputDirSet)
+	absOutputDir, absOutputFile, err := resolveDownloadOutputDestination(outputDirSet, outputFileSet)
 	if err != nil {
 		return err
 	}
@@ -175,6 +190,7 @@ func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirSet bool, u
 		TaskKey:                downloadTaskKey,
 		ArtifactKey:            artifactKey,
 		OutputDir:              absOutputDir,
+		OutputFile:             absOutputFile,
 		OutputDirExplicitlySet: outputDirSet,
 		Json:                   useJson,
 		AutoExtract:            downloadAutoExtract,
@@ -184,6 +200,22 @@ func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirSet bool, u
 		return handleTaskKeyError(err)
 	}
 	return nil
+}
+
+func resolveDownloadOutputDestination(outputDirSet, outputFileSet bool) (string, string, error) {
+	if outputFileSet {
+		absOutputFile, err := filepath.Abs(downloadOutputFile)
+		if err != nil {
+			return "", "", errors.Wrapf(err, "unable to resolve absolute path for %s", downloadOutputFile)
+		}
+		return "", absOutputFile, nil
+	}
+
+	absOutputDir, err := resolveDownloadOutputDir(outputDirSet)
+	if err != nil {
+		return "", "", err
+	}
+	return absOutputDir, "", nil
 }
 
 func resolveDownloadOutputDir(explicitlySet bool) (string, error) {

--- a/cmd/rwx/artifacts/download.go
+++ b/cmd/rwx/artifacts/download.go
@@ -12,12 +12,11 @@ import (
 )
 
 var (
-	downloadOutputDir   string
-	downloadOutputFile  string
-	downloadAutoExtract bool
-	downloadOpen        bool
-	downloadAll         bool
-	downloadTaskKey     string
+	downloadOutputDirectory string
+	downloadAutoExtract     bool
+	downloadOpen            bool
+	downloadAll             bool
+	downloadTaskKey         string
 
 	DownloadCmd *cobra.Command
 )
@@ -63,40 +62,28 @@ func InitDownload(requireAccessToken func() error, getService func() cli.Service
 			taskKeySet := cmd.Flags().Changed("task")
 			svc := getService()
 
-			outputDirSet := cmd.Flags().Changed("output-dir")
-			outputFileSet := cmd.Flags().Changed("output-file")
+			outputDirectoryExplicitlySet, err := downloadOutputDirectoryExplicitlySet(cmd)
+			if err != nil {
+				return err
+			}
 
 			if taskKeySet {
-				return runDownloadWithTaskKey(svc, args, outputDirSet, outputFileSet, useJsonOutput())
+				return runDownloadWithTaskKey(svc, args, outputDirectoryExplicitlySet, useJsonOutput())
 			}
 
 			taskID := args[0]
 
 			if downloadAll {
-				if outputFileSet {
-					return errors.New("--output-file cannot be used with --all")
-				}
-
-				var absOutputDir string
-				var err error
-
-				outputDir := downloadOutputDir
-				if !outputDirSet {
-					outputDir, err = cli.FindDefaultDownloadsDir()
-					if err != nil {
-						return errors.Wrap(err, "unable to determine default downloads directory")
-					}
-				}
-				absOutputDir, err = filepath.Abs(outputDir)
+				absOutputDirectory, err := resolveDownloadOutputDirectory(outputDirectoryExplicitlySet)
 				if err != nil {
-					return errors.Wrapf(err, "unable to resolve absolute path for %s", outputDir)
+					return err
 				}
 
 				useJson := useJsonOutput()
 				_, err = svc.DownloadAllArtifacts(cli.DownloadAllArtifactsConfig{
 					TaskID:                 taskID,
-					OutputDir:              absOutputDir,
-					OutputDirExplicitlySet: outputDirSet,
+					OutputDir:              absOutputDirectory,
+					OutputDirExplicitlySet: outputDirectoryExplicitlySet,
 					Json:                   useJson,
 					AutoExtract:            downloadAutoExtract,
 					Open:                   downloadOpen,
@@ -106,40 +93,17 @@ func InitDownload(requireAccessToken func() error, getService func() cli.Service
 
 			artifactKey := args[1]
 
-			if outputDirSet && outputFileSet {
-				return errors.New("output-dir and output-file cannot be used together")
-			}
-
-			var absOutputDir string
-			var absOutputFile string
-			var err error
-
-			if downloadOutputFile != "" {
-				absOutputFile, err = filepath.Abs(downloadOutputFile)
-				if err != nil {
-					return errors.Wrapf(err, "unable to resolve absolute path for %s", downloadOutputFile)
-				}
-			} else {
-				outputDir := downloadOutputDir
-				if !outputDirSet {
-					outputDir, err = cli.FindDefaultDownloadsDir()
-					if err != nil {
-						return errors.Wrap(err, "unable to determine default downloads directory")
-					}
-				}
-				absOutputDir, err = filepath.Abs(outputDir)
-				if err != nil {
-					return errors.Wrapf(err, "unable to resolve absolute path for %s", outputDir)
-				}
+			absOutputDirectory, err := resolveDownloadOutputDirectory(outputDirectoryExplicitlySet)
+			if err != nil {
+				return err
 			}
 
 			useJson := useJsonOutput()
 			_, err = svc.DownloadArtifact(cli.DownloadArtifactConfig{
 				TaskID:                 taskID,
 				ArtifactKey:            artifactKey,
-				OutputDir:              absOutputDir,
-				OutputFile:             absOutputFile,
-				OutputDirExplicitlySet: outputDirSet,
+				OutputDir:              absOutputDirectory,
+				OutputDirExplicitlySet: outputDirectoryExplicitlySet,
 				Json:                   useJson,
 				AutoExtract:            downloadAutoExtract,
 				Open:                   downloadOpen,
@@ -150,25 +114,23 @@ func InitDownload(requireAccessToken func() error, getService func() cli.Service
 		Use:   "download [task-id | run-id --task <key>] [artifact-key] [flags]",
 	}
 
-	DownloadCmd.Flags().StringVar(&downloadOutputDir, "output-dir", "", "output directory for the downloaded artifact (defaults to .rwx/downloads folder)")
-	DownloadCmd.Flags().StringVar(&downloadOutputFile, "output-file", "", "output file path for the downloaded artifact")
-	DownloadCmd.MarkFlagsMutuallyExclusive("output-dir", "output-file")
+	DownloadCmd.Flags().StringVar(&downloadOutputDirectory, "output-directory", "", "output directory for downloaded artifacts (defaults to .rwx/downloads folder)")
+	DownloadCmd.Flags().StringVar(&downloadOutputDirectory, "output-dir", "", "output directory for downloaded artifacts (defaults to .rwx/downloads folder)")
+	if err := DownloadCmd.Flags().MarkHidden("output-dir"); err != nil {
+		panic(err)
+	}
 	DownloadCmd.Flags().BoolVar(&downloadAutoExtract, "auto-extract", false, "automatically extract directory tar archives")
 	DownloadCmd.Flags().BoolVar(&downloadOpen, "open", false, "automatically open the downloaded file(s)")
 	DownloadCmd.Flags().BoolVar(&downloadAll, "all", false, "download all artifacts for the task")
 	DownloadCmd.Flags().StringVar(&downloadTaskKey, "task", "", "task key (e.g., ci.checks.lint); resolves the task by key instead of ID")
 }
 
-func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirSet, outputFileSet bool, useJson bool) error {
+func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirectoryExplicitlySet bool, useJson bool) error {
 	var runID string
 	var artifactKey string
 	var err error
 
 	if downloadAll {
-		if outputFileSet {
-			return errors.New("--output-file cannot be used with --all")
-		}
-
 		if len(args) > 0 {
 			runID = args[0]
 		} else {
@@ -178,24 +140,16 @@ func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirSet, output
 			}
 		}
 
-		var absOutputDir string
-		outputDir := downloadOutputDir
-		if !outputDirSet {
-			outputDir, err = cli.FindDefaultDownloadsDir()
-			if err != nil {
-				return errors.Wrap(err, "unable to determine default downloads directory")
-			}
-		}
-		absOutputDir, err = filepath.Abs(outputDir)
+		absOutputDirectory, err := resolveDownloadOutputDirectory(outputDirectoryExplicitlySet)
 		if err != nil {
-			return errors.Wrapf(err, "unable to resolve absolute path for %s", outputDir)
+			return err
 		}
 
 		_, err = svc.DownloadAllArtifacts(cli.DownloadAllArtifactsConfig{
 			RunID:                  runID,
 			TaskKey:                downloadTaskKey,
-			OutputDir:              absOutputDir,
-			OutputDirExplicitlySet: outputDirSet,
+			OutputDir:              absOutputDirectory,
+			OutputDirExplicitlySet: outputDirectoryExplicitlySet,
 			Json:                   useJson,
 			AutoExtract:            downloadAutoExtract,
 			Open:                   downloadOpen,
@@ -218,39 +172,17 @@ func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirSet, output
 		}
 	}
 
-	if outputDirSet && outputFileSet {
-		return errors.New("output-dir and output-file cannot be used together")
-	}
-
-	var absOutputDir string
-	var absOutputFile string
-
-	if downloadOutputFile != "" {
-		absOutputFile, err = filepath.Abs(downloadOutputFile)
-		if err != nil {
-			return errors.Wrapf(err, "unable to resolve absolute path for %s", downloadOutputFile)
-		}
-	} else {
-		outputDir := downloadOutputDir
-		if !outputDirSet {
-			outputDir, err = cli.FindDefaultDownloadsDir()
-			if err != nil {
-				return errors.Wrap(err, "unable to determine default downloads directory")
-			}
-		}
-		absOutputDir, err = filepath.Abs(outputDir)
-		if err != nil {
-			return errors.Wrapf(err, "unable to resolve absolute path for %s", outputDir)
-		}
+	absOutputDirectory, err := resolveDownloadOutputDirectory(outputDirectoryExplicitlySet)
+	if err != nil {
+		return err
 	}
 
 	_, err = svc.DownloadArtifact(cli.DownloadArtifactConfig{
 		RunID:                  runID,
 		TaskKey:                downloadTaskKey,
 		ArtifactKey:            artifactKey,
-		OutputDir:              absOutputDir,
-		OutputFile:             absOutputFile,
-		OutputDirExplicitlySet: outputDirSet,
+		OutputDir:              absOutputDirectory,
+		OutputDirExplicitlySet: outputDirectoryExplicitlySet,
 		Json:                   useJson,
 		AutoExtract:            downloadAutoExtract,
 		Open:                   downloadOpen,
@@ -259,6 +191,32 @@ func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirSet, output
 		return handleTaskKeyError(err)
 	}
 	return nil
+}
+
+func downloadOutputDirectoryExplicitlySet(cmd *cobra.Command) (bool, error) {
+	outputDirectorySet := cmd.Flags().Changed("output-directory")
+	outputDirAliasSet := cmd.Flags().Changed("output-dir")
+	if outputDirectorySet && outputDirAliasSet {
+		return false, errors.New("output-directory and output-dir cannot be used together")
+	}
+	return outputDirectorySet || outputDirAliasSet, nil
+}
+
+func resolveDownloadOutputDirectory(explicitlySet bool) (string, error) {
+	outputDirectory := downloadOutputDirectory
+	if !explicitlySet {
+		var err error
+		outputDirectory, err = cli.FindDefaultDownloadsDir()
+		if err != nil {
+			return "", errors.Wrap(err, "unable to determine default downloads directory")
+		}
+	}
+
+	absOutputDirectory, err := filepath.Abs(outputDirectory)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to resolve absolute path for %s", outputDirectory)
+	}
+	return absOutputDirectory, nil
 }
 
 // handleTaskKeyError formats task-key-specific errors for user display.

--- a/cmd/rwx/artifacts/download.go
+++ b/cmd/rwx/artifacts/download.go
@@ -12,11 +12,11 @@ import (
 )
 
 var (
-	downloadOutputDirectory string
-	downloadAutoExtract     bool
-	downloadOpen            bool
-	downloadAll             bool
-	downloadTaskKey         string
+	downloadOutputDir   string
+	downloadAutoExtract bool
+	downloadOpen        bool
+	downloadAll         bool
+	downloadTaskKey     string
 
 	DownloadCmd *cobra.Command
 )
@@ -62,19 +62,16 @@ func InitDownload(requireAccessToken func() error, getService func() cli.Service
 			taskKeySet := cmd.Flags().Changed("task")
 			svc := getService()
 
-			outputDirectoryExplicitlySet, err := downloadOutputDirectoryExplicitlySet(cmd)
-			if err != nil {
-				return err
-			}
+			outputDirSet := cmd.Flags().Changed("output-dir")
 
 			if taskKeySet {
-				return runDownloadWithTaskKey(svc, args, outputDirectoryExplicitlySet, useJsonOutput())
+				return runDownloadWithTaskKey(svc, args, outputDirSet, useJsonOutput())
 			}
 
 			taskID := args[0]
 
 			if downloadAll {
-				absOutputDirectory, err := resolveDownloadOutputDirectory(outputDirectoryExplicitlySet)
+				absOutputDir, err := resolveDownloadOutputDir(outputDirSet)
 				if err != nil {
 					return err
 				}
@@ -82,8 +79,8 @@ func InitDownload(requireAccessToken func() error, getService func() cli.Service
 				useJson := useJsonOutput()
 				_, err = svc.DownloadAllArtifacts(cli.DownloadAllArtifactsConfig{
 					TaskID:                 taskID,
-					OutputDir:              absOutputDirectory,
-					OutputDirExplicitlySet: outputDirectoryExplicitlySet,
+					OutputDir:              absOutputDir,
+					OutputDirExplicitlySet: outputDirSet,
 					Json:                   useJson,
 					AutoExtract:            downloadAutoExtract,
 					Open:                   downloadOpen,
@@ -93,7 +90,7 @@ func InitDownload(requireAccessToken func() error, getService func() cli.Service
 
 			artifactKey := args[1]
 
-			absOutputDirectory, err := resolveDownloadOutputDirectory(outputDirectoryExplicitlySet)
+			absOutputDir, err := resolveDownloadOutputDir(outputDirSet)
 			if err != nil {
 				return err
 			}
@@ -102,8 +99,8 @@ func InitDownload(requireAccessToken func() error, getService func() cli.Service
 			_, err = svc.DownloadArtifact(cli.DownloadArtifactConfig{
 				TaskID:                 taskID,
 				ArtifactKey:            artifactKey,
-				OutputDir:              absOutputDirectory,
-				OutputDirExplicitlySet: outputDirectoryExplicitlySet,
+				OutputDir:              absOutputDir,
+				OutputDirExplicitlySet: outputDirSet,
 				Json:                   useJson,
 				AutoExtract:            downloadAutoExtract,
 				Open:                   downloadOpen,
@@ -114,18 +111,14 @@ func InitDownload(requireAccessToken func() error, getService func() cli.Service
 		Use:   "download [task-id | run-id --task <key>] [artifact-key] [flags]",
 	}
 
-	DownloadCmd.Flags().StringVar(&downloadOutputDirectory, "output-directory", "", "output directory for downloaded artifacts (defaults to .rwx/downloads folder)")
-	DownloadCmd.Flags().StringVar(&downloadOutputDirectory, "output-dir", "", "output directory for downloaded artifacts (defaults to .rwx/downloads folder)")
-	if err := DownloadCmd.Flags().MarkHidden("output-dir"); err != nil {
-		panic(err)
-	}
+	DownloadCmd.Flags().StringVar(&downloadOutputDir, "output-dir", "", "output directory for downloaded artifacts (defaults to .rwx/downloads folder)")
 	DownloadCmd.Flags().BoolVar(&downloadAutoExtract, "auto-extract", false, "automatically extract directory tar archives")
 	DownloadCmd.Flags().BoolVar(&downloadOpen, "open", false, "automatically open the downloaded file(s)")
 	DownloadCmd.Flags().BoolVar(&downloadAll, "all", false, "download all artifacts for the task")
 	DownloadCmd.Flags().StringVar(&downloadTaskKey, "task", "", "task key (e.g., ci.checks.lint); resolves the task by key instead of ID")
 }
 
-func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirectoryExplicitlySet bool, useJson bool) error {
+func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirSet bool, useJson bool) error {
 	var runID string
 	var artifactKey string
 	var err error
@@ -140,7 +133,7 @@ func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirectoryExpli
 			}
 		}
 
-		absOutputDirectory, err := resolveDownloadOutputDirectory(outputDirectoryExplicitlySet)
+		absOutputDir, err := resolveDownloadOutputDir(outputDirSet)
 		if err != nil {
 			return err
 		}
@@ -148,8 +141,8 @@ func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirectoryExpli
 		_, err = svc.DownloadAllArtifacts(cli.DownloadAllArtifactsConfig{
 			RunID:                  runID,
 			TaskKey:                downloadTaskKey,
-			OutputDir:              absOutputDirectory,
-			OutputDirExplicitlySet: outputDirectoryExplicitlySet,
+			OutputDir:              absOutputDir,
+			OutputDirExplicitlySet: outputDirSet,
 			Json:                   useJson,
 			AutoExtract:            downloadAutoExtract,
 			Open:                   downloadOpen,
@@ -172,7 +165,7 @@ func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirectoryExpli
 		}
 	}
 
-	absOutputDirectory, err := resolveDownloadOutputDirectory(outputDirectoryExplicitlySet)
+	absOutputDir, err := resolveDownloadOutputDir(outputDirSet)
 	if err != nil {
 		return err
 	}
@@ -181,8 +174,8 @@ func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirectoryExpli
 		RunID:                  runID,
 		TaskKey:                downloadTaskKey,
 		ArtifactKey:            artifactKey,
-		OutputDir:              absOutputDirectory,
-		OutputDirExplicitlySet: outputDirectoryExplicitlySet,
+		OutputDir:              absOutputDir,
+		OutputDirExplicitlySet: outputDirSet,
 		Json:                   useJson,
 		AutoExtract:            downloadAutoExtract,
 		Open:                   downloadOpen,
@@ -193,30 +186,21 @@ func runDownloadWithTaskKey(svc cli.Service, args []string, outputDirectoryExpli
 	return nil
 }
 
-func downloadOutputDirectoryExplicitlySet(cmd *cobra.Command) (bool, error) {
-	outputDirectorySet := cmd.Flags().Changed("output-directory")
-	outputDirAliasSet := cmd.Flags().Changed("output-dir")
-	if outputDirectorySet && outputDirAliasSet {
-		return false, errors.New("output-directory and output-dir cannot be used together")
-	}
-	return outputDirectorySet || outputDirAliasSet, nil
-}
-
-func resolveDownloadOutputDirectory(explicitlySet bool) (string, error) {
-	outputDirectory := downloadOutputDirectory
+func resolveDownloadOutputDir(explicitlySet bool) (string, error) {
+	outputDir := downloadOutputDir
 	if !explicitlySet {
 		var err error
-		outputDirectory, err = cli.FindDefaultDownloadsDir()
+		outputDir, err = cli.FindDefaultDownloadsDir()
 		if err != nil {
 			return "", errors.Wrap(err, "unable to determine default downloads directory")
 		}
 	}
 
-	absOutputDirectory, err := filepath.Abs(outputDirectory)
+	absOutputDir, err := filepath.Abs(outputDir)
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to resolve absolute path for %s", outputDirectory)
+		return "", errors.Wrapf(err, "unable to resolve absolute path for %s", outputDir)
 	}
-	return absOutputDirectory, nil
+	return absOutputDir, nil
 }
 
 // handleTaskKeyError formats task-key-specific errors for user display.

--- a/cmd/rwx/artifacts/download_test.go
+++ b/cmd/rwx/artifacts/download_test.go
@@ -14,6 +14,9 @@ func TestDownloadOutputDirFlags(t *testing.T) {
 	require.NotNil(t, outputDirFlag)
 	require.False(t, outputDirFlag.Hidden)
 
+	outputFileFlag := DownloadCmd.Flags().Lookup("output-file")
+	require.NotNil(t, outputFileFlag)
+	require.False(t, outputFileFlag.Hidden)
+
 	require.Nil(t, DownloadCmd.Flags().Lookup("output-directory"))
-	require.Nil(t, DownloadCmd.Flags().Lookup("output-file"))
 }

--- a/cmd/rwx/artifacts/download_test.go
+++ b/cmd/rwx/artifacts/download_test.go
@@ -1,0 +1,22 @@
+package artifacts
+
+import (
+	"testing"
+
+	"github.com/rwx-cloud/rwx/internal/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadOutputDirectoryFlags(t *testing.T) {
+	InitDownload(func() error { return nil }, func() cli.Service { return cli.Service{} }, func() bool { return false })
+
+	outputDirectoryFlag := DownloadCmd.Flags().Lookup("output-directory")
+	require.NotNil(t, outputDirectoryFlag)
+	require.False(t, outputDirectoryFlag.Hidden)
+
+	outputDirAlias := DownloadCmd.Flags().Lookup("output-dir")
+	require.NotNil(t, outputDirAlias)
+	require.True(t, outputDirAlias.Hidden)
+
+	require.Nil(t, DownloadCmd.Flags().Lookup("output-file"))
+}

--- a/cmd/rwx/artifacts/download_test.go
+++ b/cmd/rwx/artifacts/download_test.go
@@ -7,16 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDownloadOutputDirectoryFlags(t *testing.T) {
+func TestDownloadOutputDirFlags(t *testing.T) {
 	InitDownload(func() error { return nil }, func() cli.Service { return cli.Service{} }, func() bool { return false })
 
-	outputDirectoryFlag := DownloadCmd.Flags().Lookup("output-directory")
-	require.NotNil(t, outputDirectoryFlag)
-	require.False(t, outputDirectoryFlag.Hidden)
+	outputDirFlag := DownloadCmd.Flags().Lookup("output-dir")
+	require.NotNil(t, outputDirFlag)
+	require.False(t, outputDirFlag.Hidden)
 
-	outputDirAlias := DownloadCmd.Flags().Lookup("output-dir")
-	require.NotNil(t, outputDirAlias)
-	require.True(t, outputDirAlias.Hidden)
-
+	require.Nil(t, DownloadCmd.Flags().Lookup("output-directory"))
 	require.Nil(t, DownloadCmd.Flags().Lookup("output-file"))
 }

--- a/cmd/rwx/logs.go
+++ b/cmd/rwx/logs.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	LogsOutputDir   string
+	LogsOutputFile  string
 	LogsAutoExtract bool
 	LogsZip         bool
 	LogsOpen        bool
@@ -41,22 +42,37 @@ var (
 			var err error
 
 			outputDirSet := cmd.Flags().Changed("output-dir")
-			outputDir := LogsOutputDir
-			if !outputDirSet {
-				outputDir, err = cli.FindDefaultDownloadsDir()
-				if err != nil {
-					return errors.Wrap(err, "unable to determine default logs directory")
-				}
+			outputFileSet := cmd.Flags().Changed("output-file")
+			if outputDirSet && outputFileSet {
+				return errors.New("output-dir and output-file cannot be used together")
 			}
-			absOutputDir, err := filepath.Abs(outputDir)
-			if err != nil {
-				return errors.Wrapf(err, "unable to resolve absolute path for %s", outputDir)
+
+			var absOutputDir string
+			var absOutputFile string
+			if outputFileSet {
+				absOutputFile, err = filepath.Abs(LogsOutputFile)
+				if err != nil {
+					return errors.Wrapf(err, "unable to resolve absolute path for %s", LogsOutputFile)
+				}
+			} else {
+				outputDir := LogsOutputDir
+				if !outputDirSet {
+					outputDir, err = cli.FindDefaultDownloadsDir()
+					if err != nil {
+						return errors.Wrap(err, "unable to determine default logs directory")
+					}
+				}
+				absOutputDir, err = filepath.Abs(outputDir)
+				if err != nil {
+					return errors.Wrapf(err, "unable to resolve absolute path for %s", outputDir)
+				}
 			}
 
 			useJson := useJsonOutput()
 
 			cfg := cli.DownloadLogsConfig{
 				OutputDir:              absOutputDir,
+				OutputFile:             absOutputFile,
 				OutputDirExplicitlySet: outputDirSet,
 				Json:                   useJson,
 				Zip:                    LogsZip,
@@ -94,6 +110,7 @@ var (
 
 func init() {
 	logsCmd.Flags().StringVar(&LogsOutputDir, "output-dir", "", "output directory for downloaded logs (defaults to .rwx/downloads folder)")
+	logsCmd.Flags().StringVar(&LogsOutputFile, "output-file", "", "output file path for the downloaded zip archive; only valid with --zip")
 	logsCmd.Flags().BoolVar(&LogsAutoExtract, "auto-extract", false, "automatically extract zip archives")
 	if err := logsCmd.Flags().MarkHidden("auto-extract"); err != nil {
 		panic(err)

--- a/cmd/rwx/logs.go
+++ b/cmd/rwx/logs.go
@@ -11,11 +11,11 @@ import (
 )
 
 var (
-	LogsOutputDirectory string
-	LogsAutoExtract     bool
-	LogsZip             bool
-	LogsOpen            bool
-	LogsTaskKey         string
+	LogsOutputDir   string
+	LogsAutoExtract bool
+	LogsZip         bool
+	LogsOpen        bool
+	LogsTaskKey     string
 
 	logsCmd = &cobra.Command{
 		GroupID: "outputs",
@@ -38,32 +38,26 @@ var (
 				}
 			}
 
-			outputDirectorySet := cmd.Flags().Changed("output-directory")
-			outputDirAliasSet := cmd.Flags().Changed("output-dir")
-			if outputDirectorySet && outputDirAliasSet {
-				return errors.New("output-directory and output-dir cannot be used together")
-			}
-
 			var err error
 
-			outputDirectoryExplicitlySet := outputDirectorySet || outputDirAliasSet
-			outputDirectory := LogsOutputDirectory
-			if !outputDirectoryExplicitlySet {
-				outputDirectory, err = cli.FindDefaultDownloadsDir()
+			outputDirSet := cmd.Flags().Changed("output-dir")
+			outputDir := LogsOutputDir
+			if !outputDirSet {
+				outputDir, err = cli.FindDefaultDownloadsDir()
 				if err != nil {
 					return errors.Wrap(err, "unable to determine default logs directory")
 				}
 			}
-			absOutputDirectory, err := filepath.Abs(outputDirectory)
+			absOutputDir, err := filepath.Abs(outputDir)
 			if err != nil {
-				return errors.Wrapf(err, "unable to resolve absolute path for %s", outputDirectory)
+				return errors.Wrapf(err, "unable to resolve absolute path for %s", outputDir)
 			}
 
 			useJson := useJsonOutput()
 
 			cfg := cli.DownloadLogsConfig{
-				OutputDir:              absOutputDirectory,
-				OutputDirExplicitlySet: outputDirectoryExplicitlySet,
+				OutputDir:              absOutputDir,
+				OutputDirExplicitlySet: outputDirSet,
 				Json:                   useJson,
 				Zip:                    LogsZip,
 				Open:                   LogsOpen,
@@ -99,11 +93,7 @@ var (
 )
 
 func init() {
-	logsCmd.Flags().StringVar(&LogsOutputDirectory, "output-directory", "", "output directory for downloaded logs (defaults to .rwx/downloads folder)")
-	logsCmd.Flags().StringVar(&LogsOutputDirectory, "output-dir", "", "output directory for downloaded logs (defaults to .rwx/downloads folder)")
-	if err := logsCmd.Flags().MarkHidden("output-dir"); err != nil {
-		panic(err)
-	}
+	logsCmd.Flags().StringVar(&LogsOutputDir, "output-dir", "", "output directory for downloaded logs (defaults to .rwx/downloads folder)")
 	logsCmd.Flags().BoolVar(&LogsAutoExtract, "auto-extract", false, "automatically extract zip archives")
 	if err := logsCmd.Flags().MarkHidden("auto-extract"); err != nil {
 		panic(err)

--- a/cmd/rwx/logs.go
+++ b/cmd/rwx/logs.go
@@ -11,12 +11,11 @@ import (
 )
 
 var (
-	LogsOutputDir   string
-	LogsOutputFile  string
-	LogsAutoExtract bool
-	LogsZip         bool
-	LogsOpen        bool
-	LogsTaskKey     string
+	LogsOutputDirectory string
+	LogsAutoExtract     bool
+	LogsZip             bool
+	LogsOpen            bool
+	LogsTaskKey         string
 
 	logsCmd = &cobra.Command{
 		GroupID: "outputs",
@@ -39,43 +38,35 @@ var (
 				}
 			}
 
-			outputDirSet := cmd.Flags().Changed("output-dir")
-			outputFileSet := cmd.Flags().Changed("output-file")
-			if outputDirSet && outputFileSet {
-				return errors.New("output-dir and output-file cannot be used together")
+			outputDirectorySet := cmd.Flags().Changed("output-directory")
+			outputDirAliasSet := cmd.Flags().Changed("output-dir")
+			if outputDirectorySet && outputDirAliasSet {
+				return errors.New("output-directory and output-dir cannot be used together")
 			}
 
-			var absOutputDir string
-			var absOutputFile string
 			var err error
 
-			if LogsOutputFile != "" {
-				absOutputFile, err = filepath.Abs(LogsOutputFile)
+			outputDirectoryExplicitlySet := outputDirectorySet || outputDirAliasSet
+			outputDirectory := LogsOutputDirectory
+			if !outputDirectoryExplicitlySet {
+				outputDirectory, err = cli.FindDefaultDownloadsDir()
 				if err != nil {
-					return errors.Wrapf(err, "unable to resolve absolute path for %s", LogsOutputFile)
+					return errors.Wrap(err, "unable to determine default logs directory")
 				}
-			} else {
-				outputDir := LogsOutputDir
-				if !outputDirSet {
-					outputDir, err = cli.FindDefaultDownloadsDir()
-					if err != nil {
-						return errors.Wrap(err, "unable to determine default logs directory")
-					}
-				}
-				absOutputDir, err = filepath.Abs(outputDir)
-				if err != nil {
-					return errors.Wrapf(err, "unable to resolve absolute path for %s", outputDir)
-				}
+			}
+			absOutputDirectory, err := filepath.Abs(outputDirectory)
+			if err != nil {
+				return errors.Wrapf(err, "unable to resolve absolute path for %s", outputDirectory)
 			}
 
 			useJson := useJsonOutput()
 
 			cfg := cli.DownloadLogsConfig{
-				OutputDir:  absOutputDir,
-				OutputFile: absOutputFile,
-				Json:       useJson,
-				Zip:        LogsZip,
-				Open:       LogsOpen,
+				OutputDir:              absOutputDirectory,
+				OutputDirExplicitlySet: outputDirectoryExplicitlySet,
+				Json:                   useJson,
+				Zip:                    LogsZip,
+				Open:                   LogsOpen,
 			}
 
 			if taskKeySet {
@@ -108,9 +99,11 @@ var (
 )
 
 func init() {
-	logsCmd.Flags().StringVar(&LogsOutputDir, "output-dir", "", "output directory for the downloaded log file (defaults to .rwx/downloads folder)")
-	logsCmd.Flags().StringVar(&LogsOutputFile, "output-file", "", "output file path for the downloaded log file")
-	logsCmd.MarkFlagsMutuallyExclusive("output-dir", "output-file")
+	logsCmd.Flags().StringVar(&LogsOutputDirectory, "output-directory", "", "output directory for downloaded logs (defaults to .rwx/downloads folder)")
+	logsCmd.Flags().StringVar(&LogsOutputDirectory, "output-dir", "", "output directory for downloaded logs (defaults to .rwx/downloads folder)")
+	if err := logsCmd.Flags().MarkHidden("output-dir"); err != nil {
+		panic(err)
+	}
 	logsCmd.Flags().BoolVar(&LogsAutoExtract, "auto-extract", false, "automatically extract zip archives")
 	if err := logsCmd.Flags().MarkHidden("auto-extract"); err != nil {
 		panic(err)

--- a/cmd/rwx/logs_test.go
+++ b/cmd/rwx/logs_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogsOutputDirectoryFlags(t *testing.T) {
+	outputDirectoryFlag := logsCmd.Flags().Lookup("output-directory")
+	require.NotNil(t, outputDirectoryFlag)
+	require.False(t, outputDirectoryFlag.Hidden)
+
+	outputDirAlias := logsCmd.Flags().Lookup("output-dir")
+	require.NotNil(t, outputDirAlias)
+	require.True(t, outputDirAlias.Hidden)
+
+	require.Nil(t, logsCmd.Flags().Lookup("output-file"))
+}

--- a/cmd/rwx/logs_test.go
+++ b/cmd/rwx/logs_test.go
@@ -11,6 +11,9 @@ func TestLogsOutputDirFlags(t *testing.T) {
 	require.NotNil(t, outputDirFlag)
 	require.False(t, outputDirFlag.Hidden)
 
+	outputFileFlag := logsCmd.Flags().Lookup("output-file")
+	require.NotNil(t, outputFileFlag)
+	require.False(t, outputFileFlag.Hidden)
+
 	require.Nil(t, logsCmd.Flags().Lookup("output-directory"))
-	require.Nil(t, logsCmd.Flags().Lookup("output-file"))
 }

--- a/cmd/rwx/logs_test.go
+++ b/cmd/rwx/logs_test.go
@@ -6,14 +6,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLogsOutputDirectoryFlags(t *testing.T) {
-	outputDirectoryFlag := logsCmd.Flags().Lookup("output-directory")
-	require.NotNil(t, outputDirectoryFlag)
-	require.False(t, outputDirectoryFlag.Hidden)
+func TestLogsOutputDirFlags(t *testing.T) {
+	outputDirFlag := logsCmd.Flags().Lookup("output-dir")
+	require.NotNil(t, outputDirFlag)
+	require.False(t, outputDirFlag.Hidden)
 
-	outputDirAlias := logsCmd.Flags().Lookup("output-dir")
-	require.NotNil(t, outputDirAlias)
-	require.True(t, outputDirAlias.Hidden)
-
+	require.Nil(t, logsCmd.Flags().Lookup("output-directory"))
 	require.Nil(t, logsCmd.Flags().Lookup("output-file"))
 }

--- a/internal/cli/service_artifacts.go
+++ b/internal/cli/service_artifacts.go
@@ -24,6 +24,7 @@ type DownloadArtifactConfig struct {
 	TaskKey                string
 	ArtifactKey            string
 	OutputDir              string
+	OutputFile             string
 	OutputDirExplicitlySet bool
 	Json                   bool
 	AutoExtract            bool
@@ -41,8 +42,11 @@ func (c DownloadArtifactConfig) Validate() error {
 	if c.ArtifactKey == "" {
 		return errors.New("artifact key must be provided")
 	}
-	if c.OutputDir == "" {
-		return errors.New("output directory must be provided")
+	if c.OutputDir != "" && c.OutputFile != "" {
+		return errors.New("output-dir and output-file cannot be used together")
+	}
+	if c.OutputDir == "" && c.OutputFile == "" {
+		return errors.New("output directory or output file must be provided")
 	}
 	return nil
 }
@@ -86,6 +90,13 @@ func (s Service) DownloadArtifact(cfg DownloadArtifactConfig) (_ *DownloadArtifa
 
 	totalBytes = artifactDownloadRequest.SizeInBytes
 
+	// For files, always extract the single file from the tar.
+	// For directories, extract if AutoExtract is true.
+	shouldExtract := artifactDownloadRequest.Kind == "file" || (artifactDownloadRequest.Kind == "directory" && cfg.AutoExtract)
+	if shouldExtract && cfg.OutputFile != "" {
+		return nil, errors.Wrap(errors.New("output-file cannot be used when extracting artifacts; use output-dir"), "validation failed")
+	}
+
 	stopSpinner := Spin(
 		"Downloading artifact...",
 		s.StderrIsTTY,
@@ -97,10 +108,6 @@ func (s Service) DownloadArtifact(cfg DownloadArtifactConfig) (_ *DownloadArtifa
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to download artifact")
 	}
-
-	// For files, always extract the single file from the tar
-	// For directories, extract if AutoExtract is true
-	shouldExtract := artifactDownloadRequest.Kind == "file" || (artifactDownloadRequest.Kind == "directory" && cfg.AutoExtract)
 
 	var outputFiles []string
 
@@ -131,7 +138,10 @@ func (s Service) DownloadArtifact(cfg DownloadArtifactConfig) (_ *DownloadArtifa
 			fmt.Fprintf(s.Stdout, "Extracted %d file(s) to %s\n", len(outputFiles), extractDir)
 		}
 	} else {
-		outputPath := filepath.Join(cfg.OutputDir, artifactDownloadRequest.Filename)
+		outputPath := cfg.OutputFile
+		if outputPath == "" {
+			outputPath = filepath.Join(cfg.OutputDir, artifactDownloadRequest.Filename)
+		}
 
 		outputDir := filepath.Dir(outputPath)
 		if err := os.MkdirAll(outputDir, 0755); err != nil {

--- a/internal/cli/service_artifacts.go
+++ b/internal/cli/service_artifacts.go
@@ -24,7 +24,6 @@ type DownloadArtifactConfig struct {
 	TaskKey                string
 	ArtifactKey            string
 	OutputDir              string
-	OutputFile             string
 	OutputDirExplicitlySet bool
 	Json                   bool
 	AutoExtract            bool
@@ -42,8 +41,8 @@ func (c DownloadArtifactConfig) Validate() error {
 	if c.ArtifactKey == "" {
 		return errors.New("artifact key must be provided")
 	}
-	if c.OutputDir != "" && c.OutputFile != "" {
-		return errors.New("output-dir and output-file cannot be used together")
+	if c.OutputDir == "" {
+		return errors.New("output directory must be provided")
 	}
 	return nil
 }
@@ -106,13 +105,8 @@ func (s Service) DownloadArtifact(cfg DownloadArtifactConfig) (_ *DownloadArtifa
 	var outputFiles []string
 
 	if shouldExtract {
-		// Extract tar to output directory
 		var extractDir string
-		if cfg.OutputFile != "" {
-			// If output file is specified, use its directory as extraction dir
-			extractDir = filepath.Dir(cfg.OutputFile)
-		} else if cfg.OutputDirExplicitlySet {
-			// If output-dir was explicitly set by user, extract directly into it
+		if cfg.OutputDirExplicitlySet {
 			extractDir = cfg.OutputDir
 		} else {
 			// For default Downloads folder, create a subdirectory named after the tar file
@@ -131,28 +125,13 @@ func (s Service) DownloadArtifact(cfg DownloadArtifactConfig) (_ *DownloadArtifa
 			return nil, errors.Wrapf(err, "unable to extract tar archive")
 		}
 
-		// For single file artifacts, if OutputFile is specified, rename the extracted file
-		if artifactDownloadRequest.Kind == "file" && cfg.OutputFile != "" && len(extractedFiles) == 1 {
-			newPath := cfg.OutputFile
-			if err := os.Rename(extractedFiles[0], newPath); err != nil {
-				return nil, errors.Wrapf(err, "unable to rename extracted file to %s", newPath)
-			}
-			outputFiles = []string{newPath}
-		} else {
-			outputFiles = extractedFiles
-		}
+		outputFiles = extractedFiles
 
 		if !cfg.Json && artifactDownloadRequest.Kind == "directory" {
 			fmt.Fprintf(s.Stdout, "Extracted %d file(s) to %s\n", len(outputFiles), extractDir)
 		}
 	} else {
-		// Save the raw tar file
-		var outputPath string
-		if cfg.OutputFile != "" {
-			outputPath = cfg.OutputFile
-		} else {
-			outputPath = filepath.Join(cfg.OutputDir, artifactDownloadRequest.Filename)
-		}
+		outputPath := filepath.Join(cfg.OutputDir, artifactDownloadRequest.Filename)
 
 		outputDir := filepath.Dir(outputPath)
 		if err := os.MkdirAll(outputDir, 0755); err != nil {
@@ -332,6 +311,9 @@ func (c DownloadAllArtifactsConfig) Validate() error {
 		}
 	} else if c.TaskID == "" {
 		return errors.New("task ID must be provided")
+	}
+	if c.OutputDir == "" {
+		return errors.New("output directory must be provided")
 	}
 	return nil
 }

--- a/internal/cli/service_artifacts_test.go
+++ b/internal/cli/service_artifacts_test.go
@@ -109,19 +109,17 @@ func TestService_DownloadArtifact(t *testing.T) {
 		require.Contains(t, err.Error(), "artifact key must be provided")
 	})
 
-	t.Run("when validation fails - both output-dir and output-file set", func(t *testing.T) {
+	t.Run("when validation fails - missing output directory", func(t *testing.T) {
 		s := setupTest(t)
 
 		_, err := s.service.DownloadArtifact(cli.DownloadArtifactConfig{
 			TaskID:      "task-123",
 			ArtifactKey: "my-artifact",
-			OutputDir:   s.tmp,
-			OutputFile:  filepath.Join(s.tmp, "custom.txt"),
 		})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "validation failed")
-		require.Contains(t, err.Error(), "output-dir and output-file cannot be used together")
+		require.Contains(t, err.Error(), "output directory must be provided")
 	})
 
 	t.Run("when download succeeds with file artifact - always extracts", func(t *testing.T) {
@@ -256,7 +254,7 @@ func TestService_DownloadArtifact(t *testing.T) {
 		require.Contains(t, output, "subdir/file3.txt")
 	})
 
-	t.Run("when download succeeds with OutputFile specified for file artifact", func(t *testing.T) {
+	t.Run("when download succeeds with explicit output directory for file artifact", func(t *testing.T) {
 		s := setupTest(t)
 
 		fileContent := []byte("custom file content")
@@ -264,7 +262,7 @@ func TestService_DownloadArtifact(t *testing.T) {
 			"original.txt": fileContent,
 		})
 
-		customOutputFile := filepath.Join(s.tmp, "custom", "renamed.txt")
+		customOutputDir := filepath.Join(s.tmp, "custom")
 		s.mockAPI.MockGetArtifactDownloadRequest = func(taskId, artifactKey string) (api.ArtifactDownloadRequestResult, error) {
 			return api.ArtifactDownloadRequestResult{
 				URL:      "https://example.com/artifact",
@@ -279,21 +277,65 @@ func TestService_DownloadArtifact(t *testing.T) {
 		}
 
 		_, err := s.service.DownloadArtifact(cli.DownloadArtifactConfig{
-			TaskID:      "task-999",
-			ArtifactKey: "my-file",
-			OutputFile:  customOutputFile,
+			TaskID:                 "task-999",
+			ArtifactKey:            "my-file",
+			OutputDir:              customOutputDir,
+			OutputDirExplicitlySet: true,
 		})
 
 		require.NoError(t, err)
-		require.FileExists(t, customOutputFile)
+		expectedPath := filepath.Join(customOutputDir, "original.txt")
+		require.FileExists(t, expectedPath)
+		require.NoDirExists(t, filepath.Join(customOutputDir, "task-999-my-file"))
 
-		actualContents, err := os.ReadFile(customOutputFile)
+		actualContents, err := os.ReadFile(expectedPath)
 		require.NoError(t, err)
 		require.Equal(t, fileContent, actualContents)
 
 		output := s.mockStdout.String()
 		require.Contains(t, output, "Artifact downloaded to")
-		require.Contains(t, output, "renamed.txt")
+		require.Contains(t, output, "original.txt")
+	})
+
+	t.Run("when auto-extracting directory artifact with explicit output directory, extracts directly into it", func(t *testing.T) {
+		s := setupTest(t)
+
+		tarBytes := createTestTar(t, map[string][]byte{
+			"file1.txt":        []byte("content 1"),
+			"subdir/file2.txt": []byte("content 2"),
+		})
+
+		s.mockAPI.MockGetArtifactDownloadRequest = func(taskId, artifactKey string) (api.ArtifactDownloadRequestResult, error) {
+			return api.ArtifactDownloadRequestResult{
+				URL:      "https://example.com/artifact",
+				Filename: "task-333-my-dir.tar",
+				Kind:     "directory",
+				Key:      "my-dir",
+			}, nil
+		}
+
+		s.mockAPI.MockDownloadArtifact = func(request api.ArtifactDownloadRequestResult) ([]byte, error) {
+			return tarBytes, nil
+		}
+
+		outputDir := filepath.Join(s.tmp, "requested-output")
+		result, err := s.service.DownloadArtifact(cli.DownloadArtifactConfig{
+			TaskID:                 "task-333",
+			ArtifactKey:            "my-dir",
+			OutputDir:              outputDir,
+			OutputDirExplicitlySet: true,
+			AutoExtract:            true,
+		})
+
+		require.NoError(t, err)
+		require.Len(t, result.OutputFiles, 2)
+		require.FileExists(t, filepath.Join(outputDir, "file1.txt"))
+		require.FileExists(t, filepath.Join(outputDir, "subdir", "file2.txt"))
+		require.NoDirExists(t, filepath.Join(outputDir, "task-333-my-dir"))
+
+		output := s.mockStdout.String()
+		require.Contains(t, output, "Extracted 2 file(s)")
+		require.Contains(t, output, outputDir)
 	})
 
 	t.Run("when download succeeds with JSON output - single file", func(t *testing.T) {

--- a/internal/cli/service_artifacts_test.go
+++ b/internal/cli/service_artifacts_test.go
@@ -109,7 +109,7 @@ func TestService_DownloadArtifact(t *testing.T) {
 		require.Contains(t, err.Error(), "artifact key must be provided")
 	})
 
-	t.Run("when validation fails - missing output directory", func(t *testing.T) {
+	t.Run("when validation fails - missing output destination", func(t *testing.T) {
 		s := setupTest(t)
 
 		_, err := s.service.DownloadArtifact(cli.DownloadArtifactConfig{
@@ -119,7 +119,22 @@ func TestService_DownloadArtifact(t *testing.T) {
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "validation failed")
-		require.Contains(t, err.Error(), "output directory must be provided")
+		require.Contains(t, err.Error(), "output directory or output file must be provided")
+	})
+
+	t.Run("when validation fails - both output dir and output file set", func(t *testing.T) {
+		s := setupTest(t)
+
+		_, err := s.service.DownloadArtifact(cli.DownloadArtifactConfig{
+			TaskID:      "task-123",
+			ArtifactKey: "my-artifact",
+			OutputDir:   s.tmp,
+			OutputFile:  filepath.Join(s.tmp, "artifact.tar"),
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "validation failed")
+		require.Contains(t, err.Error(), "output-dir and output-file cannot be used together")
 	})
 
 	t.Run("when download succeeds with file artifact - always extracts", func(t *testing.T) {
@@ -208,6 +223,43 @@ func TestService_DownloadArtifact(t *testing.T) {
 		require.Contains(t, output, "task-456-my-dir.tar")
 	})
 
+	t.Run("when download succeeds with directory artifact and output-file - saves tar to file", func(t *testing.T) {
+		s := setupTest(t)
+
+		tarBytes := createTestTar(t, map[string][]byte{
+			"file1.txt": []byte("content 1"),
+		})
+		customPath := filepath.Join(s.tmp, "custom", "artifact.tar")
+
+		s.mockAPI.MockGetArtifactDownloadRequest = func(taskId, artifactKey string) (api.ArtifactDownloadRequestResult, error) {
+			return api.ArtifactDownloadRequestResult{
+				URL:      "https://example.com/artifact",
+				Filename: "task-456-my-dir.tar",
+				Kind:     "directory",
+				Key:      "my-dir",
+			}, nil
+		}
+
+		s.mockAPI.MockDownloadArtifact = func(request api.ArtifactDownloadRequestResult) ([]byte, error) {
+			return tarBytes, nil
+		}
+
+		result, err := s.service.DownloadArtifact(cli.DownloadArtifactConfig{
+			TaskID:      "task-456",
+			ArtifactKey: "my-dir",
+			OutputFile:  customPath,
+			AutoExtract: false,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, []string{customPath}, result.OutputFiles)
+		require.FileExists(t, customPath)
+
+		actualContents, err := os.ReadFile(customPath)
+		require.NoError(t, err)
+		require.Equal(t, tarBytes, actualContents)
+	})
+
 	t.Run("when download succeeds with directory artifact and auto-extract true - extracts", func(t *testing.T) {
 		s := setupTest(t)
 
@@ -252,6 +304,53 @@ func TestService_DownloadArtifact(t *testing.T) {
 		require.Contains(t, output, "file1.txt")
 		require.Contains(t, output, "file2.txt")
 		require.Contains(t, output, "subdir/file3.txt")
+	})
+
+	t.Run("when file artifact has output-file, it fails because file artifacts extract", func(t *testing.T) {
+		s := setupTest(t)
+
+		s.mockAPI.MockGetArtifactDownloadRequest = func(taskId, artifactKey string) (api.ArtifactDownloadRequestResult, error) {
+			return api.ArtifactDownloadRequestResult{
+				URL:      "https://example.com/artifact",
+				Filename: "task-999-my-file.tar",
+				Kind:     "file",
+				Key:      "my-file",
+			}, nil
+		}
+
+		_, err := s.service.DownloadArtifact(cli.DownloadArtifactConfig{
+			TaskID:      "task-999",
+			ArtifactKey: "my-file",
+			OutputFile:  filepath.Join(s.tmp, "custom", "artifact.txt"),
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "validation failed")
+		require.Contains(t, err.Error(), "output-file cannot be used when extracting artifacts; use output-dir")
+	})
+
+	t.Run("when auto-extracting directory artifact has output-file, it fails", func(t *testing.T) {
+		s := setupTest(t)
+
+		s.mockAPI.MockGetArtifactDownloadRequest = func(taskId, artifactKey string) (api.ArtifactDownloadRequestResult, error) {
+			return api.ArtifactDownloadRequestResult{
+				URL:      "https://example.com/artifact",
+				Filename: "task-333-my-dir.tar",
+				Kind:     "directory",
+				Key:      "my-dir",
+			}, nil
+		}
+
+		_, err := s.service.DownloadArtifact(cli.DownloadArtifactConfig{
+			TaskID:      "task-333",
+			ArtifactKey: "my-dir",
+			OutputFile:  filepath.Join(s.tmp, "custom", "artifact.tar"),
+			AutoExtract: true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "validation failed")
+		require.Contains(t, err.Error(), "output-file cannot be used when extracting artifacts; use output-dir")
 	})
 
 	t.Run("when download succeeds with explicit output directory for file artifact", func(t *testing.T) {

--- a/internal/cli/service_logs.go
+++ b/internal/cli/service_logs.go
@@ -17,14 +17,14 @@ import (
 )
 
 type DownloadLogsConfig struct {
-	TaskID     string
-	RunID      string
-	TaskKey    string
-	OutputDir  string
-	OutputFile string
-	Json       bool
-	Zip        bool
-	Open       bool
+	TaskID                 string
+	RunID                  string
+	TaskKey                string
+	OutputDir              string
+	OutputDirExplicitlySet bool
+	Json                   bool
+	Zip                    bool
+	Open                   bool
 }
 
 func (c DownloadLogsConfig) Validate() error {
@@ -35,8 +35,8 @@ func (c DownloadLogsConfig) Validate() error {
 	} else if c.TaskID == "" {
 		return errors.New("task ID must be provided")
 	}
-	if c.OutputDir != "" && c.OutputFile != "" {
-		return errors.New("output-dir and output-file cannot be used together")
+	if c.OutputDir == "" {
+		return errors.New("output directory must be provided")
 	}
 	return nil
 }
@@ -87,21 +87,10 @@ func (s Service) DownloadLogs(cfg DownloadLogsConfig) (_ *DownloadLogsResult, dl
 		return nil, errors.Wrap(err, "unable to download logs")
 	}
 
-	// When OutputFile is set but we're in default extract mode, use its directory as the base.
-	outputDir := cfg.OutputDir
-	if outputDir == "" && cfg.OutputFile != "" {
-		outputDir = filepath.Dir(cfg.OutputFile)
-	}
-
 	var outputFiles []string
 
 	if cfg.Zip {
-		var zipPath string
-		if cfg.OutputFile != "" {
-			zipPath = cfg.OutputFile
-		} else {
-			zipPath = filepath.Join(outputDir, logDownloadRequest.Filename)
-		}
+		zipPath := filepath.Join(cfg.OutputDir, logDownloadRequest.Filename)
 
 		if err := os.MkdirAll(filepath.Dir(zipPath), 0755); err != nil {
 			return nil, errors.Wrapf(err, "unable to create output directory %s", filepath.Dir(zipPath))
@@ -117,7 +106,10 @@ func (s Service) DownloadLogs(cfg DownloadLogsConfig) (_ *DownloadLogsResult, dl
 			fmt.Fprintf(s.Stdout, "Logs downloaded to %s\n", zipPath)
 		}
 	} else {
-		extractDir := filepath.Join(outputDir, logDownloadRequest.RunID)
+		extractDir := cfg.OutputDir
+		if !cfg.OutputDirExplicitlySet {
+			extractDir = filepath.Join(cfg.OutputDir, logDownloadRequest.RunID)
+		}
 		if err := os.MkdirAll(extractDir, 0755); err != nil {
 			return nil, errors.Wrapf(err, "unable to create extraction directory %s", extractDir)
 		}

--- a/internal/cli/service_logs.go
+++ b/internal/cli/service_logs.go
@@ -21,6 +21,7 @@ type DownloadLogsConfig struct {
 	RunID                  string
 	TaskKey                string
 	OutputDir              string
+	OutputFile             string
 	OutputDirExplicitlySet bool
 	Json                   bool
 	Zip                    bool
@@ -35,8 +36,14 @@ func (c DownloadLogsConfig) Validate() error {
 	} else if c.TaskID == "" {
 		return errors.New("task ID must be provided")
 	}
-	if c.OutputDir == "" {
-		return errors.New("output directory must be provided")
+	if c.OutputDir != "" && c.OutputFile != "" {
+		return errors.New("output-dir and output-file cannot be used together")
+	}
+	if !c.Zip && c.OutputFile != "" {
+		return errors.New("output-file can only be used with --zip")
+	}
+	if c.OutputDir == "" && c.OutputFile == "" {
+		return errors.New("output directory or output file must be provided")
 	}
 	return nil
 }
@@ -90,7 +97,10 @@ func (s Service) DownloadLogs(cfg DownloadLogsConfig) (_ *DownloadLogsResult, dl
 	var outputFiles []string
 
 	if cfg.Zip {
-		zipPath := filepath.Join(cfg.OutputDir, logDownloadRequest.Filename)
+		zipPath := cfg.OutputFile
+		if zipPath == "" {
+			zipPath = filepath.Join(cfg.OutputDir, logDownloadRequest.Filename)
+		}
 
 		if err := os.MkdirAll(filepath.Dir(zipPath), 0755); err != nil {
 			return nil, errors.Wrapf(err, "unable to create output directory %s", filepath.Dir(zipPath))

--- a/internal/cli/service_logs_test.go
+++ b/internal/cli/service_logs_test.go
@@ -280,7 +280,7 @@ func TestService_DownloadLogs(t *testing.T) {
 		require.Contains(t, err.Error(), "task ID must be provided")
 	})
 
-	t.Run("when validation fails - missing output directory", func(t *testing.T) {
+	t.Run("when validation fails - missing output destination", func(t *testing.T) {
 		s := setupTest(t)
 
 		_, err := s.service.DownloadLogs(cli.DownloadLogsConfig{
@@ -289,7 +289,35 @@ func TestService_DownloadLogs(t *testing.T) {
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "validation failed")
-		require.Contains(t, err.Error(), "output directory must be provided")
+		require.Contains(t, err.Error(), "output directory or output file must be provided")
+	})
+
+	t.Run("when validation fails - output file set while extracting", func(t *testing.T) {
+		s := setupTest(t)
+
+		_, err := s.service.DownloadLogs(cli.DownloadLogsConfig{
+			TaskID:     "task-123",
+			OutputFile: filepath.Join(s.tmp, "task.log"),
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "validation failed")
+		require.Contains(t, err.Error(), "output-file can only be used with --zip")
+	})
+
+	t.Run("when validation fails - both output dir and output file set", func(t *testing.T) {
+		s := setupTest(t)
+
+		_, err := s.service.DownloadLogs(cli.DownloadLogsConfig{
+			TaskID:     "task-123",
+			OutputDir:  s.tmp,
+			OutputFile: filepath.Join(s.tmp, "task.zip"),
+			Zip:        true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "validation failed")
+		require.Contains(t, err.Error(), "output-dir and output-file cannot be used together")
 	})
 
 	t.Run("when --zip flag saves raw zip without extraction", func(t *testing.T) {
@@ -337,13 +365,13 @@ func TestService_DownloadLogs(t *testing.T) {
 		require.Equal(t, []string{zipPath}, result.OutputFiles)
 	})
 
-	t.Run("when --zip flag with explicit output directory", func(t *testing.T) {
+	t.Run("when --zip flag with output-file", func(t *testing.T) {
 		s := setupTest(t)
 
 		zipBytes := createTestZip(t, map[string][]byte{
 			"task.log": []byte("log content"),
 		})
-		customDir := filepath.Join(s.tmp, "custom")
+		customPath := filepath.Join(s.tmp, "custom", "archive.zip")
 
 		s.mockAPI.MockGetLogDownloadRequest = func(taskId string) (api.LogDownloadRequestResult, error) {
 			return api.LogDownloadRequestResult{
@@ -359,14 +387,16 @@ func TestService_DownloadLogs(t *testing.T) {
 		}
 
 		_, err := s.service.DownloadLogs(cli.DownloadLogsConfig{
-			TaskID:                 "task-123",
-			OutputDir:              customDir,
-			OutputDirExplicitlySet: true,
-			Zip:                    true,
+			TaskID:     "task-123",
+			OutputFile: customPath,
+			Zip:        true,
 		})
 
 		require.NoError(t, err)
-		require.FileExists(t, filepath.Join(customDir, "task-123-logs.zip"))
+		require.FileExists(t, customPath)
+		actualBytes, err := os.ReadFile(customPath)
+		require.NoError(t, err)
+		require.Equal(t, zipBytes, actualBytes)
 	})
 
 	t.Run("when --zip flag with JSON output", func(t *testing.T) {

--- a/internal/cli/service_logs_test.go
+++ b/internal/cli/service_logs_test.go
@@ -151,6 +151,44 @@ func TestService_DownloadLogs(t *testing.T) {
 		require.Contains(t, result.OutputFiles[0], "ci.rspec.rspec-0.log")
 	})
 
+	t.Run("when explicit output directory is set, extracts directly into it", func(t *testing.T) {
+		s := setupTest(t)
+
+		zipBytes := createTestZip(t, map[string][]byte{
+			"test.log": []byte("log content"),
+		})
+
+		s.mockAPI.MockGetLogDownloadRequest = func(taskId string) (api.LogDownloadRequestResult, error) {
+			return api.LogDownloadRequestResult{
+				URL:      "https://example.com/logs",
+				Token:    "jwt-token",
+				Filename: "task-123-logs.zip",
+				RunID:    "run-explicit",
+			}, nil
+		}
+
+		s.mockAPI.MockDownloadLogs = func(request api.LogDownloadRequestResult) ([]byte, error) {
+			return zipBytes, nil
+		}
+
+		outputDir := filepath.Join(s.tmp, "requested-output")
+		result, err := s.service.DownloadLogs(cli.DownloadLogsConfig{
+			TaskID:                 "task-123",
+			OutputDir:              outputDir,
+			OutputDirExplicitlySet: true,
+		})
+
+		require.NoError(t, err)
+		expectedPath := filepath.Join(outputDir, "test.log")
+		require.FileExists(t, expectedPath)
+		require.NoFileExists(t, filepath.Join(outputDir, "run-explicit", "test.log"))
+		require.Equal(t, []string{expectedPath}, result.OutputFiles)
+
+		output := s.mockStdout.String()
+		require.Contains(t, output, "Logs downloaded to")
+		require.Contains(t, output, outputDir+string(os.PathSeparator))
+	})
+
 	t.Run("when download succeeds with multiple log files", func(t *testing.T) {
 		s := setupTest(t)
 
@@ -242,18 +280,16 @@ func TestService_DownloadLogs(t *testing.T) {
 		require.Contains(t, err.Error(), "task ID must be provided")
 	})
 
-	t.Run("when validation fails - both output-dir and output-file set", func(t *testing.T) {
+	t.Run("when validation fails - missing output directory", func(t *testing.T) {
 		s := setupTest(t)
 
 		_, err := s.service.DownloadLogs(cli.DownloadLogsConfig{
-			TaskID:     "task-123",
-			OutputDir:  s.tmp,
-			OutputFile: filepath.Join(s.tmp, "custom.zip"),
+			TaskID: "task-123",
 		})
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "validation failed")
-		require.Contains(t, err.Error(), "output-dir and output-file cannot be used together")
+		require.Contains(t, err.Error(), "output directory must be provided")
 	})
 
 	t.Run("when --zip flag saves raw zip without extraction", func(t *testing.T) {
@@ -301,13 +337,13 @@ func TestService_DownloadLogs(t *testing.T) {
 		require.Equal(t, []string{zipPath}, result.OutputFiles)
 	})
 
-	t.Run("when --zip flag with output-file", func(t *testing.T) {
+	t.Run("when --zip flag with explicit output directory", func(t *testing.T) {
 		s := setupTest(t)
 
 		zipBytes := createTestZip(t, map[string][]byte{
 			"task.log": []byte("log content"),
 		})
-		customPath := filepath.Join(s.tmp, "custom", "archive.zip")
+		customDir := filepath.Join(s.tmp, "custom")
 
 		s.mockAPI.MockGetLogDownloadRequest = func(taskId string) (api.LogDownloadRequestResult, error) {
 			return api.LogDownloadRequestResult{
@@ -323,13 +359,14 @@ func TestService_DownloadLogs(t *testing.T) {
 		}
 
 		_, err := s.service.DownloadLogs(cli.DownloadLogsConfig{
-			TaskID:     "task-123",
-			OutputFile: customPath,
-			Zip:        true,
+			TaskID:                 "task-123",
+			OutputDir:              customDir,
+			OutputDirExplicitlySet: true,
+			Zip:                    true,
 		})
 
 		require.NoError(t, err)
-		require.FileExists(t, customPath)
+		require.FileExists(t, filepath.Join(customDir, "task-123-logs.zip"))
 	})
 
 	t.Run("when --zip flag with JSON output", func(t *testing.T) {


### PR DESCRIPTION
## Summary

`rwx logs` and `rwx artifacts download` were treating `--output-file` like a destination for extracted content, but extracted logs/artifacts are directory-shaped. That led to confusing results such as `rwx logs <task> --output-file /tmp/run2.log` extracting files under a generated directory instead of creating `/tmp/run2.log`.

This PR keeps both destination flags, with mode-specific semantics:

- `--output-dir` is the destination for extracted content.
- `--output-file` is only valid when saving a raw archive.
- `rwx logs --zip --output-file <path>` writes the downloaded zip exactly to `<path>`.
- `rwx artifacts download --output-file <path>` writes the raw tar exactly to `<path>` only when the artifact is not being extracted.
- File artifacts always extract, so they reject `--output-file` and require `--output-dir` or the default downloads directory.
- Directory artifacts reject `--output-file` when `--auto-extract` is set.
- Default behavior is preserved: when no output flag is provided, extracted files still go under generated subdirectories in the default downloads location.
