### PR TITLE
Hide sandbox git sync probes from logs

### DIFF
--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1448,11 +1448,6 @@ func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHe
 		})
 	}()
 
-	if err := s.ensureSandboxGitDir(); err != nil {
-		syncPushErr = err
-		return patchBytes, syncPushErr
-	}
-
 	if err := s.ensureSandboxHasCommit(localHead, jsonMode); err != nil {
 		syncPushErr = err
 		return patchBytes, syncPushErr
@@ -1528,33 +1523,34 @@ func (s Service) warnUnresolvedRejectFiles() {
 	fmt.Fprintln(s.Stderr, "These will be synced to the sandbox and may cause issues. Resolve and delete them when possible.")
 }
 
-func (s Service) ensureSandboxGitDir() error {
+func (s Service) ensureSandboxHasCommit(localHead string, jsonMode bool) error {
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
-	exitCode, err := s.SSHClient.ExecuteCommand("test -d .git || test -f .git")
-	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
-	if err != nil {
-		return errors.Wrap(err, "failed to check sandbox git directory")
+	gitDirExitCode, gitDirErr := s.SSHClient.ExecuteCommand("test -d .git || test -f .git")
+	if gitDirErr != nil {
+		_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
+		return errors.Wrap(gitDirErr, "failed to check sandbox git directory")
 	}
-	if exitCode != 0 {
+	if gitDirExitCode != 0 {
+		_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 		return errors.ErrSandboxNoGitDir
 	}
-	return nil
-}
 
-func (s Service) ensureSandboxHasCommit(localHead string, jsonMode bool) error {
-	if s.sandboxHasCommit(localHead) {
-		return nil
+	hasCommit := s.sandboxHasCommit(localHead)
+	if !hasCommit {
+		_, _ = s.SSHClient.ExecuteCommand("/usr/bin/git fetch --prune origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1")
+		hasCommit = s.sandboxHasCommit(localHead)
 	}
 
-	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
-	_, _ = s.SSHClient.ExecuteCommand("/usr/bin/git fetch --prune origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1")
+	var knownTips []string
+	if !hasCommit {
+		knownTips = s.remoteKnownTips()
+	}
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 
-	if s.sandboxHasCommit(localHead) {
+	if hasCommit {
 		return nil
 	}
 
-	knownTips := s.remoteKnownTips()
 	excludes := make([]string, 0, len(knownTips))
 	seen := make(map[string]bool, len(knownTips))
 	for _, tip := range knownTips {
@@ -1601,6 +1597,7 @@ func (s Service) ensureSandboxHasCommit(localHead string, jsonMode bool) error {
 		fetchBundleCmd,
 		fd,
 	)
+	hasCommit = streamErr == nil && exitCode == 0 && s.sandboxHasCommit(localHead)
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 	if streamErr != nil {
 		return errors.Wrap(streamErr, "failed to stream git bundle to sandbox")
@@ -1612,7 +1609,7 @@ func (s Service) ensureSandboxHasCommit(localHead string, jsonMode bool) error {
 		return fmt.Errorf("failed to import git bundle in sandbox (exit code %d)", exitCode)
 	}
 
-	if !s.sandboxHasCommit(localHead) {
+	if !hasCommit {
 		return fmt.Errorf("sandbox still does not contain local commit %s after bundle import", localHead)
 	}
 

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -63,6 +63,34 @@ func TestService_ListSandboxes(t *testing.T) {
 	})
 }
 
+func requireCommandWrappedBySyncMarkers(t *testing.T, commands []string, commandIndex int) {
+	t.Helper()
+
+	startIndex := -1
+	for i := commandIndex - 1; i >= 0; i-- {
+		if commands[i] == "__rwx_sandbox_sync_start__" {
+			startIndex = i
+			break
+		}
+		if commands[i] == "__rwx_sandbox_sync_end__" {
+			break
+		}
+	}
+	require.NotEqual(t, -1, startIndex, "command %q should be preceded by a sync start marker", commands[commandIndex])
+
+	endIndex := -1
+	for i := commandIndex + 1; i < len(commands); i++ {
+		if commands[i] == "__rwx_sandbox_sync_end__" {
+			endIndex = i
+			break
+		}
+		if commands[i] == "__rwx_sandbox_sync_start__" {
+			break
+		}
+	}
+	require.NotEqual(t, -1, endIndex, "command %q should be followed by a sync end marker", commands[commandIndex])
+}
+
 func TestService_LockWaitOutput(t *testing.T) {
 	t.Run("no output when lock is uncontended", func(t *testing.T) {
 		setup := setupTest(t)
@@ -1494,6 +1522,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		}
 
 		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
+			commandOrder = append(commandOrder, cmd)
 			switch {
 			case strings.Contains(cmd, "for-each-ref"):
 				return 0, knownTip + "\ncccccccccccccccccccccccccccccccccccccccc\n", nil
@@ -1509,6 +1538,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		var stdinCommands []string
 		var stdinPayloads []string
 		setup.mockSSH.MockExecuteCommandWithStdinAndCombinedOutput = func(command string, stdin io.Reader) (int, string, error) {
+			commandOrder = append(commandOrder, command)
 			data, _ := io.ReadAll(stdin)
 			stdinCommands = append(stdinCommands, command)
 			stdinPayloads = append(stdinPayloads, string(data))
@@ -1531,6 +1561,46 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Contains(t, strings.Join(commandOrder, "\n"), "git checkout -f -B 'feature/sync' '"+localHead+"'")
 		require.Contains(t, strings.Join(commandOrder, "\n"), "git write-tree")
 		require.Contains(t, strings.Join(commandOrder, "\n"), "git clean -fd")
+		for i, cmd := range commandOrder {
+			if strings.Contains(cmd, "cat-file -e") || strings.Contains(cmd, "for-each-ref") {
+				requireCommandWrappedBySyncMarkers(t, commandOrder, i)
+			}
+		}
+		firstProbeIndex := slices.IndexFunc(commandOrder, func(cmd string) bool {
+			return strings.Contains(cmd, "cat-file -e")
+		})
+		knownTipsIndex := slices.IndexFunc(commandOrder, func(cmd string) bool {
+			return strings.Contains(cmd, "for-each-ref")
+		})
+		require.NotEqual(t, -1, firstProbeIndex)
+		require.NotEqual(t, -1, knownTipsIndex)
+		require.Less(t, firstProbeIndex, knownTipsIndex)
+		gitDirIndex := slices.IndexFunc(commandOrder, func(cmd string) bool {
+			return strings.Contains(cmd, "test -d .git")
+		})
+		require.NotEqual(t, -1, gitDirIndex)
+		require.Less(t, gitDirIndex, firstProbeIndex)
+		require.Equal(t, "__rwx_sandbox_sync_start__", commandOrder[gitDirIndex-1])
+		require.Equal(t, "__rwx_sandbox_sync_end__", commandOrder[knownTipsIndex+1])
+		require.NotContains(t, commandOrder[gitDirIndex+1:knownTipsIndex], "__rwx_sandbox_sync_start__")
+		require.NotContains(t, commandOrder[gitDirIndex+1:knownTipsIndex], "__rwx_sandbox_sync_end__")
+
+		bundleImportIndex := slices.IndexFunc(commandOrder, func(cmd string) bool {
+			return strings.Contains(cmd, "git bundle verify")
+		})
+		require.NotEqual(t, -1, bundleImportIndex)
+		finalProbeIndex := -1
+		for i := bundleImportIndex + 1; i < len(commandOrder); i++ {
+			if strings.Contains(commandOrder[i], "cat-file -e") {
+				finalProbeIndex = i
+				break
+			}
+		}
+		require.NotEqual(t, -1, finalProbeIndex)
+		require.Equal(t, "__rwx_sandbox_sync_start__", commandOrder[bundleImportIndex-1])
+		require.Equal(t, "__rwx_sandbox_sync_end__", commandOrder[finalProbeIndex+1])
+		require.NotContains(t, commandOrder[bundleImportIndex+1:finalProbeIndex], "__rwx_sandbox_sync_start__")
+		require.NotContains(t, commandOrder[bundleImportIndex+1:finalProbeIndex], "__rwx_sandbox_sync_end__")
 		require.Contains(t, stdinCommands[0], "git bundle verify")
 		require.Contains(t, stdinCommands[0], "refs/rwx/bundles/test:refs/rwx/bundles/test")
 		require.Equal(t, "bundle-data", stdinPayloads[0])


### PR DESCRIPTION
Wrap sandbox git-state sync probes in the existing sync marker window so Mint suppresses them from sandbox logs. Adds regression coverage for the PR #520 probe path.