### PR TITLE
Remove Debug switch

### DIFF
--- a/cmd/rwx/main.go
+++ b/cmd/rwx/main.go
@@ -38,12 +38,7 @@ func main() {
 	}
 
 	if !errors.Is(err, HandledError) {
-		if Debug {
-			// Enabling debug output will print stacktraces
-			fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
-		} else {
-			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-		}
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 	}
 
 	os.Exit(1)

--- a/cmd/rwx/run.go
+++ b/cmd/rwx/run.go
@@ -23,7 +23,7 @@ var (
 	TargetedTasks  []string
 	NoCache        bool
 	Open           bool
-	Debug          bool
+	RunDebug       bool
 	Wait           bool
 	FailFast       bool
 	Title          string
@@ -121,7 +121,7 @@ var (
 				}
 			}
 
-			if Wait && !Debug {
+			if Wait && !RunDebug {
 				waitResult, err := service.GetRunStatus(cli.GetRunStatusConfig{
 					RunID:    runResult.RunID,
 					Wait:     true,
@@ -157,7 +157,7 @@ var (
 				}
 			}
 
-			if Debug {
+			if RunDebug {
 				fmt.Println()
 				stopSpinner := cli.Spin("Waiting for run to hit a breakpoint...", service.StdoutIsTTY, service.Stdout)
 
@@ -197,7 +197,7 @@ func init() {
 	_ = runCmd.Flags().MarkHidden("file")
 	addRwxDirFlag(runCmd)
 	runCmd.Flags().BoolVar(&Open, "open", false, "open the run in a browser")
-	runCmd.Flags().BoolVar(&Debug, "debug", false, "start a remote debugging session once a breakpoint is hit")
+	runCmd.Flags().BoolVar(&RunDebug, "debug", false, "start a remote debugging session once a breakpoint is hit")
 	runCmd.Flags().BoolVar(&Wait, "wait", false, "poll for the run to complete and report the result status")
 	runCmd.Flags().BoolVar(&FailFast, "fail-fast", false, "stop waiting when failures are available (only has an effect when used with --wait)")
 	runCmd.Flags().StringVar(&Title, "title", "", "the title the UI will display for the run")


### PR DESCRIPTION
I noticed we leak a stack trace on certain kinds of rwx-breakpoint disconnects. The reason is twofold:

1. We're treating one of our expecting exit states as an error (I'll fix that separately)
2. Long ago, we had a way to pass `--debug` and render stack traces intead of formatted errors. That hasn't existed for a while but `rwx run --debug` happens to still set the `Debug` package level global.

This both removes the formatter switching and renames the global to be more in line with our other use of `--debug` - `DispatchDebug`. Using the global in the first place strikes me as a little bit odd but it appears to be a common pattern with Cobra.