### PR TITLE
Detect coding agent environment in CLI telemetry

### DIFF
--- a/internal/telemetry/agent.go
+++ b/internal/telemetry/agent.go
@@ -1,0 +1,56 @@
+package telemetry
+
+import (
+	"os"
+	"strings"
+)
+
+// agentEnvVars maps a coding agent to the environment variables whose presence
+// signals it. There is no cross-agent standard yet (akin to CI=true), so this
+// is a best-effort, additive list.
+//
+// Order matters: the first agent with a matching variable wins, so specific
+// agents come before the generic AI_AGENT catch-all.
+var agentEnvVars = []struct {
+	agent   string
+	envVars []string
+}{
+	// Claude Code sets CLAUDECODE=1 in every subprocess it spawns.
+	// https://code.claude.com/docs/en/env-vars
+	{"claude_code", []string{"CLAUDECODE", "CLAUDE_CODE"}},
+	{"cursor", []string{"CURSOR_AGENT"}},
+	{"codex", []string{"CODEX_SANDBOX", "CODEX_CI"}},
+	{"gemini_cli", []string{"GEMINI_CLI"}},
+	{"copilot_cli", []string{"COPILOT_CLI"}},
+	// AI_AGENT is a generic, agent-agnostic signal; only used when no specific
+	// agent above matched.
+	{"agent", []string{"AI_AGENT"}},
+}
+
+// detectAgent returns the name of the coding agent the CLI appears to be
+// running inside, or "" when none is detected.
+func detectAgent() string {
+	for _, e := range agentEnvVars {
+		for _, v := range e.envVars {
+			if envSet(v) {
+				return e.agent
+			}
+		}
+	}
+	return ""
+}
+
+// envSet reports whether an environment variable is present and not explicitly
+// disabled. We accept any non-falsy value rather than requiring "1"/"true"
+// because some agents use other values (e.g. Codex sets CODEX_SANDBOX=seatbelt).
+func envSet(name string) bool {
+	v, ok := os.LookupEnv(name)
+	if !ok {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "0", "false":
+		return false
+	}
+	return true
+}

--- a/internal/telemetry/agent_test.go
+++ b/internal/telemetry/agent_test.go
@@ -1,0 +1,56 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// clearAgentEnv unsets every env var that detectAgent inspects so a test starts
+// from a known-empty environment. t.Setenv restores prior values on cleanup.
+func clearAgentEnv(t *testing.T) {
+	t.Helper()
+	for _, e := range agentEnvVars {
+		for _, v := range e.envVars {
+			t.Setenv(v, "")
+		}
+	}
+}
+
+func TestDetectAgent(t *testing.T) {
+	t.Run("none detected", func(t *testing.T) {
+		clearAgentEnv(t)
+		require.Equal(t, "", detectAgent())
+	})
+
+	t.Run("claude code", func(t *testing.T) {
+		clearAgentEnv(t)
+		t.Setenv("CLAUDECODE", "1")
+		require.Equal(t, "claude_code", detectAgent())
+	})
+
+	t.Run("codex via seatbelt value", func(t *testing.T) {
+		clearAgentEnv(t)
+		t.Setenv("CODEX_SANDBOX", "seatbelt")
+		require.Equal(t, "codex", detectAgent())
+	})
+
+	t.Run("generic AI_AGENT", func(t *testing.T) {
+		clearAgentEnv(t)
+		t.Setenv("AI_AGENT", "true")
+		require.Equal(t, "agent", detectAgent())
+	})
+
+	t.Run("specific agent wins over generic", func(t *testing.T) {
+		clearAgentEnv(t)
+		t.Setenv("AI_AGENT", "1")
+		t.Setenv("CLAUDECODE", "1")
+		require.Equal(t, "claude_code", detectAgent())
+	})
+
+	t.Run("falsy values are not detected", func(t *testing.T) {
+		clearAgentEnv(t)
+		t.Setenv("AI_AGENT", "false")
+		require.Equal(t, "", detectAgent())
+	})
+}

--- a/internal/telemetry/collector.go
+++ b/internal/telemetry/collector.go
@@ -12,6 +12,7 @@ type Event struct {
 	Timestamp string         `json:"ts"`
 	OS        string         `json:"os"`
 	Arch      string         `json:"arch"`
+	Agent     string         `json:"agent,omitempty"`
 	Props     map[string]any `json:"props,omitempty"`
 }
 
@@ -19,11 +20,14 @@ type Event struct {
 type Collector struct {
 	mu     sync.Mutex
 	events []Event
+	// agent is the coding agent detected from the environment at construction,
+	// stamped onto every event's envelope. Empty when no agent is detected.
+	agent string
 }
 
 // NewCollector creates a Collector.
 func NewCollector() *Collector {
-	return &Collector{}
+	return &Collector{agent: detectAgent()}
 }
 
 // Record enqueues a telemetry event.
@@ -33,6 +37,7 @@ func (c *Collector) Record(event string, props map[string]any) {
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 		OS:        runtime.GOOS,
 		Arch:      runtime.GOARCH,
+		Agent:     c.agent,
 		Props:     props,
 	}
 

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -20,6 +20,29 @@ func TestCollector_Record_WhenEnabled(t *testing.T) {
 	require.NotEmpty(t, events[0].Arch)
 }
 
+func TestCollector_Record_StampsAgent(t *testing.T) {
+	clearAgentEnv(t)
+	t.Setenv("CLAUDECODE", "1")
+
+	c := NewCollector()
+	c.Record("test_event", nil)
+
+	events := c.Drain()
+	require.Len(t, events, 1)
+	require.Equal(t, "claude_code", events[0].Agent)
+}
+
+func TestCollector_Record_OmitsAgentWhenNoneDetected(t *testing.T) {
+	clearAgentEnv(t)
+
+	c := NewCollector()
+	c.Record("test_event", nil)
+
+	events := c.Drain()
+	require.Len(t, events, 1)
+	require.Empty(t, events[0].Agent)
+}
+
 func TestCollector_Drain_ClearsQueue(t *testing.T) {
 	c := NewCollector()
 	c.Record("e1", nil)


### PR DESCRIPTION
### Background

[RWX-945: Add agent_detected to CLI telemetry](https://linear.app/rwx-cloud/issue/RWX-945/add-agent-detected-to-cli-telemetry)

Came out of a [Slack discussion](https://rwxhq.slack.com/archives/C044VB13K6G/p1780331859800649?thread_ts=1780327332.203589&cid=C044VB13K6G) about understanding how agents consume the RWX CLI. We'd previously punted on agent detection because there's a long tail of env vars and no reliable way to be 100% sure you're in an agentic session (the hope being a `CI=true`-style standard would emerge). The conclusion was that some data beats no data.

Blocked by https://github.com/rwx-cloud/cloud/pull/7620

### Problem

CLI telemetry has no signal for whether a command was run inside a coding agent's subprocess. We can't tell what fraction of CLI usage is agent-driven, or which agents.

### Solution

Detect the coding-agent environment from env vars and stamp it onto every telemetry event.

- Added `detectAgent()` in `internal/telemetry/agent.go` with an ordered, additive table covering Claude Code (`CLAUDECODE`/`CLAUDE_CODE`), Cursor (`CURSOR_AGENT`), Codex (`CODEX_SANDBOX`/`CODEX_CI`), Gemini CLI (`GEMINI_CLI`), Copilot CLI (`COPILOT_CLI`), and a generic `AI_AGENT` catch-all.
- Detection is **presence + non-falsy value** (any value other than `""`/`0`/`false`). This is more robust than strict `=1`/`=true` matching: Codex sets `CODEX_SANDBOX=seatbelt`.
- Lives on the **event envelope** (`agent`, `json:"agent,omitempty"`), next to `os`/`arch`, since it's process-constant. `Collector` detects once in `NewCollector()` and stamps every event (`cli.command`, `cli.error`, `api.summary`, `lsp.node_check`) — no per-call-site threading.
- **Precedence:** specific agents win over the generic `AI_AGENT`. First match wins.

Tradeoffs / notes:
- Used the field name `agent` (the detected name, omitted when none) rather than a bare `agent_detected` boolean — detection is derivable from presence, and the name is more useful for grouping in dashboards.
- Deliberately does not fall back to `CI`. We already have a proxy for CI (use of the default `RWX_ACCESS_TOKEN`), and classifying CI as an "agent" risks breaking that signal. The one case we lose is a user running a PAT in CI, which is minor today.
