### PR TITLE
Restore deprecated download flags and CI telemetry detection

### DIFF
--- a/cmd/rwx/artifacts/download.go
+++ b/cmd/rwx/artifacts/download.go
@@ -61,13 +61,20 @@ func InitDownload(requireAccessToken func() error, getService func() cli.Service
 			taskKeySet := cmd.Flags().Changed("task")
 			svc := getService()
 
-			outputSet := cmd.Flags().Changed("output")
+			outputSet, outputFileSet, err := downloadOutputFlagSet(cmd)
+			if err != nil {
+				return err
+			}
 
 			if taskKeySet {
-				return runDownloadWithTaskKey(svc, args, outputSet, useJsonOutput())
+				return runDownloadWithTaskKey(svc, args, outputSet, outputFileSet, useJsonOutput())
 			}
 
 			taskID := args[0]
+
+			if downloadAll && outputFileSet {
+				return errors.New("--output-file cannot be used with --all")
+			}
 
 			absOutput, err := cli.ResolveDownloadOutput(downloadOutput, outputSet)
 			if err != nil {
@@ -106,18 +113,52 @@ func InitDownload(requireAccessToken func() error, getService func() cli.Service
 	}
 
 	DownloadCmd.Flags().StringVar(&downloadOutput, "output", "", "output path for the downloaded artifact")
+	DownloadCmd.Flags().StringVar(&downloadOutput, "output-dir", "", "output path for the downloaded artifact")
+	if err := DownloadCmd.Flags().MarkDeprecated("output-dir", "use --output instead"); err != nil {
+		panic(err)
+	}
+	DownloadCmd.Flags().StringVar(&downloadOutput, "output-file", "", "output path for the downloaded artifact")
+	if err := DownloadCmd.Flags().MarkDeprecated("output-file", "use --output instead"); err != nil {
+		panic(err)
+	}
 	DownloadCmd.Flags().BoolVar(&downloadAutoExtract, "auto-extract", false, "automatically extract directory tar archives")
 	DownloadCmd.Flags().BoolVar(&downloadOpen, "open", false, "automatically open the downloaded file(s)")
 	DownloadCmd.Flags().BoolVar(&downloadAll, "all", false, "download all artifacts for the task")
 	DownloadCmd.Flags().StringVar(&downloadTaskKey, "task", "", "task key (e.g., ci.checks.lint); resolves the task by key instead of ID")
 }
 
-func runDownloadWithTaskKey(svc cli.Service, args []string, outputSet bool, useJson bool) error {
+func downloadOutputFlagSet(cmd *cobra.Command) (outputSet bool, outputFileSet bool, err error) {
+	outputSet = cmd.Flags().Changed("output")
+	outputDirSet := cmd.Flags().Changed("output-dir")
+	outputFileSet = cmd.Flags().Changed("output-file")
+
+	if boolCount(outputSet, outputDirSet, outputFileSet) > 1 {
+		return false, false, errors.New("--output, --output-dir, and --output-file cannot be used together")
+	}
+
+	return outputSet || outputDirSet || outputFileSet, outputFileSet, nil
+}
+
+func boolCount(values ...bool) int {
+	count := 0
+	for _, value := range values {
+		if value {
+			count++
+		}
+	}
+	return count
+}
+
+func runDownloadWithTaskKey(svc cli.Service, args []string, outputSet bool, outputFileSet bool, useJson bool) error {
 	var runID string
 	var artifactKey string
 	var err error
 
 	if downloadAll {
+		if outputFileSet {
+			return errors.New("--output-file cannot be used with --all")
+		}
+
 		if len(args) > 0 {
 			runID = args[0]
 		} else {

--- a/cmd/rwx/artifacts/download_test.go
+++ b/cmd/rwx/artifacts/download_test.go
@@ -1,14 +1,16 @@
-package main
+package artifacts
 
 import (
 	"testing"
 
+	"github.com/rwx-cloud/rwx/internal/cli"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
-func TestLogsOutputFlagSurface(t *testing.T) {
-	flags := logsCmd.Flags()
+func TestDownloadOutputFlagSurface(t *testing.T) {
+	InitDownload(func() error { return nil }, func() cli.Service { return cli.Service{} }, func() bool { return false })
+	flags := DownloadCmd.Flags()
 
 	require.NotNil(t, flags.Lookup("output"))
 
@@ -21,46 +23,43 @@ func TestLogsOutputFlagSurface(t *testing.T) {
 	require.NotNil(t, outputFileFlag)
 	require.True(t, outputFileFlag.Hidden)
 	require.NotEmpty(t, outputFileFlag.Deprecated)
-
-	autoExtractFlag := flags.Lookup("auto-extract")
-	require.NotNil(t, autoExtractFlag)
-	require.True(t, autoExtractFlag.Hidden)
-	require.NotEmpty(t, autoExtractFlag.Deprecated)
 }
 
-func TestLogsOutputFlagSet(t *testing.T) {
+func TestDownloadOutputFlagSet(t *testing.T) {
 	t.Run("output is explicit when output-dir is set", func(t *testing.T) {
-		cmd := newLogsOutputFlagTestCommand(t)
+		cmd := newDownloadOutputFlagTestCommand(t)
 
-		require.NoError(t, cmd.Flags().Set("output-dir", "logs"))
+		require.NoError(t, cmd.Flags().Set("output-dir", "artifacts"))
 
-		outputSet, err := logsOutputFlagSet(cmd)
+		outputSet, outputFileSet, err := downloadOutputFlagSet(cmd)
 		require.NoError(t, err)
 		require.True(t, outputSet)
+		require.False(t, outputFileSet)
 	})
 
 	t.Run("output is explicit when output-file is set", func(t *testing.T) {
-		cmd := newLogsOutputFlagTestCommand(t)
+		cmd := newDownloadOutputFlagTestCommand(t)
 
-		require.NoError(t, cmd.Flags().Set("output-file", "logs.zip"))
+		require.NoError(t, cmd.Flags().Set("output-file", "artifact.tar"))
 
-		outputSet, err := logsOutputFlagSet(cmd)
+		outputSet, outputFileSet, err := downloadOutputFlagSet(cmd)
 		require.NoError(t, err)
 		require.True(t, outputSet)
+		require.True(t, outputFileSet)
 	})
 
 	t.Run("output flags are mutually exclusive", func(t *testing.T) {
-		cmd := newLogsOutputFlagTestCommand(t)
+		cmd := newDownloadOutputFlagTestCommand(t)
 
-		require.NoError(t, cmd.Flags().Set("output", "logs"))
-		require.NoError(t, cmd.Flags().Set("output-dir", "legacy-logs"))
+		require.NoError(t, cmd.Flags().Set("output", "artifacts"))
+		require.NoError(t, cmd.Flags().Set("output-file", "artifact.tar"))
 
-		_, err := logsOutputFlagSet(cmd)
+		_, _, err := downloadOutputFlagSet(cmd)
 		require.EqualError(t, err, "--output, --output-dir, and --output-file cannot be used together")
 	})
 }
 
-func newLogsOutputFlagTestCommand(t *testing.T) *cobra.Command {
+func newDownloadOutputFlagTestCommand(t *testing.T) *cobra.Command {
 	t.Helper()
 
 	cmd := &cobra.Command{}

--- a/cmd/rwx/logs.go
+++ b/cmd/rwx/logs.go
@@ -36,8 +36,10 @@ var (
 				}
 			}
 
-			outputSet := cmd.Flags().Changed("output")
-			var err error
+			outputSet, err := logsOutputFlagSet(cmd)
+			if err != nil {
+				return err
+			}
 
 			absOutput, err := cli.ResolveDownloadOutput(LogsOutput, outputSet)
 			if err != nil {
@@ -85,13 +87,43 @@ var (
 
 func init() {
 	logsCmd.Flags().StringVar(&LogsOutput, "output", "", "output path for the downloaded logs")
+	logsCmd.Flags().StringVar(&LogsOutput, "output-dir", "", "output path for the downloaded logs")
+	if err := logsCmd.Flags().MarkDeprecated("output-dir", "use --output instead"); err != nil {
+		panic(err)
+	}
+	logsCmd.Flags().StringVar(&LogsOutput, "output-file", "", "output path for the downloaded logs")
+	if err := logsCmd.Flags().MarkDeprecated("output-file", "use --output instead"); err != nil {
+		panic(err)
+	}
 	logsCmd.Flags().BoolVar(&LogsAutoExtract, "auto-extract", false, "automatically extract zip archives")
-	if err := logsCmd.Flags().MarkHidden("auto-extract"); err != nil {
+	if err := logsCmd.Flags().MarkDeprecated("auto-extract", "logs are extracted by default; use --zip to save the raw archive"); err != nil {
 		panic(err)
 	}
 	logsCmd.Flags().BoolVar(&LogsZip, "zip", false, "skip extraction and save raw zip archive")
 	logsCmd.Flags().BoolVar(&LogsOpen, "open", false, "automatically open the downloaded file(s)")
 	logsCmd.Flags().StringVar(&LogsTaskKey, "task", "", "task key (e.g., ci.checks.lint); resolves the task by key instead of ID")
+}
+
+func logsOutputFlagSet(cmd *cobra.Command) (bool, error) {
+	outputSet := cmd.Flags().Changed("output")
+	outputDirSet := cmd.Flags().Changed("output-dir")
+	outputFileSet := cmd.Flags().Changed("output-file")
+
+	if boolCount(outputSet, outputDirSet, outputFileSet) > 1 {
+		return false, errors.New("--output, --output-dir, and --output-file cannot be used together")
+	}
+
+	return outputSet || outputDirSet || outputFileSet, nil
+}
+
+func boolCount(values ...bool) int {
+	count := 0
+	for _, value := range values {
+		if value {
+			count++
+		}
+	}
+	return count
 }
 
 // handleTaskKeyError formats task-key-specific errors for user display.

--- a/internal/telemetry/agent.go
+++ b/internal/telemetry/agent.go
@@ -27,6 +27,25 @@ var agentEnvVars = []struct {
 	{"agent", []string{"AI_AGENT"}},
 }
 
+// ciEnvVars maps CI systems to environment variables whose presence signals
+// them. Order matters: provider-specific signals win over the generic CI=true
+// convention.
+var ciEnvVars = []struct {
+	ci      string
+	envVars []string
+}{
+	{"github_actions", []string{"GITHUB_ACTIONS"}},
+	{"gitlab_ci", []string{"GITLAB_CI"}},
+	{"circleci", []string{"CIRCLECI"}},
+	{"buildkite", []string{"BUILDKITE"}},
+	{"jenkins", []string{"JENKINS_URL", "JENKINS_HOME"}},
+	{"travis_ci", []string{"TRAVIS"}},
+	{"azure_pipelines", []string{"TF_BUILD"}},
+	{"bitbucket_pipelines", []string{"BITBUCKET_BUILD_NUMBER"}},
+	{"teamcity", []string{"TEAMCITY_VERSION"}},
+	{"ci", []string{"CI"}},
+}
+
 // detectAgent returns the name of the coding agent the CLI appears to be
 // running inside, or "" when none is detected.
 func detectAgent() string {
@@ -34,6 +53,19 @@ func detectAgent() string {
 		for _, v := range e.envVars {
 			if envSet(v) {
 				return e.agent
+			}
+		}
+	}
+	return ""
+}
+
+// detectCI returns the name of the CI environment the CLI appears to be
+// running inside, or "" when none is detected.
+func detectCI() string {
+	for _, e := range ciEnvVars {
+		for _, v := range e.envVars {
+			if envSet(v) {
+				return e.ci
 			}
 		}
 	}

--- a/internal/telemetry/agent.go
+++ b/internal/telemetry/agent.go
@@ -43,6 +43,7 @@ var ciEnvVars = []struct {
 	{"azure_pipelines", []string{"TF_BUILD"}},
 	{"bitbucket_pipelines", []string{"BITBUCKET_BUILD_NUMBER"}},
 	{"teamcity", []string{"TEAMCITY_VERSION"}},
+	{"rwx", []string{"RWX"}},
 	{"ci", []string{"CI"}},
 }
 

--- a/internal/telemetry/agent_test.go
+++ b/internal/telemetry/agent_test.go
@@ -84,11 +84,24 @@ func TestDetectCI(t *testing.T) {
 		require.Equal(t, "github_actions", detectCI())
 	})
 
+	t.Run("rwx", func(t *testing.T) {
+		clearCIEnv(t)
+		t.Setenv("RWX", "true")
+		require.Equal(t, "rwx", detectCI())
+	})
+
 	t.Run("specific CI wins over generic", func(t *testing.T) {
 		clearCIEnv(t)
 		t.Setenv("CI", "1")
 		t.Setenv("BUILDKITE", "true")
 		require.Equal(t, "buildkite", detectCI())
+	})
+
+	t.Run("rwx wins over generic", func(t *testing.T) {
+		clearCIEnv(t)
+		t.Setenv("CI", "1")
+		t.Setenv("RWX", "true")
+		require.Equal(t, "rwx", detectCI())
 	})
 
 	t.Run("falsy values are not detected", func(t *testing.T) {

--- a/internal/telemetry/agent_test.go
+++ b/internal/telemetry/agent_test.go
@@ -17,6 +17,17 @@ func clearAgentEnv(t *testing.T) {
 	}
 }
 
+// clearCIEnv unsets every env var that detectCI inspects so a test starts
+// from a known-empty environment. t.Setenv restores prior values on cleanup.
+func clearCIEnv(t *testing.T) {
+	t.Helper()
+	for _, e := range ciEnvVars {
+		for _, v := range e.envVars {
+			t.Setenv(v, "")
+		}
+	}
+}
+
 func TestDetectAgent(t *testing.T) {
 	t.Run("none detected", func(t *testing.T) {
 		clearAgentEnv(t)
@@ -52,5 +63,37 @@ func TestDetectAgent(t *testing.T) {
 		clearAgentEnv(t)
 		t.Setenv("AI_AGENT", "false")
 		require.Equal(t, "", detectAgent())
+	})
+}
+
+func TestDetectCI(t *testing.T) {
+	t.Run("none detected", func(t *testing.T) {
+		clearCIEnv(t)
+		require.Equal(t, "", detectCI())
+	})
+
+	t.Run("generic CI", func(t *testing.T) {
+		clearCIEnv(t)
+		t.Setenv("CI", "true")
+		require.Equal(t, "ci", detectCI())
+	})
+
+	t.Run("github actions", func(t *testing.T) {
+		clearCIEnv(t)
+		t.Setenv("GITHUB_ACTIONS", "true")
+		require.Equal(t, "github_actions", detectCI())
+	})
+
+	t.Run("specific CI wins over generic", func(t *testing.T) {
+		clearCIEnv(t)
+		t.Setenv("CI", "1")
+		t.Setenv("BUILDKITE", "true")
+		require.Equal(t, "buildkite", detectCI())
+	})
+
+	t.Run("falsy values are not detected", func(t *testing.T) {
+		clearCIEnv(t)
+		t.Setenv("CI", "false")
+		require.Equal(t, "", detectCI())
 	})
 }

--- a/internal/telemetry/collector.go
+++ b/internal/telemetry/collector.go
@@ -13,6 +13,7 @@ type Event struct {
 	OS        string         `json:"os"`
 	Arch      string         `json:"arch"`
 	Agent     string         `json:"agent,omitempty"`
+	CI        string         `json:"ci,omitempty"`
 	Props     map[string]any `json:"props,omitempty"`
 }
 
@@ -23,11 +24,14 @@ type Collector struct {
 	// agent is the coding agent detected from the environment at construction,
 	// stamped onto every event's envelope. Empty when no agent is detected.
 	agent string
+	// ci is the CI environment detected from the environment at construction,
+	// stamped onto every event's envelope. Empty when no CI is detected.
+	ci string
 }
 
 // NewCollector creates a Collector.
 func NewCollector() *Collector {
-	return &Collector{agent: detectAgent()}
+	return &Collector{agent: detectAgent(), ci: detectCI()}
 }
 
 // Record enqueues a telemetry event.
@@ -38,6 +42,7 @@ func (c *Collector) Record(event string, props map[string]any) {
 		OS:        runtime.GOOS,
 		Arch:      runtime.GOARCH,
 		Agent:     c.agent,
+		CI:        c.ci,
 		Props:     props,
 	}
 

--- a/internal/telemetry/collector_test.go
+++ b/internal/telemetry/collector_test.go
@@ -22,6 +22,7 @@ func TestCollector_Record_WhenEnabled(t *testing.T) {
 
 func TestCollector_Record_StampsAgent(t *testing.T) {
 	clearAgentEnv(t)
+	clearCIEnv(t)
 	t.Setenv("CLAUDECODE", "1")
 
 	c := NewCollector()
@@ -34,6 +35,7 @@ func TestCollector_Record_StampsAgent(t *testing.T) {
 
 func TestCollector_Record_OmitsAgentWhenNoneDetected(t *testing.T) {
 	clearAgentEnv(t)
+	clearCIEnv(t)
 
 	c := NewCollector()
 	c.Record("test_event", nil)
@@ -41,6 +43,31 @@ func TestCollector_Record_OmitsAgentWhenNoneDetected(t *testing.T) {
 	events := c.Drain()
 	require.Len(t, events, 1)
 	require.Empty(t, events[0].Agent)
+}
+
+func TestCollector_Record_StampsCI(t *testing.T) {
+	clearAgentEnv(t)
+	clearCIEnv(t)
+	t.Setenv("GITHUB_ACTIONS", "true")
+
+	c := NewCollector()
+	c.Record("test_event", nil)
+
+	events := c.Drain()
+	require.Len(t, events, 1)
+	require.Equal(t, "github_actions", events[0].CI)
+}
+
+func TestCollector_Record_OmitsCIWhenNoneDetected(t *testing.T) {
+	clearAgentEnv(t)
+	clearCIEnv(t)
+
+	c := NewCollector()
+	c.Record("test_event", nil)
+
+	events := c.Drain()
+	require.Len(t, events, 1)
+	require.Empty(t, events[0].CI)
 }
 
 func TestCollector_Drain_ClearsQueue(t *testing.T) {


### PR DESCRIPTION

## Summary

- Restore the legacy `--output-dir` and `--output-file` download flags as hidden deprecated aliases for `--output`.
- Emit deprecation warnings for `rwx logs --auto-extract`, `--output-dir`, and `--output-file` while keeping the compatibility paths working.
- Add CI environment detection to telemetry event envelopes, alongside the existing coding-agent detection.

## Details

For `rwx logs` and `rwx artifacts download`, the legacy output flags now write into the same backing value as `--output`. The commands treat any of the three output flags as an explicit output path and reject ambiguous combinations like `--output` plus `--output-dir`.

`rwx artifacts download --all --output-file` still fails because a single file output path is not valid for multi-artifact downloads.

Telemetry now detects common CI providers from environment variables, including RWX via `RWX`. Provider-specific signals win over the generic `CI` fallback. The detected value is stamped as `ci` on each telemetry event envelope.
