### PR TITLE
Start sandbox runs with untracked patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.direnv
 /.language-server
 /rwx
+/.rwx/sandboxes/*.lock

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -75,6 +75,7 @@ type GitClient interface {
 	GetCommit() (string, error)
 	GetOriginUrl() string
 	GeneratePatchFile(destDir string, pathspec []string) (git.PatchFile, error)
+	GeneratePatchFileIncludingUntracked(destDir string, pathspec []string) (git.PatchFile, error)
 	GeneratePatch(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error)
 	GenerateDirtyPatches() (git.DirtyPatches, error)
 	HasCommit(sha string) bool

--- a/internal/cli/sandbox_storage.go
+++ b/internal/cli/sandbox_storage.go
@@ -125,6 +125,7 @@ func LockSandboxStorage() (*SandboxStorageLock, error) {
 	if err := os.MkdirAll(filepath.Dir(lockPath), os.ModePerm); err != nil {
 		return nil, err
 	}
+	ensureSandboxesDirGitignore(filepath.Dir(lockPath))
 
 	lock := &SandboxStorageLock{flock: flock.New(lockPath)}
 	if err := lock.flock.Lock(); err != nil {
@@ -146,6 +147,7 @@ func TryLockSandboxStorage() (*SandboxStorageLock, error) {
 	if err := os.MkdirAll(filepath.Dir(lockPath), os.ModePerm); err != nil {
 		return nil, err
 	}
+	ensureSandboxesDirGitignore(filepath.Dir(lockPath))
 
 	lock := &SandboxStorageLock{flock: flock.New(lockPath)}
 	locked, err := lock.flock.TryLock()

--- a/internal/cli/sandbox_storage_test.go
+++ b/internal/cli/sandbox_storage_test.go
@@ -342,6 +342,19 @@ func TestSandboxStorage_LoadAndSave(t *testing.T) {
 		require.Equal(t, "*\n", string(contents))
 	})
 
+	t.Run("creates .gitignore before locking storage", func(t *testing.T) {
+		tmpDir := setupTestStorageDir(t)
+
+		lock, err := cli.LockSandboxStorage()
+		require.NoError(t, err)
+		defer cli.UnlockSandboxStorage(lock)
+
+		gitignorePath := filepath.Join(tmpDir, ".rwx", "sandboxes", ".gitignore")
+		contents, err := os.ReadFile(gitignorePath)
+		require.NoError(t, err)
+		require.Equal(t, "*\n", string(contents))
+	})
+
 	t.Run("creates directory structure if it does not exist", func(t *testing.T) {
 		tmpDir := setupTestStorageDir(t)
 

--- a/internal/cli/service_run.go
+++ b/internal/cli/service_run.go
@@ -112,77 +112,164 @@ func (c InitiateRunConfig) Validate() error {
 	return nil
 }
 
-// InitiateRun will connect to the Cloud API and start a new run in Mint.
-func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, error) {
-	err := cfg.Validate()
-	if err != nil {
-		return nil, errors.Wrap(err, "validation failed")
+type runGitMetadata struct {
+	installed    bool
+	directory    bool
+	available    bool
+	errorMessage string
+	sha          string
+	branch       string
+	originURL    string
+}
+
+func (s Service) runGitMetadata() runGitMetadata {
+	metadata := runGitMetadata{
+		installed: s.GitClient.IsInstalled(),
+		directory: s.GitClient.IsInsideWorkTree(),
+	}
+	metadata.available = metadata.installed && metadata.directory
+
+	if metadata.available {
+		sha, err := s.GitClient.GetCommit()
+		if err != nil {
+			metadata.errorMessage = err.Error()
+			metadata.available = false
+		} else {
+			metadata.sha = sha
+			metadata.branch = s.GitClient.GetBranch()
+			metadata.originURL = s.GitClient.GetOriginUrl()
+		}
+	} else if !metadata.installed {
+		metadata.errorMessage = "Git is not installed"
+	} else if !metadata.directory {
+		metadata.errorMessage = "You are not in a git repository"
 	}
 
-	var rwxDirectory []RwxDirectoryEntry
+	return metadata
+}
 
-	rwxDirectoryPath, err := findAndValidateRwxDirectoryPath(cfg.RwxDirectory)
+func (m runGitMetadata) apiGitMetadata() api.GitMetadata {
+	return api.GitMetadata{
+		Branch:    m.branch,
+		Sha:       m.sha,
+		OriginUrl: m.originURL,
+	}
+}
+
+func (m runGitMetadata) apiPatchMetadata(patchFile git.PatchFile) api.PatchMetadata {
+	return api.PatchMetadata{
+		Sent:           patchFile.Written,
+		UntrackedFiles: patchFile.UntrackedFiles.Files,
+		UntrackedCount: patchFile.UntrackedFiles.Count,
+		LFSFiles:       patchFile.LFSChangedFiles.Files,
+		LFSCount:       patchFile.LFSChangedFiles.Count,
+		ErrorMessage:   m.errorMessage,
+		GitDirectory:   m.directory,
+		GitInstalled:   m.installed,
+	}
+}
+
+type runDefinitionPaths struct {
+	rwxDirectoryPath          string
+	runDefinitionPath         string
+	relativeRunDefinitionPath string
+	tempRwxDir                string
+}
+
+func resolveRunDefinitionPaths(rwxDirectory, mintFilePath string) (runDefinitionPaths, func(), error) {
+	rwxDirectoryPath, err := findAndValidateRwxDirectoryPath(rwxDirectory)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to find .rwx directory")
+		return runDefinitionPaths{}, func() {}, errors.Wrap(err, "unable to find .rwx directory")
 	}
 
-	runDefinitionPath, err := FindRunDefinitionFile(cfg.MintFilePath, rwxDirectoryPath)
+	runDefinitionPath, err := FindRunDefinitionFile(mintFilePath, rwxDirectoryPath)
 	if err != nil {
+		return runDefinitionPaths{}, func() {}, err
+	}
+
+	paths := runDefinitionPaths{
+		rwxDirectoryPath:          rwxDirectoryPath,
+		runDefinitionPath:         runDefinitionPath,
+		relativeRunDefinitionPath: relativePathFromWd(runDefinitionPath),
+	}
+
+	if paths.rwxDirectoryPath == "" {
+		tempRwxDir, err := os.MkdirTemp("", ".rwx-*")
+		if err != nil {
+			return runDefinitionPaths{}, func() {}, errors.Wrap(err, "unable to create temporary .rwx directory")
+		}
+		paths.rwxDirectoryPath = tempRwxDir
+		paths.tempRwxDir = tempRwxDir
+		return paths, func() { os.RemoveAll(tempRwxDir) }, nil
+	}
+
+	return paths, func() {}, nil
+}
+
+type runDefinitionUpload struct {
+	paths         runDefinitionPaths
+	rwxDirectory  []RwxDirectoryEntry
+	runDefinition []RwxDirectoryEntry
+}
+
+func loadRunDefinitionUpload(paths runDefinitionPaths, requestedRwxDirectory string) (*runDefinitionUpload, error) {
+	upload := &runDefinitionUpload{paths: paths}
+	if err := upload.load(requestedRwxDirectory); err != nil {
 		return nil, err
 	}
+	return upload, nil
+}
 
-	gitInstalled := s.GitClient.IsInstalled()
-	gitDirectory := s.GitClient.IsInsideWorkTree()
-	var errorMessage string
-	var sha, branch, originUrl string
-
-	// Track whether we can generate patches (requires working git)
-	gitAvailable := gitInstalled && gitDirectory
-
-	if gitAvailable {
-		var err error
-		sha, err = s.GitClient.GetCommit()
-		if err != nil {
-			errorMessage = err.Error()
-			gitAvailable = false
-		} else {
-			branch = s.GitClient.GetBranch()
-			originUrl = s.GitClient.GetOriginUrl()
+func (u *runDefinitionUpload) load(requestedRwxDirectory string) error {
+	entries, err := rwxDirectoryEntries(u.paths.rwxDirectoryPath)
+	if err != nil {
+		if errors.Is(err, errors.ErrFileNotExists) && u.paths.tempRwxDir == "" {
+			return fmt.Errorf("You specified --dir %q, but %q could not be found", requestedRwxDirectory, requestedRwxDirectory)
 		}
-	} else if !gitInstalled {
-		errorMessage = "Git is not installed"
-	} else if !gitDirectory {
-		errorMessage = "You are not in a git repository"
+
+		return errors.Wrapf(err, "unable to load directory %q", u.paths.rwxDirectoryPath)
 	}
+	u.rwxDirectory = entries
 
-	patchFile := git.PatchFile{}
-
-	// When there's no .rwx directory, create a temporary one for patches and to set run.dir
-	var tempRwxDir string
-	if rwxDirectoryPath == "" {
-		tempRwxDir, err = os.MkdirTemp("", ".rwx-*")
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to create temporary .rwx directory")
-		}
-		defer os.RemoveAll(tempRwxDir)
-		rwxDirectoryPath = tempRwxDir
+	runDefinition, err := rwxDirectoryEntriesFromPaths([]string{u.paths.relativeRunDefinitionPath})
+	if err != nil {
+		return errors.Wrap(err, "unable to read provided files")
 	}
-
-	patchDir := filepath.Join(rwxDirectoryPath, ".patches")
-	defer os.RemoveAll(patchDir)
-
-	// Generate patches if enabled and git is available
-	patchable := cfg.Patchable && gitAvailable
-	if _, ok := os.LookupEnv("RWX_DISABLE_GIT_PATCH"); ok {
-		patchable = false
+	runDefinition = filterFiles(runDefinition)
+	if len(runDefinition) != 1 {
+		return fmt.Errorf("expected exactly 1 run definition, got %d", len(runDefinition))
 	}
+	u.runDefinition = runDefinition
 
-	// Convert to relative path for display purposes (e.g., run title)
-	relativeRunDefinitionPath := relativePathFromWd(runDefinitionPath)
+	return nil
+}
 
+func (u *runDefinitionUpload) reload() error {
+	runDefinition, err := rwxDirectoryEntriesFromPaths([]string{u.paths.relativeRunDefinitionPath})
+	if err != nil {
+		return errors.Wrapf(err, "unable to reload %q", u.paths.relativeRunDefinitionPath)
+	}
+	u.runDefinition = filterFiles(runDefinition)
+
+	rwxDirectory, err := rwxDirectoryEntries(u.paths.rwxDirectoryPath)
+	if err != nil && !errors.Is(err, errors.ErrFileNotExists) {
+		return errors.Wrapf(err, "unable to reload rwx directory %q", u.paths.rwxDirectoryPath)
+	}
+	u.rwxDirectory = rwxDirectory
+
+	return nil
+}
+
+func (u *runDefinitionUpload) appendRunDefinitionOutsideRwxDir() {
+	if outside, err := runDefinitionOutsideRwxDir(u.paths.runDefinitionPath, u.paths.rwxDirectoryPath); err == nil && outside {
+		u.rwxDirectory = appendWorkflowUploadEntry(u.rwxDirectory, u.runDefinition[0])
+	}
+}
+
+func (s Service) cliInitParamsOverrideGitParams(relativeRunDefinitionPath string, initParams map[string]string) (bool, error) {
 	resolveResult, err := ResolveCliParamsForFile(relativeRunDefinitionPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to resolve CLI init params")
+		return false, errors.Wrap(err, "unable to resolve CLI init params")
 	}
 
 	if resolveResult.Rewritten {
@@ -190,56 +277,126 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 	}
 
 	for _, gitParam := range resolveResult.GitParams {
-		if _, exists := cfg.InitParameters[gitParam]; exists {
-			patchable = false
-			break
+		if _, exists := initParams[gitParam]; exists {
+			return true, nil
 		}
+	}
+
+	return false, nil
+}
+
+func (s Service) configureRunDefinitionUpload(upload *runDefinitionUpload) error {
+	addBaseIfNeeded, err := s.insertDefaultBaseIfMissing(upload.runDefinition)
+	if err != nil {
+		return errors.Wrap(err, "unable to resolve base")
+	}
+
+	if len(addBaseIfNeeded.UpdatedRunFiles) > 0 {
+		update := addBaseIfNeeded.UpdatedRunFiles[0]
+		fmt.Fprintf(s.Stderr, "Configured %q to run on %s\n\n", update.OriginalPath, update.ResolvedBase.Image)
+
+		if err = upload.reload(); err != nil {
+			return err
+		}
+	}
+
+	if len(addBaseIfNeeded.ErroredRunFiles) > 0 {
+		for _, erroredFile := range addBaseIfNeeded.ErroredRunFiles {
+			fmt.Fprintf(s.Stderr, "Failed to configure base for %q: %v\n", erroredFile.OriginalPath, erroredFile.Error)
+		}
+	}
+
+	mintFiles := filterYAMLFilesForModification(upload.runDefinition, func(doc *YAMLDoc) bool {
+		return true
+	})
+	resolvedPackages, err := s.resolveOrUpdatePackagesForFiles(mintFiles, false, PickLatestMajorVersion)
+	if err != nil {
+		return err
+	}
+	if len(resolvedPackages) > 0 {
+		for rwxPackage, version := range resolvedPackages {
+			fmt.Fprintf(s.Stderr, "Configured package %s to use version %s\n", rwxPackage, version)
+		}
+		fmt.Fprintln(s.Stderr, "")
+
+		if err = upload.reload(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func initializationParametersFromMap(params map[string]string) []api.InitializationParameter {
+	initializationParameters := make([]api.InitializationParameter, 0, len(params))
+	for key, value := range params {
+		initializationParameters = append(initializationParameters, api.InitializationParameter{
+			Key:   key,
+			Value: value,
+		})
+	}
+	return initializationParameters
+}
+
+func (s Service) callInitiateRun(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+	initiateStart := time.Now()
+	runResult, err := s.APIClient.InitiateRun(cfg)
+
+	s.recordTelemetry("run.initiate", map[string]any{
+		"has_targets":     len(cfg.TargetedTaskKeys) > 0,
+		"has_init_params": len(cfg.InitializationParameters) > 0,
+		"duration_ms":     time.Since(initiateStart).Milliseconds(),
+		"success":         err == nil,
+	})
+
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to initiate run")
+	}
+
+	return runResult, nil
+}
+
+// InitiateRun will connect to the Cloud API and start a new run in Mint.
+func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Wrap(err, "validation failed")
+	}
+
+	paths, cleanupPaths, err := resolveRunDefinitionPaths(cfg.RwxDirectory, cfg.MintFilePath)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanupPaths()
+
+	gitMetadata := s.runGitMetadata()
+	patchFile := git.PatchFile{}
+	patchDir := filepath.Join(paths.rwxDirectoryPath, ".patches")
+	defer os.RemoveAll(patchDir)
+
+	patchable := cfg.Patchable && gitMetadata.available
+	if _, ok := os.LookupEnv("RWX_DISABLE_GIT_PATCH"); ok {
+		patchable = false
+	}
+
+	if overridesGitParams, err := s.cliInitParamsOverrideGitParams(paths.relativeRunDefinitionPath, cfg.InitParameters); err != nil {
+		return nil, err
+	} else if overridesGitParams {
+		patchable = false
 	}
 
 	if patchable {
-		var patchErr error
-		patchFile, patchErr = s.GitClient.GeneratePatchFile(patchDir, []string{".", ":!" + relativeRunDefinitionPath})
-		if patchErr != nil {
-			errorMessage = patchErr.Error()
-			fmt.Fprintf(s.Stderr, "Warning: failed to generate patch: %s\n\n", errorMessage)
+		patchPathspec := []string{".", ":!" + paths.relativeRunDefinitionPath}
+		if generatedPatch, patchErr := s.GitClient.GeneratePatchFile(patchDir, patchPathspec); patchErr != nil {
+			gitMetadata.errorMessage = patchErr.Error()
+			fmt.Fprintf(s.Stderr, "Warning: failed to generate patch: %s\n\n", gitMetadata.errorMessage)
+		} else {
+			patchFile = generatedPatch
 		}
 	}
 
-	// Load directory entries
-	entries, err := rwxDirectoryEntries(rwxDirectoryPath)
+	upload, err := loadRunDefinitionUpload(paths, cfg.RwxDirectory)
 	if err != nil {
-		if errors.Is(err, errors.ErrFileNotExists) && tempRwxDir == "" {
-			// User explicitly specified a directory that doesn't exist
-			return nil, fmt.Errorf("You specified --dir %q, but %q could not be found", cfg.RwxDirectory, cfg.RwxDirectory)
-		}
-
-		return nil, errors.Wrapf(err, "unable to load directory %q", rwxDirectoryPath)
-	}
-
-	rwxDirectory = entries
-
-	runDefinition, err := rwxDirectoryEntriesFromPaths([]string{relativeRunDefinitionPath})
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to read provided files")
-	}
-	runDefinition = filterFiles(runDefinition)
-	if len(runDefinition) != 1 {
-		return nil, fmt.Errorf("expected exactly 1 run definition, got %d", len(runDefinition))
-	}
-
-	// reloadRunDefinitions reloads run definitions after modifying the file.
-	reloadRunDefinitions := func() error {
-		runDefinition, err = rwxDirectoryEntriesFromPaths([]string{relativeRunDefinitionPath})
-		if err != nil {
-			return errors.Wrapf(err, "unable to reload %q", relativeRunDefinitionPath)
-		}
-		rwxDirectoryEntries, err := rwxDirectoryEntries(rwxDirectoryPath)
-		if err != nil && !errors.Is(err, errors.ErrFileNotExists) {
-			return errors.Wrapf(err, "unable to reload rwx directory %q", rwxDirectoryPath)
-		}
-
-		rwxDirectory = rwxDirectoryEntries
-		return nil
+		return nil, err
 	}
 
 	if patchFile.Written {
@@ -265,94 +422,21 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 		fmt.Fprintln(s.Stderr, "")
 	}
 
-	addBaseIfNeeded, err := s.insertDefaultBaseIfMissing(runDefinition)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to resolve base")
-	}
-
-	if len(addBaseIfNeeded.UpdatedRunFiles) > 0 {
-		update := addBaseIfNeeded.UpdatedRunFiles[0]
-		fmt.Fprintf(s.Stderr, "Configured %q to run on %s\n\n", update.OriginalPath, update.ResolvedBase.Image)
-
-		if err = reloadRunDefinitions(); err != nil {
-			return nil, err
-		}
-	}
-
-	if len(addBaseIfNeeded.ErroredRunFiles) > 0 {
-		for _, erroredFile := range addBaseIfNeeded.ErroredRunFiles {
-			fmt.Fprintf(s.Stderr, "Failed to configure base for %q: %v\n", erroredFile.OriginalPath, erroredFile.Error)
-		}
-	}
-
-	mintFiles := filterYAMLFilesForModification(runDefinition, func(doc *YAMLDoc) bool {
-		return true
-	})
-	resolvedPackages, err := s.resolveOrUpdatePackagesForFiles(mintFiles, false, PickLatestMajorVersion)
-	if err != nil {
+	if err := s.configureRunDefinitionUpload(upload); err != nil {
 		return nil, err
 	}
-	if len(resolvedPackages) > 0 {
-		for rwxPackage, version := range resolvedPackages {
-			fmt.Fprintf(s.Stderr, "Configured package %s to use version %s\n", rwxPackage, version)
-		}
-		fmt.Fprintln(s.Stderr, "")
 
-		if err = reloadRunDefinitions(); err != nil {
-			return nil, err
-		}
-	}
+	upload.appendRunDefinitionOutsideRwxDir()
 
-	if outside, err := runDefinitionOutsideRwxDir(runDefinitionPath, rwxDirectoryPath); err == nil && outside {
-		rwxDirectory = appendWorkflowUploadEntry(rwxDirectory, runDefinition[0])
-	}
-
-	i := 0
-	initializationParameters := make([]api.InitializationParameter, len(cfg.InitParameters))
-	for key, value := range cfg.InitParameters {
-		initializationParameters[i] = api.InitializationParameter{
-			Key:   key,
-			Value: value,
-		}
-		i++
-	}
-
-	initiateStart := time.Now()
-	runResult, err := s.APIClient.InitiateRun(api.InitiateRunConfig{
-		InitializationParameters: initializationParameters,
-		TaskDefinitions:          runDefinition,
-		RwxDirectory:             rwxDirectory,
+	return s.callInitiateRun(api.InitiateRunConfig{
+		InitializationParameters: initializationParametersFromMap(cfg.InitParameters),
+		TaskDefinitions:          upload.runDefinition,
+		RwxDirectory:             upload.rwxDirectory,
 		TargetedTaskKeys:         cfg.TargetedTasks,
 		Title:                    cfg.Title,
 		UseCache:                 !cfg.NoCache,
 		CliState:                 cfg.CliState,
-		Git: api.GitMetadata{
-			Branch:    branch,
-			Sha:       sha,
-			OriginUrl: originUrl,
-		},
-		Patch: api.PatchMetadata{
-			Sent:           patchFile.Written,
-			UntrackedFiles: patchFile.UntrackedFiles.Files,
-			UntrackedCount: patchFile.UntrackedFiles.Count,
-			LFSFiles:       patchFile.LFSChangedFiles.Files,
-			LFSCount:       patchFile.LFSChangedFiles.Count,
-			ErrorMessage:   errorMessage,
-			GitDirectory:   gitDirectory,
-			GitInstalled:   gitInstalled,
-		},
+		Git:                      gitMetadata.apiGitMetadata(),
+		Patch:                    gitMetadata.apiPatchMetadata(patchFile),
 	})
-
-	s.recordTelemetry("run.initiate", map[string]any{
-		"has_targets":     len(cfg.TargetedTasks) > 0,
-		"has_init_params": len(cfg.InitParameters) > 0,
-		"duration_ms":     time.Since(initiateStart).Milliseconds(),
-		"success":         err == nil,
-	})
-
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to initiate run")
-	}
-
-	return runResult, nil
 }

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -201,6 +201,72 @@ func (s Service) CheckExistingSandbox(configFile string) (*CheckExistingSandboxR
 	}, nil
 }
 
+func (s Service) initiateSandboxRun(cfg InitiateRunConfig) (*api.InitiateRunResult, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Wrap(err, "validation failed")
+	}
+
+	paths, cleanupPaths, err := resolveRunDefinitionPaths(cfg.RwxDirectory, cfg.MintFilePath)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanupPaths()
+
+	gitMetadata := s.runGitMetadata()
+	patchFile := git.PatchFile{}
+	patchDir := filepath.Join(paths.rwxDirectoryPath, ".patches")
+	defer os.RemoveAll(patchDir)
+
+	patchable := cfg.Patchable && gitMetadata.available
+	if _, ok := os.LookupEnv("RWX_DISABLE_GIT_PATCH"); ok {
+		patchable = false
+	}
+
+	if overridesGitParams, err := s.cliInitParamsOverrideGitParams(paths.relativeRunDefinitionPath, cfg.InitParameters); err != nil {
+		return nil, err
+	} else if overridesGitParams {
+		patchable = false
+	}
+
+	if patchable {
+		patchPathspec := []string{".", ":!" + paths.relativeRunDefinitionPath}
+		if generatedPatch, patchErr := s.GitClient.GeneratePatchFileIncludingUntracked(patchDir, patchPathspec); patchErr != nil {
+			gitMetadata.errorMessage = patchErr.Error()
+			fmt.Fprintf(s.Stderr, "Warning: failed to generate patch: %s\n\n", gitMetadata.errorMessage)
+		} else {
+			patchFile = generatedPatch
+			patchFile.UntrackedFiles = git.UntrackedFilesMetadata{}
+		}
+	}
+
+	upload, err := loadRunDefinitionUpload(paths, cfg.RwxDirectory)
+	if err != nil {
+		return nil, err
+	}
+
+	if patchFile.Written {
+		fmt.Fprintf(s.Stderr, "Included a git patch for uncommitted changes\n\n")
+	}
+
+	if err := s.configureRunDefinitionUpload(upload); err != nil {
+		return nil, err
+	}
+
+	upload.appendRunDefinitionOutsideRwxDir()
+
+	return s.callInitiateRun(api.InitiateRunConfig{
+		InitializationParameters: initializationParametersFromMap(cfg.InitParameters),
+		TaskDefinitions:          upload.runDefinition,
+		RwxDirectory:             upload.rwxDirectory,
+		TargetedTaskKeys:         cfg.TargetedTasks,
+		Title:                    cfg.Title,
+		UseCache:                 !cfg.NoCache,
+		CliState:                 cfg.CliState,
+		Git:                      gitMetadata.apiGitMetadata(),
+		Patch:                    gitMetadata.apiPatchMetadata(patchFile),
+	})
+}
+
 func (s Service) StartSandbox(cfg StartSandboxConfig) (*StartSandboxResult, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -306,7 +372,7 @@ func (s Service) StartSandbox(cfg StartSandboxConfig) (*StartSandboxResult, erro
 	// Construct a descriptive title for the sandbox run
 	title := SandboxTitle(cwd, branch, cfg.ConfigFile)
 
-	runResult, err := s.InitiateRun(InitiateRunConfig{
+	runResult, err := s.initiateSandboxRun(InitiateRunConfig{
 		MintFilePath:   cfg.ConfigFile,
 		RwxDirectory:   cfg.RwxDirectory,
 		Json:           cfg.Json,

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -22,6 +22,7 @@ const (
 	sandboxDirectiveLockReleased  = "__rwx_sandbox_lock_released__"
 	maxSandboxGitBundleBytes      = 100 * 1024 * 1024
 	warnSandboxGitBundleBytes     = 25 * 1024 * 1024
+	sandboxStoragePathspec        = "-- . ':(exclude).rwx/sandboxes' ':(exclude).mint/sandboxes'"
 )
 
 // Config types
@@ -229,7 +230,7 @@ func (s Service) initiateSandboxRun(cfg InitiateRunConfig) (*api.InitiateRunResu
 	}
 
 	if patchable {
-		patchPathspec := []string{".", ":!" + paths.relativeRunDefinitionPath}
+		patchPathspec := []string{".", ":!" + paths.relativeRunDefinitionPath, ":!.rwx/sandboxes", ":!.mint/sandboxes"}
 		if generatedPatch, patchErr := s.GitClient.GeneratePatchFileIncludingUntracked(patchDir, patchPathspec); patchErr != nil {
 			gitMetadata.errorMessage = patchErr.Error()
 			fmt.Fprintf(s.Stderr, "Warning: failed to generate patch: %s\n\n", gitMetadata.errorMessage)
@@ -1334,7 +1335,7 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 
 	// Include untracked files in the diff by adding them with intent-to-add
 	// Get untracked files, add with -N, get diff, then reset
-	lsExitCode, untrackedOutput, lsErr := s.SSHClient.ExecuteCommandWithOutput("/usr/bin/git ls-files --others --exclude-standard")
+	lsExitCode, untrackedOutput, lsErr := s.SSHClient.ExecuteCommandWithOutput("/usr/bin/git ls-files --others --exclude-standard " + sandboxStoragePathspec)
 	if lsErr != nil {
 		_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 		return nil, 0, errors.Wrap(lsErr, "failed to list untracked files in sandbox")
@@ -1346,7 +1347,7 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 
 	untrackedFiles := []string{}
 	for _, f := range strings.Split(strings.TrimSpace(untrackedOutput), "\n") {
-		if f != "" {
+		if f != "" && !isSandboxStoragePath(f) {
 			untrackedFiles = append(untrackedFiles, f)
 		}
 	}
@@ -1371,7 +1372,7 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 
 	// Get patch from sandbox (stdout only to avoid output capture issues after sync markers).
 	// Binary diffs need full indexes so local git apply can recreate new binary files.
-	exitCode, patch, err := s.SSHClient.ExecuteCommandWithOutput("/usr/bin/git diff --binary --full-index refs/rwx-sync")
+	exitCode, patch, err := s.SSHClient.ExecuteCommandWithOutput("/usr/bin/git diff --binary --full-index refs/rwx-sync " + sandboxStoragePathspec)
 	patchBytes := len(patch)
 
 	// Reset the intent-to-add for untracked files
@@ -1824,6 +1825,10 @@ func newFilePathsForDirtyPatches(patches git.DirtyPatches) []string {
 
 func quoteShellArg(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func isSandboxStoragePath(path string) bool {
+	return strings.HasPrefix(path, ".rwx/sandboxes/") || strings.HasPrefix(path, ".mint/sandboxes/")
 }
 
 // parsePatchFiles extracts file paths from a git patch

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -2650,7 +2650,7 @@ func TestService_ExecSandbox_PullPatchFailureRecovery(t *testing.T) {
 }
 
 func TestService_StartSandbox(t *testing.T) {
-	t.Run("sends a git patch", func(t *testing.T) {
+	t.Run("sends a git patch that includes untracked files", func(t *testing.T) {
 		setup := setupTest(t)
 
 		// Create .rwx directory and sandbox config file
@@ -2665,7 +2665,8 @@ func TestService_StartSandbox(t *testing.T) {
 		setup.mockGit.MockGetBranch = "main"
 		setup.mockGit.MockGetCommit = "abc123"
 		setup.mockGit.MockGetOriginUrl = "git@github.com:example/repo.git"
-		setup.mockGit.MockGeneratePatchFile = git.PatchFile{
+		setup.mockGit.MockGeneratePatchFileError = errors.New("generic patch generator should not be used")
+		setup.mockGit.MockGeneratePatchFileIncludingUntracked = git.PatchFile{
 			Written:        true,
 			UntrackedFiles: git.UntrackedFilesMetadata{Files: []string{"foo.txt"}, Count: 1},
 		}
@@ -2704,9 +2705,12 @@ func TestService_StartSandbox(t *testing.T) {
 
 		require.NoError(t, err)
 		require.True(t, receivedPatch.Sent, "sandbox start should send a git patch")
+		require.Empty(t, receivedPatch.UntrackedFiles, "sandbox start patch already includes untracked files")
+		require.Equal(t, 0, receivedPatch.UntrackedCount)
+		require.NotContains(t, setup.mockStderr.String(), "The patch did not include")
 	})
 
-	t.Run("passes init params to InitiateRun", func(t *testing.T) {
+	t.Run("passes init params to sandbox run", func(t *testing.T) {
 		setup := setupTest(t)
 
 		// Create .rwx directory and sandbox config file

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -2167,6 +2167,8 @@ func TestService_ExecSandbox_Pull(t *testing.T) {
 		address := "192.168.1.1:22"
 		var stdoutOnlyCommands []string
 		var pullDiffCommand string
+		var addNCommand string
+		var resetCommand string
 
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
 			return api.SandboxConnectionInfo{
@@ -2187,11 +2189,17 @@ func TestService_ExecSandbox_Pull(t *testing.T) {
 		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
 			stdoutOnlyCommands = append(stdoutOnlyCommands, cmd)
 			if strings.Contains(cmd, "git ls-files --others") {
-				return 0, "untracked.txt\n", nil
+				return 0, "untracked.txt\n.rwx/sandboxes/sandboxes.json.lock\n", nil
+			}
+			if strings.Contains(cmd, "git add -N") {
+				addNCommand = cmd
 			}
 			if isSandboxPullDiffCommand(cmd) {
 				pullDiffCommand = cmd
 				return 0, sandboxPatch, nil
+			}
+			if strings.Contains(cmd, "git reset HEAD") {
+				resetCommand = cmd
 			}
 			return 0, "", nil
 		}
@@ -2243,6 +2251,13 @@ func TestService_ExecSandbox_Pull(t *testing.T) {
 		require.Contains(t, pullDiffCommand, "--binary")
 		require.Contains(t, pullDiffCommand, "--full-index")
 		require.True(t, foundReset, "git reset HEAD should use stdout-only output")
+		require.NotContains(t, addNCommand, ".rwx/sandboxes/sandboxes.json.lock")
+		require.NotContains(t, resetCommand, ".rwx/sandboxes/sandboxes.json.lock")
+		for _, cmd := range stdoutOnlyCommands {
+			if strings.Contains(cmd, "git ls-files --others") || isSandboxPullDiffCommand(cmd) {
+				require.Contains(t, cmd, ":(exclude).rwx/sandboxes")
+			}
+		}
 	})
 
 	t.Run("pull only includes sandbox exec-changed files", func(t *testing.T) {

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -372,9 +372,13 @@ func (c *Client) GeneratePatchFile(destDir string, pathspec []string) (PatchFile
 
 // AddUntrackedFilesForPatch temporarily adds untracked files with intent-to-add
 // so they appear in git diff. Returns a cleanup function to undo the add.
-func (c *Client) AddUntrackedFilesForPatch() (cleanup func(), err error) {
-	// Get untracked files
-	cmd := exec.Command(c.Binary, "ls-files", "--others", "--exclude-standard")
+func (c *Client) AddUntrackedFilesForPatch(pathspec []string) (cleanup func(), err error) {
+	args := []string{"ls-files", "--others", "--exclude-standard"}
+	if len(pathspec) > 0 {
+		args = append(args, "--")
+		args = append(args, pathspec...)
+	}
+	cmd := exec.Command(c.Binary, args...)
 	cmd.Dir = c.Dir
 	output, err := cmd.Output()
 	if err != nil {
@@ -395,7 +399,7 @@ func (c *Client) AddUntrackedFilesForPatch() (cleanup func(), err error) {
 	}
 
 	// Add with intent-to-add
-	args := append([]string{"add", "-N", "--"}, files...)
+	args = append([]string{"add", "-N", "--"}, files...)
 	cmd = exec.Command(c.Binary, args...)
 	cmd.Dir = c.Dir
 	if err := cmd.Run(); err != nil {
@@ -413,11 +417,29 @@ func (c *Client) AddUntrackedFilesForPatch() (cleanup func(), err error) {
 	return cleanup, nil
 }
 
+// GeneratePatchFileIncludingUntracked writes a patch file for committed and
+// working-tree changes, including untracked files matched by pathspec.
+func (c *Client) GeneratePatchFileIncludingUntracked(destDir string, pathspec []string) (PatchFile, error) {
+	cleanup, err := c.AddUntrackedFilesForPatch(pathspec)
+	if err != nil {
+		return PatchFile{}, fmt.Errorf("unable to include untracked files in patch: %w", err)
+	}
+	defer cleanup()
+
+	patchFile, err := c.GeneratePatchFile(destDir, pathspec)
+	if err != nil {
+		return PatchFile{}, err
+	}
+
+	patchFile.UntrackedFiles = UntrackedFilesMetadata{}
+	return patchFile, nil
+}
+
 // GeneratePatch returns patch bytes for working tree changes relative to the base commit on origin.
 // Returns (nil, nil, nil) if no changes or unable to generate patch.
 func (c *Client) GeneratePatch(pathspec []string) ([]byte, *LFSChangedFilesMetadata, error) {
 	// Add untracked files temporarily so they appear in the diff
-	cleanup, err := c.AddUntrackedFilesForPatch()
+	cleanup, err := c.AddUntrackedFilesForPatch(pathspec)
 	if err != nil {
 		// Non-fatal: proceed without untracked files
 		cleanup = func() {}
@@ -441,7 +463,7 @@ func (c *Client) GeneratePatch(pathspec []string) ([]byte, *LFSChangedFilesMetad
 }
 
 func (c *Client) GenerateDirtyPatches() (DirtyPatches, error) {
-	cleanup, err := c.AddUntrackedFilesForPatch()
+	cleanup, err := c.AddUntrackedFilesForPatch(nil)
 	if err != nil {
 		cleanup = func() {}
 	}

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -577,6 +577,62 @@ func TestGeneratePatchFile(t *testing.T) {
 	})
 }
 
+func TestGeneratePatchFileIncludingUntracked(t *testing.T) {
+	t.Run("writes a patch file with untracked files", func(t *testing.T) {
+		tempDir, sha := repoFixture(t, "testdata/GeneratePatchFile-diff-untracked")
+
+		client := &git.Client{Binary: "git", Dir: filepath.Join(tempDir, "repo")}
+		patchFile, err := client.GeneratePatchFileIncludingUntracked(client.Dir, nil)
+		require.NoError(t, err)
+
+		require.True(t, patchFile.Written)
+		require.Equal(t, filepath.Join(client.Dir, sha), patchFile.Path)
+		require.Empty(t, patchFile.UntrackedFiles.Files)
+		require.Equal(t, 0, patchFile.UntrackedFiles.Count)
+
+		patch, err := os.ReadFile(patchFile.Path)
+		require.NoError(t, err)
+		require.Contains(t, string(patch), "foo.txt")
+		require.Contains(t, string(patch), "bar.txt")
+	})
+
+	t.Run("writes a patch file when there are only untracked files", func(t *testing.T) {
+		tempDir, sha := repoFixture(t, "testdata/GeneratePatchFile-diff-untracked-only")
+
+		client := &git.Client{Binary: "git", Dir: filepath.Join(tempDir, "repo")}
+		patchFile, err := client.GeneratePatchFileIncludingUntracked(client.Dir, nil)
+		require.NoError(t, err)
+
+		require.True(t, patchFile.Written)
+		require.Equal(t, filepath.Join(client.Dir, sha), patchFile.Path)
+		require.Empty(t, patchFile.UntrackedFiles.Files)
+		require.Equal(t, 0, patchFile.UntrackedFiles.Count)
+
+		patch, err := os.ReadFile(patchFile.Path)
+		require.NoError(t, err)
+		require.Contains(t, string(patch), "untracked.txt")
+		require.Contains(t, string(patch), "new file mode 100644")
+	})
+
+	t.Run("respects pathspec exclusions for untracked files", func(t *testing.T) {
+		tempDir, sha := repoFixture(t, "testdata/GeneratePatchFile-diff-exclude")
+
+		client := &git.Client{Binary: "git", Dir: filepath.Join(tempDir, "repo")}
+		patchFile, err := client.GeneratePatchFileIncludingUntracked(client.Dir, []string{".", ":!.rwx"})
+		require.NoError(t, err)
+
+		require.True(t, patchFile.Written)
+		require.Equal(t, filepath.Join(client.Dir, sha), patchFile.Path)
+
+		patch, err := os.ReadFile(patchFile.Path)
+		require.NoError(t, err)
+		require.Contains(t, string(patch), "included.txt")
+		require.Contains(t, string(patch), "untracked.txt")
+		require.NotContains(t, string(patch), "excluded.txt")
+		require.NotContains(t, string(patch), "untracked-excluded.txt")
+	})
+}
+
 func TestIsAncestor(t *testing.T) {
 	t.Run("returns true when candidate is ancestor of HEAD", func(t *testing.T) {
 		repo, firstSHA := repoFixture(t, "testdata/IsAncestor-linear")

--- a/internal/mocks/git.go
+++ b/internal/mocks/git.go
@@ -9,22 +9,24 @@ import (
 )
 
 type Git struct {
-	MockGetBranch              string
-	MockGetHead                string
-	MockGetHeadError           error
-	MockGetCommit              string
-	MockGetCommitError         error
-	MockGetOriginUrl           string
-	MockGeneratePatchFile      git.PatchFile
-	MockGeneratePatchFileError error
-	MockGeneratePatch          func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error)
-	MockGenerateDirtyPatches   func() (git.DirtyPatches, error)
-	MockHasCommit              func(sha string) bool
-	MockCreateBundleFile       func(head string, excludes []string) (git.BundleFile, error)
-	MockApplyPatch             func(patch []byte) *exec.Cmd
-	MockApplyPatchReject       func(patch []byte) *exec.Cmd
-	MockIsInstalled            bool
-	MockIsInsideWorkTree       bool
+	MockGetBranch                                string
+	MockGetHead                                  string
+	MockGetHeadError                             error
+	MockGetCommit                                string
+	MockGetCommitError                           error
+	MockGetOriginUrl                             string
+	MockGeneratePatchFile                        git.PatchFile
+	MockGeneratePatchFileError                   error
+	MockGeneratePatchFileIncludingUntracked      git.PatchFile
+	MockGeneratePatchFileIncludingUntrackedError error
+	MockGeneratePatch                            func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error)
+	MockGenerateDirtyPatches                     func() (git.DirtyPatches, error)
+	MockHasCommit                                func(sha string) bool
+	MockCreateBundleFile                         func(head string, excludes []string) (git.BundleFile, error)
+	MockApplyPatch                               func(patch []byte) *exec.Cmd
+	MockApplyPatchReject                         func(patch []byte) *exec.Cmd
+	MockIsInstalled                              bool
+	MockIsInsideWorkTree                         bool
 }
 
 func (c *Git) GetBranch() string {
@@ -56,7 +58,21 @@ func (c *Git) GeneratePatchFile(destDir string, pathspec []string) (git.PatchFil
 		return git.PatchFile{}, c.MockGeneratePatchFileError
 	}
 
-	if c.MockGeneratePatchFile.Written {
+	return c.writePatchFile(destDir, c.MockGeneratePatchFile)
+}
+
+func (c *Git) GeneratePatchFileIncludingUntracked(destDir string, pathspec []string) (git.PatchFile, error) {
+	if c.MockGeneratePatchFileIncludingUntrackedError != nil {
+		return git.PatchFile{}, c.MockGeneratePatchFileIncludingUntrackedError
+	}
+
+	patchFile, err := c.writePatchFile(destDir, c.MockGeneratePatchFileIncludingUntracked)
+	patchFile.UntrackedFiles = git.UntrackedFilesMetadata{}
+	return patchFile, err
+}
+
+func (c *Git) writePatchFile(destDir string, patchFile git.PatchFile) (git.PatchFile, error) {
+	if patchFile.Written {
 		if err := os.MkdirAll(destDir, 0755); err != nil {
 			return git.PatchFile{}, err
 		}
@@ -68,14 +84,14 @@ func (c *Git) GeneratePatchFile(destDir string, pathspec []string) (git.PatchFil
 		}
 
 		return git.PatchFile{
-			Written:         c.MockGeneratePatchFile.Written,
+			Written:         patchFile.Written,
 			Path:            path,
-			UntrackedFiles:  c.MockGeneratePatchFile.UntrackedFiles,
-			LFSChangedFiles: c.MockGeneratePatchFile.LFSChangedFiles,
+			UntrackedFiles:  patchFile.UntrackedFiles,
+			LFSChangedFiles: patchFile.LFSChangedFiles,
 		}, nil
 	}
 
-	return c.MockGeneratePatchFile, nil
+	return patchFile, nil
 }
 
 func (c *Git) GeneratePatch(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error) {


### PR DESCRIPTION
## Summary
- add a sandbox-owned run initiation path that shares preparation helpers with rwx run
- generate sandbox patch files with pathspec-filtered untracked files included
- suppress untracked-file skipped metadata and warning for sandbox starts
