### PR TITLE
Use git push for sandbox commit sync

### DIFF
--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -78,7 +78,7 @@ type GitClient interface {
 	GeneratePatch(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error)
 	GenerateDirtyPatches() (git.DirtyPatches, error)
 	HasCommit(sha string) bool
-	CreateBundleFile(head string, excludes []string) (git.BundleFile, error)
+	PushRef(opts git.PushRefOptions) error
 	ApplyPatch(patch []byte) *exec.Cmd
 	ApplyPatchReject(patch []byte) *exec.Cmd
 	IsInstalled() bool

--- a/internal/cli/service_debug.go
+++ b/internal/cli/service_debug.go
@@ -53,7 +53,7 @@ func (s Service) DebugTask(cfg DebugTaskConfig) error {
 	}
 
 	sshConfig := ssh.ClientConfig{
-		User:            "mint-cli", // TODO: Add version number
+		User:            rwxCLISSHUser,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(privateUserKey)},
 		HostKeyCallback: ssh.FixedHostKey(publicHostKey),
 		BannerCallback: func(message string) error {

--- a/internal/cli/service_debug_test.go
+++ b/internal/cli/service_debug_test.go
@@ -48,8 +48,9 @@ AAAEC6442PQKevgYgeT0SIu9zwlnEMl6MF59ZgM+i0ByMv4eLJPqG3xnZcEQmktHj/GY2i
 			}, nil
 		}
 
-		s.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
+		s.mockSSH.MockConnect = func(addr string, cfg ssh.ClientConfig) error {
 			require.Equal(t, agentAddress, addr)
+			require.Equal(t, "rwx-cli", cfg.User)
 			connectedViaSSH = true
 			return nil
 		}

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1454,6 +1454,16 @@ func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHe
 
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
 	if err := s.checkoutSandboxHead(localHead); err != nil {
+		lfsErr := s.verifySandboxLFSObjects(localHead)
+		_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
+		if lfsErr != nil {
+			syncPushErr = lfsErr
+			return patchBytes, syncPushErr
+		}
+		syncPushErr = err
+		return patchBytes, syncPushErr
+	}
+	if err := s.verifySandboxLFSObjects(localHead); err != nil {
 		_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 		syncPushErr = err
 		return patchBytes, syncPushErr
@@ -1571,6 +1581,73 @@ func (s Service) pushLocalHeadToSandbox(localHead string, connInfo *api.SandboxC
 	}
 
 	return nil
+}
+
+func (s Service) verifySandboxLFSObjects(localHead string) error {
+	exitCode, output, err := s.SSHClient.ExecuteCommandWithOutput(sandboxLFSFsckCommand(localHead))
+	if err != nil {
+		return errors.Wrap(err, "failed to check sandbox Git LFS objects")
+	}
+	if exitCode == 0 {
+		return nil
+	}
+
+	return sandboxLFSFsckError(localHead, output, exitCode)
+}
+
+func sandboxLFSFsckError(localHead, output string, exitCode int) error {
+	output = strings.TrimSpace(output)
+	files := sandboxLFSFilesFromFsckOutput(output)
+	if len(files) > 0 {
+		return fmt.Errorf("%d LFS file(s) changed locally and cannot be synced to the sandbox:\n%s\n\nGit LFS check output:\n%s", len(files), indentLines(files), output)
+	}
+	if output == "" {
+		return fmt.Errorf("LFS file(s) changed locally and cannot be synced to the sandbox for commit %s (git lfs fsck exit code %d)", localHead, exitCode)
+	}
+	return fmt.Errorf("LFS file(s) changed locally and cannot be synced to the sandbox for commit %s.\n\nGit LFS check output:\n%s", localHead, output)
+}
+
+func sandboxLFSFilesFromFsckOutput(output string) []string {
+	seen := map[string]bool{}
+	files := []string{}
+
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "objects:") {
+			continue
+		}
+
+		parts := strings.SplitN(line, ":", 3)
+		if len(parts) < 3 {
+			continue
+		}
+
+		file := strings.TrimSpace(parts[2])
+		if idx := strings.LastIndex(file, " ("); idx != -1 {
+			file = strings.TrimSpace(file[:idx])
+		}
+		if file == "" || seen[file] {
+			continue
+		}
+
+		seen[file] = true
+		files = append(files, file)
+	}
+
+	return files
+}
+
+func indentLines(lines []string) string {
+	indented := make([]string, len(lines))
+	for i, line := range lines {
+		indented[i] = "  " + line
+	}
+	return strings.Join(indented, "\n")
+}
+
+func sandboxLFSFsckCommand(localHead string) string {
+	script := fmt.Sprintf("if /usr/bin/git lfs version >/dev/null 2>&1; then /usr/bin/git lfs fsck --objects %s 2>&1; fi", quoteShellArg(localHead))
+	return "/bin/sh -lc " + quoteShellArg(script)
 }
 
 func sandboxGitPushOptions(localHead string, connInfo *api.SandboxConnectionInfo) (git.PushRefOptions, func(), error) {

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -20,8 +20,6 @@ import (
 const (
 	sandboxDirectiveLockRequested = "__rwx_sandbox_lock_requested__"
 	sandboxDirectiveLockReleased  = "__rwx_sandbox_lock_released__"
-	maxSandboxGitBundleBytes      = 100 * 1024 * 1024
-	warnSandboxGitBundleBytes     = 25 * 1024 * 1024
 )
 
 // Config types
@@ -767,7 +765,7 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 	var syncPushPatchBytes int
 	if cfg.Sync {
 		syncPushStart := time.Now()
-		patchBytes, err := s.prepareSandboxForExec(cfg.Json, isNewSandbox, localHeadForSync)
+		patchBytes, err := s.prepareSandboxForExec(cfg.Json, isNewSandbox, localHeadForSync, connInfo)
 		syncPushMs = time.Since(syncPushStart).Milliseconds()
 		syncPushPatchBytes = patchBytes
 		if err != nil {
@@ -1429,7 +1427,7 @@ func (s Service) revertSandboxToGitState(localHead string) error {
 	return nil
 }
 
-func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHead string) (int, error) {
+func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHead string, connInfo *api.SandboxConnectionInfo) (int, error) {
 	if localHead == "" {
 		return 0, fmt.Errorf("sandbox sync requires a git repository with a valid HEAD")
 	}
@@ -1449,7 +1447,7 @@ func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHe
 		})
 	}()
 
-	if err := s.ensureSandboxHasCommit(localHead, jsonMode); err != nil {
+	if err := s.ensureSandboxHasCommit(localHead, connInfo); err != nil {
 		syncPushErr = err
 		return patchBytes, syncPushErr
 	}
@@ -1524,7 +1522,7 @@ func (s Service) warnUnresolvedRejectFiles() {
 	fmt.Fprintln(s.Stderr, "These will be synced to the sandbox and may cause issues. Resolve and delete them when possible.")
 }
 
-func (s Service) ensureSandboxHasCommit(localHead string, jsonMode bool) error {
+func (s Service) ensureSandboxHasCommit(localHead string, connInfo *api.SandboxConnectionInfo) error {
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
 	gitDirExitCode, gitDirErr := s.SSHClient.ExecuteCommand("test -d .git || test -f .git")
 	if gitDirErr != nil {
@@ -1541,93 +1539,111 @@ func (s Service) ensureSandboxHasCommit(localHead string, jsonMode bool) error {
 		_, _ = s.SSHClient.ExecuteCommand("/usr/bin/git fetch --prune origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1")
 		hasCommit = s.sandboxHasCommit(localHead)
 	}
-
-	var knownTips []string
-	if !hasCommit {
-		knownTips = s.remoteKnownTips()
-	}
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 
 	if hasCommit {
 		return nil
 	}
 
-	excludes := make([]string, 0, len(knownTips))
-	seen := make(map[string]bool, len(knownTips))
-	for _, tip := range knownTips {
-		tip = strings.TrimSpace(tip)
-		if tip == "" || seen[tip] || !s.GitClient.HasCommit(tip) {
-			continue
-		}
-		seen[tip] = true
-		excludes = append(excludes, tip)
+	return s.pushLocalHeadToSandbox(localHead, connInfo)
+}
+
+func (s Service) pushLocalHeadToSandbox(localHead string, connInfo *api.SandboxConnectionInfo) error {
+	if connInfo == nil {
+		return fmt.Errorf("sandbox connection info is required to push local commits")
 	}
 
-	bundle, err := s.GitClient.CreateBundleFile(localHead, excludes)
+	opts, cleanup, err := sandboxGitPushOptions(localHead, connInfo)
 	if err != nil {
-		return errors.Wrap(err, "failed to create git bundle")
+		return err
 	}
-	if bundle.Path == "" {
-		return errors.New("failed to create git bundle")
-	}
-	if bundle.Ref == "" {
-		return errors.New("failed to create git bundle ref")
-	}
-	defer os.Remove(bundle.Path)
-
-	if bundle.Size > maxSandboxGitBundleBytes {
-		return fmt.Errorf("git bundle is %.1f MiB, which exceeds the %.0f MiB sandbox sync limit", float64(bundle.Size)/(1024*1024), float64(maxSandboxGitBundleBytes)/(1024*1024))
-	}
-	if bundle.Size > warnSandboxGitBundleBytes && !jsonMode {
-		fmt.Fprintf(s.Stderr, "Warning: streaming %.1f MiB of local git commits to the sandbox.\n", float64(bundle.Size)/(1024*1024))
-	}
-
-	fd, err := os.Open(bundle.Path)
-	if err != nil {
-		return errors.Wrap(err, "failed to open git bundle")
-	}
-	defer fd.Close()
+	defer cleanup()
 
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
-	fetchBundleCmd := fmt.Sprintf(
-		"/bin/sh -lc 'tmp=$(mktemp /tmp/rwx-bundle.XXXXXX) || exit 1; trap \"rm -f \\\"$tmp\\\"\" EXIT; cat > \"$tmp\" || exit 1; /usr/bin/git bundle verify \"$tmp\" >/dev/null || exit 1; /usr/bin/git fetch \"$tmp\" %s:%s >/dev/null'",
-		bundle.Ref,
-		bundle.Ref,
-	)
-	exitCode, output, streamErr := s.SSHClient.ExecuteCommandWithStdinAndCombinedOutput(
-		fetchBundleCmd,
-		fd,
-	)
-	hasCommit = streamErr == nil && exitCode == 0 && s.sandboxHasCommit(localHead)
+	pushErr := s.GitClient.PushRef(opts)
+	hasCommit := pushErr == nil && s.sandboxHasCommit(localHead)
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
-	if streamErr != nil {
-		return errors.Wrap(streamErr, "failed to stream git bundle to sandbox")
+	if pushErr != nil {
+		return errors.Wrap(pushErr, "failed to push git commits to sandbox")
 	}
-	if exitCode != 0 {
-		if output = strings.TrimSpace(output); output != "" {
-			return fmt.Errorf("failed to import git bundle in sandbox: %s", output)
-		}
-		return fmt.Errorf("failed to import git bundle in sandbox (exit code %d)", exitCode)
-	}
-
 	if !hasCommit {
-		return fmt.Errorf("sandbox still does not contain local commit %s after bundle import", localHead)
+		return fmt.Errorf("sandbox still does not contain local commit %s after git push", localHead)
 	}
 
 	return nil
 }
 
+func sandboxGitPushOptions(localHead string, connInfo *api.SandboxConnectionInfo) (git.PushRefOptions, func(), error) {
+	host, port, err := net.SplitHostPort(connInfo.Address)
+	if err != nil {
+		return git.PushRefOptions{}, func() {}, errors.Wrap(err, "unable to parse sandbox SSH address")
+	}
+
+	alias := fmt.Sprintf("rwx-sandbox-%d-%d", os.Getpid(), time.Now().UnixNano())
+	remoteRef := fmt.Sprintf("refs/rwx/push/%d-%d", os.Getpid(), time.Now().UnixNano())
+
+	paths := []string{}
+	cleanup := func() {
+		for _, path := range paths {
+			_ = os.Remove(path)
+		}
+	}
+
+	keyFile, err := os.CreateTemp("", "rwx-sandbox-key-*")
+	if err != nil {
+		return git.PushRefOptions{}, cleanup, err
+	}
+	keyPath := keyFile.Name()
+	paths = append(paths, keyPath)
+	if err := keyFile.Close(); err != nil {
+		cleanup()
+		return git.PushRefOptions{}, func() {}, err
+	}
+	if err := os.WriteFile(keyPath, []byte(connInfo.PrivateUserKey), 0o600); err != nil {
+		cleanup()
+		return git.PushRefOptions{}, func() {}, err
+	}
+
+	knownHostsFile, err := os.CreateTemp("", "rwx-sandbox-known-hosts-*")
+	if err != nil {
+		cleanup()
+		return git.PushRefOptions{}, func() {}, err
+	}
+	knownHostsPath := knownHostsFile.Name()
+	paths = append(paths, knownHostsPath)
+	if err := knownHostsFile.Close(); err != nil {
+		cleanup()
+		return git.PushRefOptions{}, func() {}, err
+	}
+	knownHosts := fmt.Sprintf("%s %s\n", alias, strings.TrimSpace(connInfo.PublicHostKey))
+	if err := os.WriteFile(knownHostsPath, []byte(knownHosts), 0o600); err != nil {
+		cleanup()
+		return git.PushRefOptions{}, func() {}, err
+	}
+
+	sshCommand := shellescape.QuoteCommand([]string{
+		"ssh",
+		"-F", "/dev/null",
+		"-i", keyPath,
+		"-o", "BatchMode=yes",
+		"-o", "IdentitiesOnly=yes",
+		"-o", "StrictHostKeyChecking=yes",
+		"-o", "UserKnownHostsFile=" + knownHostsPath,
+		"-o", "HostKeyAlias=" + alias,
+		"-o", "HostName=" + host,
+		"-p", port,
+	})
+
+	return git.PushRefOptions{
+		Remote:  fmt.Sprintf("mint-cli@%s:.", alias),
+		Refspec: fmt.Sprintf("%s:%s", localHead, remoteRef),
+		Env:     []string{"GIT_SSH_COMMAND=" + sshCommand},
+	}, cleanup, nil
+}
+
 func (s Service) sandboxHasCommit(sha string) bool {
 	exitCode, err := s.SSHClient.ExecuteCommand(fmt.Sprintf("/usr/bin/git cat-file -e %s^{commit} >/dev/null 2>&1", quoteShellArg(sha)))
 	return err == nil && exitCode == 0
-}
-
-func (s Service) remoteKnownTips() []string {
-	exitCode, output, err := s.SSHClient.ExecuteCommandWithOutput("/usr/bin/git for-each-ref --format='%(objectname)' refs/heads refs/remotes refs/tags refs/rwx refs/rwx-sync 2>/dev/null")
-	if err != nil || exitCode != 0 {
-		return nil
-	}
-	return strings.Split(strings.TrimSpace(output), "\n")
 }
 
 func (s Service) checkoutSandboxHead(localHead string) error {

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1603,7 +1603,7 @@ func sandboxLFSFsckError(localHead, output string, exitCode int) error {
 	output = strings.TrimSpace(output)
 	files := sandboxLFSFilesFromFsckOutput(output)
 	if len(files) > 0 {
-		return fmt.Errorf("%d LFS file(s) changed locally and cannot be synced to the sandbox:\n%s\n\nGit LFS check output:\n%s", len(files), indentLines(files), output)
+		return fmt.Errorf("%d LFS file(s) changed locally and cannot be synced to the sandbox:\n%s", len(files), indentLines(files))
 	}
 	if output == "" {
 		return fmt.Errorf("LFS file(s) changed locally and cannot be synced to the sandbox for commit %s (git lfs fsck exit code %d)", localHead, exitCode)

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1602,13 +1602,14 @@ func (s Service) verifySandboxLFSObjects(localHead string) error {
 func sandboxLFSFsckError(localHead, output string, exitCode int) error {
 	output = strings.TrimSpace(output)
 	files := sandboxLFSFilesFromFsckOutput(output)
+	recovery := "To recover, push your changes and reset the sandbox."
 	if len(files) > 0 {
-		return fmt.Errorf("%d LFS file(s) changed locally and cannot be synced to the sandbox:\n%s", len(files), indentLines(files))
+		return fmt.Errorf("%d LFS file(s) changed locally and cannot be synced to the sandbox:\n%s\n\n%s", len(files), indentLines(files), recovery)
 	}
 	if output == "" {
-		return fmt.Errorf("LFS file(s) changed locally and cannot be synced to the sandbox for commit %s (git lfs fsck exit code %d)", localHead, exitCode)
+		return fmt.Errorf("LFS file(s) changed locally and cannot be synced to the sandbox for commit %s (git lfs fsck exit code %d).\n\n%s", localHead, exitCode, recovery)
 	}
-	return fmt.Errorf("LFS file(s) changed locally and cannot be synced to the sandbox for commit %s.\n\nGit LFS check output:\n%s", localHead, output)
+	return fmt.Errorf("LFS file(s) changed locally and cannot be synced to the sandbox for commit %s.\n\n%s\n\nGit LFS check output:\n%s", localHead, recovery, output)
 }
 
 func sandboxLFSFilesFromFsckOutput(output string) []string {

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -20,7 +20,7 @@ import (
 const (
 	sandboxDirectiveLockRequested = "__rwx_sandbox_lock_requested__"
 	sandboxDirectiveLockReleased  = "__rwx_sandbox_lock_released__"
-	sandboxSSHUser                = "rwx-cli"
+	rwxCLISSHUser                 = "rwx-cli"
 )
 
 // Config types
@@ -1718,7 +1718,7 @@ func sandboxGitPushOptions(localHead string, connInfo *api.SandboxConnectionInfo
 	})
 
 	return git.PushRefOptions{
-		Remote:  fmt.Sprintf("%s@%s:.", sandboxSSHUser, alias),
+		Remote:  fmt.Sprintf("%s@%s:.", rwxCLISSHUser, alias),
 		Refspec: fmt.Sprintf("%s:%s", localHead, remoteRef),
 		Env:     []string{"GIT_SSH_COMMAND=" + sshCommand, "GIT_LFS_SKIP_PUSH=1"},
 	}, cleanup, nil
@@ -2085,7 +2085,7 @@ func (s Service) connectSSH(connInfo *api.SandboxConnectionInfo) error {
 	}
 
 	sshConfig := ssh.ClientConfig{
-		User:            sandboxSSHUser,
+		User:            rwxCLISSHUser,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(privateUserKey)},
 		HostKeyCallback: ssh.FixedHostKey(publicHostKey),
 	}

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -20,6 +20,7 @@ import (
 const (
 	sandboxDirectiveLockRequested = "__rwx_sandbox_lock_requested__"
 	sandboxDirectiveLockReleased  = "__rwx_sandbox_lock_released__"
+	sandboxSSHUser                = "rwx-cli"
 )
 
 // Config types
@@ -1717,7 +1718,7 @@ func sandboxGitPushOptions(localHead string, connInfo *api.SandboxConnectionInfo
 	})
 
 	return git.PushRefOptions{
-		Remote:  fmt.Sprintf("mint-cli@%s:.", alias),
+		Remote:  fmt.Sprintf("%s@%s:.", sandboxSSHUser, alias),
 		Refspec: fmt.Sprintf("%s:%s", localHead, remoteRef),
 		Env:     []string{"GIT_SSH_COMMAND=" + sshCommand, "GIT_LFS_SKIP_PUSH=1"},
 	}, cleanup, nil
@@ -2084,7 +2085,7 @@ func (s Service) connectSSH(connInfo *api.SandboxConnectionInfo) error {
 	}
 
 	sshConfig := ssh.ClientConfig{
-		User:            "mint-cli",
+		User:            sandboxSSHUser,
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(privateUserKey)},
 		HostKeyCallback: ssh.FixedHostKey(publicHostKey),
 	}

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1482,6 +1482,10 @@ func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHe
 		if !jsonMode {
 			fmt.Fprintf(s.Stderr, "Warning: %d LFS file(s) changed locally and cannot be synced.\n", patches.LFSChangedFiles.Count)
 		}
+		if err := s.snapshotSandboxSyncRef(); err != nil {
+			syncPushErr = err
+			return patchBytes, syncPushErr
+		}
 		return patchBytes, nil
 	}
 
@@ -1714,7 +1718,7 @@ func sandboxGitPushOptions(localHead string, connInfo *api.SandboxConnectionInfo
 	return git.PushRefOptions{
 		Remote:  fmt.Sprintf("mint-cli@%s:.", alias),
 		Refspec: fmt.Sprintf("%s:%s", localHead, remoteRef),
-		Env:     []string{"GIT_SSH_COMMAND=" + sshCommand},
+		Env:     []string{"GIT_SSH_COMMAND=" + sshCommand, "GIT_LFS_SKIP_PUSH=1"},
 	}, cleanup, nil
 }
 
@@ -1726,11 +1730,12 @@ func (s Service) sandboxHasCommit(sha string) bool {
 func (s Service) checkoutSandboxHead(localHead string) error {
 	head := quoteShellArg(localHead)
 	branch := s.GitClient.GetBranch()
+	git := "GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/bin/false SSH_ASKPASS=/bin/false /usr/bin/git"
 	var cmd string
 	if branch == "" {
-		cmd = fmt.Sprintf("/usr/bin/git checkout -f --detach %s >/dev/null 2>&1 && /usr/bin/git reset --hard %s >/dev/null 2>&1", head, head)
+		cmd = fmt.Sprintf("%s checkout -f --detach %s >/dev/null 2>&1 && %s reset --hard %s >/dev/null 2>&1", git, head, git, head)
 	} else {
-		cmd = fmt.Sprintf("/usr/bin/git checkout -f -B %s %s >/dev/null 2>&1 && /usr/bin/git reset --hard %s >/dev/null 2>&1", quoteShellArg(branch), head, head)
+		cmd = fmt.Sprintf("%s checkout -f -B %s %s >/dev/null 2>&1 && %s reset --hard %s >/dev/null 2>&1", git, quoteShellArg(branch), head, git, head)
 	}
 
 	exitCode, err := s.SSHClient.ExecuteCommand(cmd)

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1465,15 +1465,12 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.True(t, foundEnd, "snapshot/reset commands should be followed by sync end marker")
 	})
 
-	t.Run("prepares sandbox from local git head and streams missing commits", func(t *testing.T) {
+	t.Run("prepares sandbox from local git head and pushes missing commits", func(t *testing.T) {
 		setup := setupTest(t)
 
 		runID := "run-git-state-sync"
 		address := "192.168.1.1:22"
 		localHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-		knownTip := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-		bundlePath := filepath.Join(setup.tmp, "missing.bundle")
-		require.NoError(t, os.WriteFile(bundlePath, []byte("bundle-data"), 0o644))
 
 		setup.mockGit.MockGetHead = localHead
 		setup.mockGit.MockGetBranch = "feature/sync"
@@ -1483,15 +1480,13 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 				Unstaged: []byte("unstaged-patch"),
 			}, nil
 		}
-		setup.mockGit.MockHasCommit = func(sha string) bool {
-			return sha == knownTip
-		}
-		var bundleHead string
-		var bundleExcludes []string
-		setup.mockGit.MockCreateBundleFile = func(head string, excludes []string) (git.BundleFile, error) {
-			bundleHead = head
-			bundleExcludes = append([]string{}, excludes...)
-			return git.BundleFile{Path: bundlePath, Ref: "refs/rwx/bundles/test", Size: int64(len("bundle-data"))}, nil
+
+		var commandOrder []string
+		var pushOpts git.PushRefOptions
+		setup.mockGit.MockPushRef = func(opts git.PushRefOptions) error {
+			pushOpts = opts
+			commandOrder = append(commandOrder, "git push "+opts.Remote+" "+opts.Refspec)
+			return nil
 		}
 
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
@@ -1507,7 +1502,6 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 			return nil
 		}
 
-		var commandOrder []string
 		catFileChecks := 0
 		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
 			commandOrder = append(commandOrder, cmd)
@@ -1528,8 +1522,6 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
 			commandOrder = append(commandOrder, cmd)
 			switch {
-			case strings.Contains(cmd, "for-each-ref"):
-				return 0, knownTip + "\ncccccccccccccccccccccccccccccccccccccccc\n", nil
 			case strings.Contains(cmd, "git ls-files --others"):
 				return 0, "", nil
 			case isSandboxPullDiffCommand(cmd):
@@ -1559,59 +1551,71 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, runID, result.RunID)
-		require.Equal(t, localHead, bundleHead)
-		require.Equal(t, []string{knownTip}, bundleExcludes)
+		require.Contains(t, pushOpts.Remote, "mint-cli@rwx-sandbox-")
+		require.True(t, strings.HasSuffix(pushOpts.Remote, ":."))
+		require.True(t, strings.HasPrefix(pushOpts.Refspec, localHead+":refs/rwx/push/"))
+		require.Len(t, pushOpts.Env, 1)
+		require.Contains(t, pushOpts.Env[0], "GIT_SSH_COMMAND=ssh")
+		require.Contains(t, pushOpts.Env[0], "-F /dev/null")
+		require.Contains(t, pushOpts.Env[0], "HostName=192.168.1.1")
+		require.Contains(t, pushOpts.Env[0], "HostKeyAlias=rwx-sandbox-")
+		require.Contains(t, pushOpts.Env[0], "StrictHostKeyChecking=yes")
+		require.Contains(t, pushOpts.Env[0], "-p 22")
 		require.Contains(t, strings.Join(commandOrder, "\n"), "git fetch --prune origin")
 		require.Contains(t, strings.Join(commandOrder, "\n"), "git checkout -f -B 'feature/sync' '"+localHead+"'")
 		require.Contains(t, strings.Join(commandOrder, "\n"), "git write-tree")
 		require.Contains(t, strings.Join(commandOrder, "\n"), "git clean -fd")
 		for i, cmd := range commandOrder {
-			if strings.Contains(cmd, "cat-file -e") || strings.Contains(cmd, "for-each-ref") {
+			if strings.Contains(cmd, "cat-file -e") {
 				requireCommandWrappedBySyncMarkers(t, commandOrder, i)
 			}
 		}
 		firstProbeIndex := slices.IndexFunc(commandOrder, func(cmd string) bool {
 			return strings.Contains(cmd, "cat-file -e")
 		})
-		knownTipsIndex := slices.IndexFunc(commandOrder, func(cmd string) bool {
-			return strings.Contains(cmd, "for-each-ref")
-		})
 		require.NotEqual(t, -1, firstProbeIndex)
-		require.NotEqual(t, -1, knownTipsIndex)
-		require.Less(t, firstProbeIndex, knownTipsIndex)
 		gitDirIndex := slices.IndexFunc(commandOrder, func(cmd string) bool {
 			return strings.Contains(cmd, "test -d .git")
 		})
+		fetchIndex := slices.IndexFunc(commandOrder, func(cmd string) bool {
+			return strings.Contains(cmd, "git fetch --prune origin")
+		})
+		postFetchProbeIndex := -1
+		for i := fetchIndex + 1; i < len(commandOrder); i++ {
+			if strings.Contains(commandOrder[i], "cat-file -e") {
+				postFetchProbeIndex = i
+				break
+			}
+		}
 		require.NotEqual(t, -1, gitDirIndex)
+		require.NotEqual(t, -1, fetchIndex)
+		require.NotEqual(t, -1, postFetchProbeIndex)
 		require.Less(t, gitDirIndex, firstProbeIndex)
 		require.Equal(t, "__rwx_sandbox_sync_start__", commandOrder[gitDirIndex-1])
-		require.Equal(t, "__rwx_sandbox_sync_end__", commandOrder[knownTipsIndex+1])
-		require.NotContains(t, commandOrder[gitDirIndex+1:knownTipsIndex], "__rwx_sandbox_sync_start__")
-		require.NotContains(t, commandOrder[gitDirIndex+1:knownTipsIndex], "__rwx_sandbox_sync_end__")
+		require.Equal(t, "__rwx_sandbox_sync_end__", commandOrder[postFetchProbeIndex+1])
+		require.NotContains(t, commandOrder[gitDirIndex+1:postFetchProbeIndex], "__rwx_sandbox_sync_start__")
+		require.NotContains(t, commandOrder[gitDirIndex+1:postFetchProbeIndex], "__rwx_sandbox_sync_end__")
 
-		bundleImportIndex := slices.IndexFunc(commandOrder, func(cmd string) bool {
-			return strings.Contains(cmd, "git bundle verify")
+		pushIndex := slices.IndexFunc(commandOrder, func(cmd string) bool {
+			return strings.HasPrefix(cmd, "git push ")
 		})
-		require.NotEqual(t, -1, bundleImportIndex)
+		require.NotEqual(t, -1, pushIndex)
 		finalProbeIndex := -1
-		for i := bundleImportIndex + 1; i < len(commandOrder); i++ {
+		for i := pushIndex + 1; i < len(commandOrder); i++ {
 			if strings.Contains(commandOrder[i], "cat-file -e") {
 				finalProbeIndex = i
 				break
 			}
 		}
 		require.NotEqual(t, -1, finalProbeIndex)
-		require.Equal(t, "__rwx_sandbox_sync_start__", commandOrder[bundleImportIndex-1])
+		require.Equal(t, "__rwx_sandbox_sync_start__", commandOrder[pushIndex-1])
 		require.Equal(t, "__rwx_sandbox_sync_end__", commandOrder[finalProbeIndex+1])
-		require.NotContains(t, commandOrder[bundleImportIndex+1:finalProbeIndex], "__rwx_sandbox_sync_start__")
-		require.NotContains(t, commandOrder[bundleImportIndex+1:finalProbeIndex], "__rwx_sandbox_sync_end__")
-		require.Contains(t, stdinCommands[0], "git bundle verify")
-		require.Contains(t, stdinCommands[0], "refs/rwx/bundles/test:refs/rwx/bundles/test")
-		require.Equal(t, "bundle-data", stdinPayloads[0])
-		require.Equal(t, "/usr/bin/git apply --index --allow-empty -", stdinCommands[1])
-		require.Equal(t, "staged-patch", stdinPayloads[1])
-		require.Equal(t, "/usr/bin/git apply --allow-empty -", stdinCommands[2])
-		require.Equal(t, "unstaged-patch", stdinPayloads[2])
+		require.NotContains(t, commandOrder[pushIndex+1:finalProbeIndex], "__rwx_sandbox_sync_start__")
+		require.NotContains(t, commandOrder[pushIndex+1:finalProbeIndex], "__rwx_sandbox_sync_end__")
+		require.Equal(t, "/usr/bin/git apply --index --allow-empty -", stdinCommands[0])
+		require.Equal(t, "staged-patch", stdinPayloads[0])
+		require.Equal(t, "/usr/bin/git apply --allow-empty -", stdinCommands[1])
+		require.Equal(t, "unstaged-patch", stdinPayloads[1])
 	})
 
 	t.Run("new sandbox sync removes pre-applied new files and snapshots only local dirty paths", func(t *testing.T) {
@@ -1709,7 +1713,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.NotContains(t, order[snapshotIndex], "/usr/bin/git add -A &&")
 	})
 
-	t.Run("fetches remote refs without streaming bundle when fetch provides local head", func(t *testing.T) {
+	t.Run("fetches remote refs without pushing when fetch provides local head", func(t *testing.T) {
 		setup := setupTest(t)
 
 		runID := "run-fetch-only"
@@ -1721,9 +1725,9 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		setup.mockGit.MockGenerateDirtyPatches = func() (git.DirtyPatches, error) {
 			return git.DirtyPatches{}, nil
 		}
-		setup.mockGit.MockCreateBundleFile = func(head string, excludes []string) (git.BundleFile, error) {
-			require.Fail(t, "bundle should not be created when remote fetch provides local head")
-			return git.BundleFile{}, nil
+		setup.mockGit.MockPushRef = func(opts git.PushRefOptions) error {
+			require.Fail(t, "push should not run when remote fetch provides local head")
+			return nil
 		}
 
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
@@ -1823,19 +1827,17 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Contains(t, strings.Join(commands, "\n"), "git checkout -f --detach '"+localHead+"'")
 	})
 
-	t.Run("fails when missing commit bundle exceeds hard limit", func(t *testing.T) {
+	t.Run("fails when pushing missing commits fails", func(t *testing.T) {
 		setup := setupTest(t)
 
-		runID := "run-bundle-too-large"
+		runID := "run-push-fail"
 		address := "192.168.1.1:22"
 		localHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-		bundlePath := filepath.Join(setup.tmp, "too-large.bundle")
-		require.NoError(t, os.WriteFile(bundlePath, []byte("bundle-data"), 0o644))
 
 		setup.mockGit.MockGetHead = localHead
-		setup.mockGit.MockGetBranch = "feature/large-bundle"
-		setup.mockGit.MockCreateBundleFile = func(head string, excludes []string) (git.BundleFile, error) {
-			return git.BundleFile{Path: bundlePath, Ref: "refs/rwx/bundles/large", Size: 101 * 1024 * 1024}, nil
+		setup.mockGit.MockGetBranch = "feature/push-fail"
+		setup.mockGit.MockPushRef = func(opts git.PushRefOptions) error {
+			return fmt.Errorf("remote rejected push")
 		}
 
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
@@ -1871,25 +1873,21 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 
 		require.Nil(t, result)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "exceeds the 100 MiB sandbox sync limit")
+		require.Contains(t, err.Error(), "failed to push git commits to sandbox")
+		require.Contains(t, err.Error(), "remote rejected push")
 	})
 
-	t.Run("warns but streams when missing commit bundle exceeds warning threshold", func(t *testing.T) {
+	t.Run("fails when sandbox lacks commit after push", func(t *testing.T) {
 		setup := setupTest(t)
 
-		runID := "run-bundle-warning"
+		runID := "run-push-missing"
 		address := "192.168.1.1:22"
 		localHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-		bundlePath := filepath.Join(setup.tmp, "warning.bundle")
-		require.NoError(t, os.WriteFile(bundlePath, []byte("bundle-data"), 0o644))
 
 		setup.mockGit.MockGetHead = localHead
-		setup.mockGit.MockGetBranch = "feature/warning-bundle"
-		setup.mockGit.MockGenerateDirtyPatches = func() (git.DirtyPatches, error) {
-			return git.DirtyPatches{}, nil
-		}
-		setup.mockGit.MockCreateBundleFile = func(head string, excludes []string) (git.BundleFile, error) {
-			return git.BundleFile{Path: bundlePath, Ref: "refs/rwx/bundles/warning", Size: 26 * 1024 * 1024}, nil
+		setup.mockGit.MockGetBranch = "feature/push-missing"
+		setup.mockGit.MockPushRef = func(opts git.PushRefOptions) error {
+			return nil
 		}
 
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
@@ -1901,18 +1899,12 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 			}, nil
 		}
 		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error { return nil }
-
-		catFileChecks := 0
 		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
 			switch {
 			case strings.Contains(cmd, "rev-parse --verify -q refs/rwx-sync"):
 				return 1, nil
 			case strings.Contains(cmd, "cat-file -e"):
-				catFileChecks++
-				if catFileChecks < 3 {
-					return 1, nil
-				}
-				return 0, nil
+				return 1, nil
 			default:
 				return 0, nil
 			}
@@ -1920,23 +1912,18 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
 			return 0, "", nil
 		}
-		setup.mockSSH.MockExecuteCommandWithStdinAndCombinedOutput = func(command string, stdin io.Reader) (int, string, error) {
-			data, _ := io.ReadAll(stdin)
-			require.Equal(t, "bundle-data", string(data))
-			return 0, "", nil
-		}
 
 		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
 			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
 			Command:    []string{"echo", "hello"},
 			RunID:      runID,
-			Json:       false,
+			Json:       true,
 			Sync:       true,
 		})
 
-		require.NoError(t, err)
-		require.Equal(t, runID, result.RunID)
-		require.Contains(t, setup.mockStderr.String(), "Warning: streaming 26.0 MiB of local git commits to the sandbox.")
+		require.Nil(t, result)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "sandbox still does not contain local commit "+localHead+" after git push")
 	})
 
 	t.Run("returns helpful error when git is not installed", func(t *testing.T) {

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1287,7 +1287,9 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 			return 0, nil
 		}
 
+		var commands []string
 		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
+			commands = append(commands, cmd)
 			return 0, nil
 		}
 
@@ -1309,6 +1311,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Equal(t, 0, result.ExitCode)
 		require.False(t, syncPatchApplied)
 		require.Contains(t, setup.mockStderr.String(), "LFS file(s) changed")
+		require.Contains(t, strings.Join(commands, "\n"), "update-ref refs/rwx-sync HEAD")
 	})
 
 	t.Run("returns error when git apply fails", func(t *testing.T) {
@@ -1554,13 +1557,14 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Contains(t, pushOpts.Remote, "mint-cli@rwx-sandbox-")
 		require.True(t, strings.HasSuffix(pushOpts.Remote, ":."))
 		require.True(t, strings.HasPrefix(pushOpts.Refspec, localHead+":refs/rwx/push/"))
-		require.Len(t, pushOpts.Env, 1)
+		require.Len(t, pushOpts.Env, 2)
 		require.Contains(t, pushOpts.Env[0], "GIT_SSH_COMMAND=ssh")
 		require.Contains(t, pushOpts.Env[0], "-F /dev/null")
 		require.Contains(t, pushOpts.Env[0], "HostName=192.168.1.1")
 		require.Contains(t, pushOpts.Env[0], "HostKeyAlias=rwx-sandbox-")
 		require.Contains(t, pushOpts.Env[0], "StrictHostKeyChecking=yes")
 		require.Contains(t, pushOpts.Env[0], "-p 22")
+		require.Equal(t, "GIT_LFS_SKIP_PUSH=1", pushOpts.Env[1])
 		require.Contains(t, strings.Join(commandOrder, "\n"), "git fetch --prune origin")
 		require.Contains(t, strings.Join(commandOrder, "\n"), "git checkout -f -B 'feature/sync' '"+localHead+"'")
 		require.Contains(t, strings.Join(commandOrder, "\n"), "git write-tree")

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1618,6 +1618,90 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Equal(t, "unstaged-patch", stdinPayloads[1])
 	})
 
+	t.Run("pushes missing commits before failing on broken sandbox LFS objects", func(t *testing.T) {
+		setup := setupTest(t)
+
+		runID := "run-lfs-push"
+		address := "192.168.1.1:22"
+		localHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+		setup.mockGit.MockGetHead = localHead
+		setup.mockGit.MockGetBranch = "feature/lfs-push"
+		setup.mockGit.MockGenerateDirtyPatches = func() (git.DirtyPatches, error) {
+			t.Fatal("dirty patches should not be generated after broken LFS objects are detected")
+			return git.DirtyPatches{}, nil
+		}
+
+		var commandOrder []string
+		pushed := false
+		setup.mockGit.MockPushRef = func(opts git.PushRefOptions) error {
+			pushed = true
+			commandOrder = append(commandOrder, "git push "+opts.Remote+" "+opts.Refspec)
+			return nil
+		}
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        address,
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
+			return nil
+		}
+		catFileChecks := 0
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
+			commandOrder = append(commandOrder, cmd)
+			switch {
+			case strings.Contains(cmd, "rev-parse --verify -q refs/rwx-sync"):
+				return 1, nil
+			case strings.Contains(cmd, "cat-file -e"):
+				catFileChecks++
+				if catFileChecks < 3 {
+					return 1, nil
+				}
+				return 0, nil
+			default:
+				return 0, nil
+			}
+		}
+		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
+			commandOrder = append(commandOrder, cmd)
+			if strings.Contains(cmd, "git lfs fsck --objects") {
+				return 2, "objects: missing: large.bin (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)\n", nil
+			}
+			return 0, "", nil
+		}
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      runID,
+			Json:       true,
+			Sync:       true,
+		})
+
+		require.Nil(t, result)
+		require.Error(t, err)
+		require.True(t, pushed)
+		require.Contains(t, err.Error(), "1 LFS file(s) changed locally and cannot be synced to the sandbox:")
+		require.Contains(t, err.Error(), "  large.bin")
+		require.Contains(t, err.Error(), "Git LFS check output:")
+		require.Contains(t, err.Error(), "objects: missing: large.bin")
+
+		pushIndex := slices.IndexFunc(commandOrder, func(cmd string) bool {
+			return strings.HasPrefix(cmd, "git push ")
+		})
+		fsckIndex := slices.IndexFunc(commandOrder, func(cmd string) bool {
+			return strings.Contains(cmd, "git lfs fsck --objects")
+		})
+		require.NotEqual(t, -1, pushIndex)
+		require.NotEqual(t, -1, fsckIndex)
+		require.Less(t, pushIndex, fsckIndex)
+	})
+
 	t.Run("new sandbox sync removes pre-applied new files and snapshots only local dirty paths", func(t *testing.T) {
 		setup := setupTest(t)
 

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1692,8 +1692,8 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.True(t, pushed)
 		require.Contains(t, err.Error(), "1 LFS file(s) changed locally and cannot be synced to the sandbox:")
 		require.Contains(t, err.Error(), "  large.bin")
-		require.Contains(t, err.Error(), "Git LFS check output:")
-		require.Contains(t, err.Error(), "objects: missing: large.bin")
+		require.NotContains(t, err.Error(), "Git LFS check output:")
+		require.NotContains(t, err.Error(), "objects: missing: large.bin")
 
 		pushIndex := slices.IndexFunc(commandOrder, func(cmd string) bool {
 			return strings.HasPrefix(cmd, "git push ")

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1692,6 +1692,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.True(t, pushed)
 		require.Contains(t, err.Error(), "1 LFS file(s) changed locally and cannot be synced to the sandbox:")
 		require.Contains(t, err.Error(), "  large.bin")
+		require.Contains(t, err.Error(), "To recover, push your changes and reset the sandbox.")
 		require.NotContains(t, err.Error(), "Git LFS check output:")
 		require.NotContains(t, err.Error(), "objects: missing: large.bin")
 

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1554,7 +1554,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, runID, result.RunID)
-		require.Contains(t, pushOpts.Remote, "mint-cli@rwx-sandbox-")
+		require.Contains(t, pushOpts.Remote, "rwx-cli@rwx-sandbox-")
 		require.True(t, strings.HasSuffix(pushOpts.Remote, ":."))
 		require.True(t, strings.HasPrefix(pushOpts.Refspec, localHead+":refs/rwx/push/"))
 		require.Len(t, pushOpts.Env, 2)

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -268,35 +268,16 @@ func (c *Client) generatePatchData(pathspec []string) patchResult {
 		return patchResult{}
 	}
 
-	lfsChangedFiles := []string{}
-
-	for _, file := range strings.Split(strings.TrimSpace(string(files)), "\n") {
-		if file == "" {
-			continue
-		}
-		cmd := exec.Command(c.Binary, "check-attr", "filter", "--", file)
-		cmd.Dir = c.Dir
-
-		attrs, err := cmd.CombinedOutput()
-		if err != nil {
-			return patchResult{}
-		}
-
-		if strings.Contains(string(attrs), "filter: lfs") {
-			parts := strings.SplitN(string(attrs), ":", 2)
-			lfsFile := strings.TrimSpace(parts[0])
-			lfsChangedFiles = append(lfsChangedFiles, string(lfsFile))
-		}
+	lfsChanged, err := c.lfsFilesForPaths(strings.Split(strings.TrimSpace(string(files)), "\n"))
+	if err != nil {
+		return patchResult{}
 	}
 
-	if len(lfsChangedFiles) > 0 {
+	if lfsChanged.Count > 0 {
 		return patchResult{
 			sha: sha,
-			lfs: LFSChangedFilesMetadata{
-				Files: lfsChangedFiles,
-				Count: len(lfsChangedFiles),
-			},
-			ok: true,
+			lfs: lfsChanged,
+			ok:  true,
 		}
 	}
 
@@ -572,6 +553,35 @@ func (c *Client) HasCommit(sha string) bool {
 	cmd := exec.Command(c.Binary, "cat-file", "-e", sha+"^{commit}")
 	cmd.Dir = c.Dir
 	return cmd.Run() == nil
+}
+
+func (c *Client) lfsFilesForPaths(files []string) (LFSChangedFilesMetadata, error) {
+	lfsChangedFiles := []string{}
+
+	for _, file := range files {
+		if file == "" {
+			continue
+		}
+
+		cmd := exec.Command(c.Binary, "check-attr", "filter", "--", file)
+		cmd.Dir = c.Dir
+
+		attrs, err := cmd.CombinedOutput()
+		if err != nil {
+			return LFSChangedFilesMetadata{}, err
+		}
+
+		if strings.Contains(string(attrs), "filter: lfs") {
+			parts := strings.SplitN(string(attrs), ":", 2)
+			lfsFile := strings.TrimSpace(parts[0])
+			lfsChangedFiles = append(lfsChangedFiles, lfsFile)
+		}
+	}
+
+	return LFSChangedFilesMetadata{
+		Files: lfsChangedFiles,
+		Count: len(lfsChangedFiles),
+	}, nil
 }
 
 func (c *Client) PushRef(opts PushRefOptions) error {

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 )
 
 type Client struct {
@@ -234,10 +233,10 @@ func (p DirtyPatches) Size() int {
 	return len(p.Staged) + len(p.Unstaged)
 }
 
-type BundleFile struct {
-	Path string
-	Ref  string
-	Size int64
+type PushRefOptions struct {
+	Remote  string
+	Refspec string
+	Env     []string
 }
 
 // patchResult holds the result of generating patch data
@@ -575,54 +574,28 @@ func (c *Client) HasCommit(sha string) bool {
 	return cmd.Run() == nil
 }
 
-func (c *Client) CreateBundleFile(head string, excludes []string) (BundleFile, error) {
-	if head == "" {
-		return BundleFile{}, fmt.Errorf("no head commit provided")
+func (c *Client) PushRef(opts PushRefOptions) error {
+	if opts.Remote == "" {
+		return fmt.Errorf("no remote provided")
+	}
+	if opts.Refspec == "" {
+		return fmt.Errorf("no refspec provided")
 	}
 
-	tmp, err := os.CreateTemp("", "rwx-sandbox-*.bundle")
-	if err != nil {
-		return BundleFile{}, err
-	}
-	path := tmp.Name()
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(path)
-		return BundleFile{}, err
-	}
-
-	ref := fmt.Sprintf("refs/rwx/bundles/%d-%d", os.Getpid(), time.Now().UnixNano())
-	updateCmd := exec.Command(c.Binary, "update-ref", ref, head)
-	updateCmd.Dir = c.Dir
-	if out, err := updateCmd.CombinedOutput(); err != nil {
-		_ = os.Remove(path)
-		return BundleFile{}, fmt.Errorf("git update-ref failed: %s", strings.TrimSpace(string(out)))
-	}
-	defer func() {
-		deleteCmd := exec.Command(c.Binary, "update-ref", "-d", ref)
-		deleteCmd.Dir = c.Dir
-		_ = deleteCmd.Run()
-	}()
-
-	args := []string{"bundle", "create", path, ref}
-	for _, exclude := range excludes {
-		if exclude != "" && c.HasCommit(exclude) {
-			args = append(args, "^"+exclude)
-		}
-	}
-	cmd := exec.Command(c.Binary, args...)
+	cmd := exec.Command(c.Binary, "push", opts.Remote, opts.Refspec)
 	cmd.Dir = c.Dir
+	if len(opts.Env) > 0 {
+		cmd.Env = append(os.Environ(), opts.Env...)
+	}
 	if out, err := cmd.CombinedOutput(); err != nil {
-		_ = os.Remove(path)
-		return BundleFile{}, fmt.Errorf("git bundle create failed: %s", strings.TrimSpace(string(out)))
+		output := strings.TrimSpace(string(out))
+		if output != "" {
+			return fmt.Errorf("git push failed: %s", output)
+		}
+		return fmt.Errorf("git push failed: %w", err)
 	}
 
-	info, err := os.Stat(path)
-	if err != nil {
-		_ = os.Remove(path)
-		return BundleFile{}, err
-	}
-
-	return BundleFile{Path: path, Ref: ref, Size: info.Size()}, nil
+	return nil
 }
 
 // IsAncestor returns true if candidateSHA is an ancestor of (or equal to) headRef.

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -399,38 +399,29 @@ func TestGenerateDirtyPatches(t *testing.T) {
 	require.Equal(t, "staged.txt", cachedNames)
 }
 
-func TestCreateBundleFile(t *testing.T) {
+func TestPushRef(t *testing.T) {
 	source := t.TempDir()
 	mustGit(t, source, "init")
 	mustGit(t, source, "config", "user.email", "test@example.com")
 	mustGit(t, source, "config", "user.name", "Test")
-	require.NoError(t, os.WriteFile(filepath.Join(source, "base.txt"), []byte("base\n"), 0o644))
-	mustGit(t, source, "add", "base.txt")
-	mustGit(t, source, "commit", "-m", "base")
-	base := mustGit(t, source, "rev-parse", "HEAD")
-
-	target := t.TempDir()
-	mustGit(t, target, "clone", source, ".")
-
-	require.NoError(t, os.WriteFile(filepath.Join(source, "feature.txt"), []byte("feature\n"), 0o644))
-	mustGit(t, source, "add", "feature.txt")
-	mustGit(t, source, "commit", "-m", "feature")
+	require.NoError(t, os.WriteFile(filepath.Join(source, "pushed.txt"), []byte("pushed\n"), 0o644))
+	mustGit(t, source, "add", "pushed.txt")
+	mustGit(t, source, "commit", "-m", "pushed")
 	head := mustGit(t, source, "rev-parse", "HEAD")
 
+	target := t.TempDir()
+	mustGit(t, target, "init", "--bare")
+
 	client := &git.Client{Binary: "git", Dir: source}
-	bundle, err := client.CreateBundleFile(head, []string{base})
+	err := client.PushRef(git.PushRefOptions{
+		Remote:  target,
+		Refspec: head + ":refs/rwx/push/test",
+		Env:     []string{"RWX_TEST_PUSH_ENV=1"},
+	})
+
 	require.NoError(t, err)
-	defer os.Remove(bundle.Path)
-	require.NotZero(t, bundle.Size)
-	require.True(t, strings.HasPrefix(bundle.Ref, "refs/rwx/bundles/"))
-
-	mustGit(t, target, "fetch", bundle.Path, bundle.Ref+":"+bundle.Ref)
-	fetched := mustGit(t, target, "rev-parse", bundle.Ref)
-	require.Equal(t, head, fetched)
-
-	showRef := exec.Command("git", "show-ref", "--verify", bundle.Ref)
-	showRef.Dir = source
-	require.Error(t, showRef.Run(), "temporary bundle ref should be removed")
+	pushed := mustGit(t, target, "rev-parse", "refs/rwx/push/test")
+	require.Equal(t, head, pushed)
 }
 
 func TestGeneratePatchFile(t *testing.T) {

--- a/internal/mocks/git.go
+++ b/internal/mocks/git.go
@@ -20,7 +20,7 @@ type Git struct {
 	MockGeneratePatch          func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error)
 	MockGenerateDirtyPatches   func() (git.DirtyPatches, error)
 	MockHasCommit              func(sha string) bool
-	MockCreateBundleFile       func(head string, excludes []string) (git.BundleFile, error)
+	MockPushRef                func(opts git.PushRefOptions) error
 	MockApplyPatch             func(patch []byte) *exec.Cmd
 	MockApplyPatchReject       func(patch []byte) *exec.Cmd
 	MockIsInstalled            bool
@@ -99,11 +99,11 @@ func (c *Git) HasCommit(sha string) bool {
 	return true
 }
 
-func (c *Git) CreateBundleFile(head string, excludes []string) (git.BundleFile, error) {
-	if c.MockCreateBundleFile != nil {
-		return c.MockCreateBundleFile(head, excludes)
+func (c *Git) PushRef(opts git.PushRefOptions) error {
+	if c.MockPushRef != nil {
+		return c.MockPushRef(opts)
 	}
-	return git.BundleFile{}, nil
+	return nil
 }
 
 func (c *Git) ApplyPatch(patch []byte) *exec.Cmd {

--- a/test/integration/sandbox-git-state-sync.sh
+++ b/test/integration/sandbox-git-state-sync.sh
@@ -61,7 +61,11 @@ run_and_capture_output() {
   shift
 
   set +e
-  "$@" 2>&1 | tee "$output_file"
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 300 "$@" 2>&1 | tee "$output_file"
+  else
+    "$@" 2>&1 | tee "$output_file"
+  fi
   local exit_code=${PIPESTATUS[0]}
   set -e
 
@@ -111,6 +115,29 @@ assert_local_file_content() {
   if [ "$actual" != "$expected" ]; then
     fail "${file} content mismatch locally (expected: ${expected}, actual: ${actual})"
   fi
+}
+
+start_git_state_sandbox() {
+  if [ -n "$SANDBOX_RUN_ID" ]; then
+    "${RWX_CLI}" sandbox stop --id "$SANDBOX_RUN_ID" >/dev/null 2>&1 || true
+    SANDBOX_RUN_ID=""
+  fi
+
+  local sandbox_result
+  sandbox_result=$("${RWX_CLI}" sandbox start "$SANDBOX_CONFIG" --json --init ref=main --init "cli=${COMMIT_SHA}" --wait)
+  SANDBOX_RUN_ID=$(echo "$sandbox_result" | jq -r ".RunID")
+
+  local sandbox_url
+  sandbox_url=$(echo "$sandbox_result" | jq -r ".RunURL // empty")
+  if [ -n "$sandbox_url" ]; then
+    echo "Sandbox URL: ${sandbox_url}"
+    echo "$sandbox_url" > "$RWX_LINKS/Sandbox Run"
+  fi
+  if [ -z "$SANDBOX_RUN_ID" ] || [ "$SANDBOX_RUN_ID" = "null" ]; then
+    echo "$sandbox_result"
+    fail "sandbox start did not return a run id"
+  fi
+  rm -rf .rwx/sandboxes
 }
 
 require_clean_worktree
@@ -166,18 +193,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-sandbox_result=$("${RWX_CLI}" sandbox start "$SANDBOX_CONFIG" --json --init ref=main --init "cli=${COMMIT_SHA}" --wait)
-SANDBOX_RUN_ID=$(echo "$sandbox_result" | jq -r ".RunID")
-sandbox_url=$(echo "$sandbox_result" | jq -r ".RunURL // empty")
-if [ -n "$sandbox_url" ]; then
-  echo "Sandbox URL: ${sandbox_url}"
-  echo "$sandbox_url" > "$RWX_LINKS/Sandbox Run"
-fi
-if [ -z "$SANDBOX_RUN_ID" ] || [ "$SANDBOX_RUN_ID" = "null" ]; then
-  echo "$sandbox_result"
-  fail "sandbox start did not return a run id"
-fi
-rm -rf .rwx/sandboxes
+start_git_state_sandbox
 require_clean_worktree
 
 echo "Scenario: unpushed local commits are pushed and become sandbox HEAD"
@@ -263,6 +279,9 @@ if [ "$lfs_push_exit" -eq 0 ]; then
 fi
 echo "$lfs_push_output" | grep -q "LFS file(s) changed locally and cannot be synced to the sandbox" || fail "missing LFS sync error for committed LFS object: ${lfs_push_output}"
 echo "$lfs_push_output" | grep -q "integration-lfs-push.bin" || fail "missing committed LFS file path in error: ${lfs_push_output}"
+
+echo "Restarting sandbox after expected LFS sync failure"
+start_git_state_sandbox
 
 echo "Scenario: dirty LFS files are reported and skipped by patch sync"
 git switch -C "${TEST_ID}-lfs-patch" "$ORIGINAL_HEAD" >/dev/null

--- a/test/integration/sandbox-git-state-sync.sh
+++ b/test/integration/sandbox-git-state-sync.sh
@@ -279,6 +279,7 @@ if [ "$lfs_push_exit" -eq 0 ]; then
 fi
 echo "$lfs_push_output" | grep -q "LFS file(s) changed locally and cannot be synced to the sandbox" || fail "missing LFS sync error for committed LFS object: ${lfs_push_output}"
 echo "$lfs_push_output" | grep -q "integration-lfs-push.bin" || fail "missing committed LFS file path in error: ${lfs_push_output}"
+echo "$lfs_push_output" | grep -q "To recover, push your changes and reset the sandbox." || fail "missing LFS sync recovery guidance: ${lfs_push_output}"
 
 echo "Restarting sandbox after expected LFS sync failure"
 start_git_state_sandbox

--- a/test/integration/sandbox-git-state-sync.sh
+++ b/test/integration/sandbox-git-state-sync.sh
@@ -81,7 +81,7 @@ ORIGINAL_HEAD=$(git rev-parse HEAD)
 ORIGINAL_BRANCH=$(git branch --show-current)
 TEST_ID="rwx-sandbox-git-state-$$"
 TEMP_BRANCHES=(
-  "${TEST_ID}-bundle"
+  "${TEST_ID}-push"
   "${TEST_ID}-feature-rebase"
   "${TEST_ID}-main-rebase"
   "${TEST_ID}-feature-merge"
@@ -92,7 +92,7 @@ TEMP_BRANCHES=(
   "${TEST_ID}-dirty-state"
 )
 TEST_FILES=(
-  integration-bundled-commit.txt
+  integration-pushed-commit.txt
   integration-feature-before-rebase.txt
   integration-main-after-rebase.txt
   integration-feature-merge.txt
@@ -135,11 +135,11 @@ fi
 rm -rf .rwx/sandboxes
 require_clean_worktree
 
-echo "Scenario: unpushed local commits are bundled and become sandbox HEAD"
-git switch -C "${TEST_ID}-bundle" "$ORIGINAL_HEAD" >/dev/null
-commit_file "integration-bundled-commit.txt" "bundled commit content" "integration bundled commit"
+echo "Scenario: unpushed local commits are pushed and become sandbox HEAD"
+git switch -C "${TEST_ID}-push" "$ORIGINAL_HEAD" >/dev/null
+commit_file "integration-pushed-commit.txt" "pushed commit content" "integration pushed commit"
 assert_sandbox_head_matches
-assert_sandbox_file_content "integration-bundled-commit.txt" "bundled commit content"
+assert_sandbox_file_content "integration-pushed-commit.txt" "pushed commit content"
 
 echo "Scenario: rebased branch carries newer main commits into reused sandbox"
 git switch -C "${TEST_ID}-feature-rebase" "$ORIGINAL_HEAD" >/dev/null

--- a/test/integration/sandbox-git-state-sync.sh
+++ b/test/integration/sandbox-git-state-sync.sh
@@ -30,6 +30,44 @@ commit_file() {
   git -c user.email="sandbox-integration@example.com" -c user.name="Sandbox Integration" commit -m "$message" >/dev/null
 }
 
+commit_lfs_file() {
+  local file="$1"
+  local content="$2"
+  local message="$3"
+
+  git lfs track "$file" >/dev/null
+  printf '%s\n' "$content" > "$file"
+  git add .gitattributes "$file"
+  git -c user.email="sandbox-integration@example.com" -c user.name="Sandbox Integration" commit -m "$message" >/dev/null
+}
+
+require_git_lfs() {
+  git lfs version >/dev/null 2>&1 || fail "sandbox LFS integration scenarios require git-lfs"
+}
+
+ensure_sandbox_git_lfs() {
+  "${RWX_CLI}" sandbox exec --id "$SANDBOX_RUN_ID" --no-sync -- sh -c '
+    set -e
+    if ! /usr/bin/git lfs version >/dev/null 2>&1; then
+      sudo apt-get update >/dev/null
+      sudo apt-get install -y git-lfs >/dev/null
+    fi
+    /usr/bin/git lfs install --local >/dev/null
+  '
+}
+
+run_and_capture_output() {
+  local output_file="$1"
+  shift
+
+  set +e
+  "$@" 2>&1 | tee "$output_file"
+  local exit_code=${PIPESTATUS[0]}
+  set -e
+
+  return "$exit_code"
+}
+
 assert_sandbox_head_matches() {
   local expected
   local actual
@@ -89,6 +127,8 @@ TEMP_BRANCHES=(
   "${TEST_ID}-force-move"
   "${TEST_ID}-sandbox-created"
   "${TEST_ID}-detached-source"
+  "${TEST_ID}-lfs-push"
+  "${TEST_ID}-lfs-patch"
   "${TEST_ID}-dirty-state"
 )
 TEST_FILES=(
@@ -102,6 +142,8 @@ TEST_FILES=(
   integration-sandbox-created-survives.txt
   integration-local-after-sandbox-created.txt
   integration-detached-head.txt
+  integration-lfs-push.bin
+  integration-lfs-patch.bin
   integration-staged-state.txt
 )
 
@@ -116,6 +158,9 @@ cleanup() {
     git switch "$ORIGINAL_BRANCH" >/dev/null 2>&1
   else
     git switch --detach "$ORIGINAL_HEAD" >/dev/null 2>&1
+  fi
+  if ! git cat-file -e "$ORIGINAL_HEAD":.gitattributes >/dev/null 2>&1; then
+    rm -f .gitattributes
   fi
   git branch -D "${TEMP_BRANCHES[@]}" >/dev/null 2>&1
 }
@@ -198,6 +243,46 @@ sandbox_branch=$("${RWX_CLI}" sandbox exec --id "$SANDBOX_RUN_ID" -- sh -c 'git 
 if [ -n "$sandbox_branch" ]; then
   fail "sandbox branch should be detached but was ${sandbox_branch}"
 fi
+
+require_git_lfs
+
+echo "Scenario: unpushed committed LFS objects fail after sandbox git push"
+ensure_sandbox_git_lfs
+git switch -C "${TEST_ID}-lfs-push" "$ORIGINAL_HEAD" >/dev/null
+echo "Creating local committed LFS object"
+commit_lfs_file "integration-lfs-push.bin" "committed lfs content" "integration committed lfs object"
+
+echo "Running sandbox exec expected to fail because the committed LFS object was not pushed"
+lfs_push_output_file=$(mktemp)
+lfs_push_exit=0
+run_and_capture_output "$lfs_push_output_file" "${RWX_CLI}" sandbox exec --id "$SANDBOX_RUN_ID" -- true || lfs_push_exit=$?
+lfs_push_output=$(cat "$lfs_push_output_file")
+rm -f "$lfs_push_output_file"
+if [ "$lfs_push_exit" -eq 0 ]; then
+  fail "sandbox exec succeeded with an unpushed committed LFS object"
+fi
+echo "$lfs_push_output" | grep -q "LFS file(s) changed locally and cannot be synced to the sandbox" || fail "missing LFS sync error for committed LFS object: ${lfs_push_output}"
+echo "$lfs_push_output" | grep -q "integration-lfs-push.bin" || fail "missing committed LFS file path in error: ${lfs_push_output}"
+
+echo "Scenario: dirty LFS files are reported and skipped by patch sync"
+git switch -C "${TEST_ID}-lfs-patch" "$ORIGINAL_HEAD" >/dev/null
+git lfs track "integration-lfs-patch.bin" >/dev/null
+printf '%s\n' "dirty lfs content" > integration-lfs-patch.bin
+
+lfs_patch_output_file=$(mktemp)
+lfs_patch_exit=0
+run_and_capture_output "$lfs_patch_output_file" "${RWX_CLI}" sandbox exec --id "$SANDBOX_RUN_ID" -- sh -c 'test ! -e integration-lfs-patch.bin' || lfs_patch_exit=$?
+lfs_patch_output=$(cat "$lfs_patch_output_file")
+rm -f "$lfs_patch_output_file"
+if [ "$lfs_patch_exit" -ne 0 ]; then
+  fail "sandbox exec failed while checking dirty LFS patch skip: ${lfs_patch_output}"
+fi
+echo "$lfs_patch_output" | grep -q "Warning: 1 LFS file(s) changed locally and cannot be synced." || fail "missing dirty LFS warning: ${lfs_patch_output}"
+if [ ! -f integration-lfs-patch.bin ]; then
+  fail "dirty LFS file was removed locally after patch sync"
+fi
+git reset -- .gitattributes integration-lfs-patch.bin >/dev/null 2>&1 || true
+rm -f .gitattributes integration-lfs-patch.bin
 
 echo "Scenario: staged and unstaged local state keep their shape in sandbox"
 git switch -C "${TEST_ID}-dirty-state" "$ORIGINAL_HEAD" >/dev/null

--- a/test/integration/sandbox-unpushed-commits.sh
+++ b/test/integration/sandbox-unpushed-commits.sh
@@ -14,6 +14,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
+rm -rf .rwx/sandboxes
+
 echo "unpushed commit content" > unpushed-commit-test.txt
 git add unpushed-commit-test.txt
 git commit -m "unpushed local commit"


### PR DESCRIPTION
## Why

We found scenarios where we were hitting the 100MiB limit for syncing gitbundles. It turns out that it's a combination of issues:

- We, generally, shallow clone with `git/clone`
- We don't have git authentication in the sandbox task (so we can't fetch from the remote)
- Occasionally an agent will do a rebase or merge main on the branch

When this happens, the resulting "diff" of commits missing in the sandbox is basically all of the commits, so nearly the entirety of the local repo gets bundled up and synced (whereas in the happy path with no rebase/merge, only the incremental gitbundle on top of the sandbox's base commit was being sent over).

This was missed initially because we swallow most git errors (not addressed here, but should be addressed) and were hiding that the remote fetch to determine what refs we have available on the sandbox was failing and most of (all?) of the local testing we did over a couple days was with small repositories that didn't hit the limit.

I made two attempts at this. One is this PR, the other was manually preferring an incremental gitbundle and falling back to an index pack approach to recreate a new shallow clone on the sandbox. It occurred to me, though, that `git push` basically handles all of this for you. So, why not just push?

Here's a sample session (new branch, untracked file, commit it, merge main): https://cloud.rwx.com/mint/rwx/runs/0adf8ed7b6a24a17954c6ac9cd141dc7

## How

When the sandbox does not have the local HEAD after fetching origin, the CLI now pushes that commit to the sandbox over the sandbox SSH connection as a temporary `refs/rwx/push/...` ref. The push uses connection details from the sandbox API to build a scoped `GIT_SSH_COMMAND`, then verifies that the sandbox can resolve the commit before checkout.

Dirty staged, unstaged, and untracked files still sync through patches so the sandbox preserves staged vs unstaged shape.

For Git LFS, the sandbox commit push skips the local LFS pre-push upload hook with `GIT_LFS_SKIP_PUSH=1`. That keeps commit sync from silently uploading LFS objects as a side effect. After the pushed commit is present, the sandbox checks out non-interactively and runs `git lfs fsck --objects <commit>`. If LFS objects are missing, the CLI returns a patch-style error that lists the known LFS files. Raw fsck output is only included when file paths cannot be parsed.

Dirty LFS file changes continue to be skipped with a warning, but the sandbox now still creates `refs/rwx-sync` so pull-back has a stable baseline.