### PR TITLE
Fix sandbox LFS fsck parsing and git-push sync follow-ups

### DIFF
--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -21,6 +22,9 @@ const (
 	sandboxDirectiveLockRequested = "__rwx_sandbox_lock_requested__"
 	sandboxDirectiveLockReleased  = "__rwx_sandbox_lock_released__"
 	rwxCLISSHUser                 = "rwx-cli"
+	// Reuse one fixed ref (force-pushed) rather than a unique ref per push so the
+	// sandbox's ref namespace doesn't accumulate dangling refs.
+	sandboxPushRef = "refs/rwx/sync-push"
 )
 
 // Config types
@@ -1455,10 +1459,12 @@ func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHe
 
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
 	if err := s.checkoutSandboxHead(localHead); err != nil {
-		lfsErr := s.verifySandboxLFSObjects(localHead)
+		// Prefer the more actionable "missing LFS objects" error, but ignore a
+		// failure of the check itself so it can't mask the checkout error.
+		lfsMissing, _ := s.checkSandboxLFSObjects(localHead)
 		_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
-		if lfsErr != nil {
-			syncPushErr = lfsErr
+		if lfsMissing != nil {
+			syncPushErr = lfsMissing
 			return patchBytes, syncPushErr
 		}
 		syncPushErr = err
@@ -1483,7 +1489,7 @@ func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHe
 		if !jsonMode {
 			fmt.Fprintf(s.Stderr, "Warning: %d LFS file(s) changed locally and cannot be synced.\n", patches.LFSChangedFiles.Count)
 		}
-		if err := s.snapshotSandboxSyncRef(); err != nil {
+		if err := s.snapshotSandboxSyncRefForExec(isNewSandbox, patches.Files); err != nil {
 			syncPushErr = err
 			return patchBytes, syncPushErr
 		}
@@ -1502,14 +1508,8 @@ func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHe
 		return patchBytes, syncPushErr
 	}
 
-	var snapshotErr error
-	if isNewSandbox {
-		snapshotErr = s.snapshotSandboxSyncRefForPaths(patches.Files)
-	} else {
-		snapshotErr = s.snapshotSandboxSyncRef()
-	}
-	if snapshotErr != nil {
-		syncPushErr = snapshotErr
+	if err := s.snapshotSandboxSyncRefForExec(isNewSandbox, patches.Files); err != nil {
+		syncPushErr = err
 		return patchBytes, syncPushErr
 	}
 
@@ -1569,10 +1569,10 @@ func (s Service) pushLocalHeadToSandbox(localHead string, connInfo *api.SandboxC
 	}
 
 	opts, cleanup, err := sandboxGitPushOptions(localHead, connInfo)
+	defer cleanup()
 	if err != nil {
 		return err
 	}
-	defer cleanup()
 
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
 	pushErr := s.GitClient.PushRef(opts)
@@ -1589,15 +1589,26 @@ func (s Service) pushLocalHeadToSandbox(localHead string, connInfo *api.SandboxC
 }
 
 func (s Service) verifySandboxLFSObjects(localHead string) error {
+	missing, checkErr := s.checkSandboxLFSObjects(localHead)
+	if checkErr != nil {
+		return checkErr
+	}
+	return missing
+}
+
+// checkSandboxLFSObjects separates a detected missing-object problem (missing)
+// from a failure to run the check (checkErr), so callers can ignore the latter
+// when they already have a more specific error.
+func (s Service) checkSandboxLFSObjects(localHead string) (missing error, checkErr error) {
 	exitCode, output, err := s.SSHClient.ExecuteCommandWithOutput(sandboxLFSFsckCommand(localHead))
 	if err != nil {
-		return errors.Wrap(err, "failed to check sandbox Git LFS objects")
+		return nil, errors.Wrap(err, "failed to check sandbox Git LFS objects")
 	}
 	if exitCode == 0 {
-		return nil
+		return nil, nil
 	}
 
-	return sandboxLFSFsckError(localHead, output, exitCode)
+	return sandboxLFSFsckError(localHead, output, exitCode), nil
 }
 
 func sandboxLFSFsckError(localHead, output string, exitCode int) error {
@@ -1613,25 +1624,23 @@ func sandboxLFSFsckError(localHead, output string, exitCode int) error {
 	return fmt.Errorf("LFS file(s) changed locally and cannot be synced to the sandbox for commit %s.\n\n%s\n\nGit LFS check output:\n%s", localHead, recovery, output)
 }
 
+// lfsFsckObjectLineRe matches a per-object `git lfs fsck` line (group 1 is the
+// path). Requiring the trailing ` (<oid>)` skips status lines like
+// `objects: repair: ...` and keeps paths that contain " (" intact.
+var lfsFsckObjectLineRe = regexp.MustCompile(`^objects: [^:]+: (.+?) \([0-9a-fA-F]{40,64}\)`)
+
 func sandboxLFSFilesFromFsckOutput(output string) []string {
 	seen := map[string]bool{}
 	files := []string{}
 
 	for _, line := range strings.Split(output, "\n") {
 		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "objects:") {
+		match := lfsFsckObjectLineRe.FindStringSubmatch(line)
+		if match == nil {
 			continue
 		}
 
-		parts := strings.SplitN(line, ":", 3)
-		if len(parts) < 3 {
-			continue
-		}
-
-		file := strings.TrimSpace(parts[2])
-		if idx := strings.LastIndex(file, " ("); idx != -1 {
-			file = strings.TrimSpace(file[:idx])
-		}
+		file := strings.TrimSpace(match[1])
 		if file == "" || seen[file] {
 			continue
 		}
@@ -1657,20 +1666,19 @@ func sandboxLFSFsckCommand(localHead string) string {
 }
 
 func sandboxGitPushOptions(localHead string, connInfo *api.SandboxConnectionInfo) (git.PushRefOptions, func(), error) {
-	host, port, err := net.SplitHostPort(connInfo.Address)
-	if err != nil {
-		return git.PushRefOptions{}, func() {}, errors.Wrap(err, "unable to parse sandbox SSH address")
-	}
-
-	alias := fmt.Sprintf("rwx-sandbox-%d-%d", os.Getpid(), time.Now().UnixNano())
-	remoteRef := fmt.Sprintf("refs/rwx/push/%d-%d", os.Getpid(), time.Now().UnixNano())
-
 	paths := []string{}
 	cleanup := func() {
 		for _, path := range paths {
 			_ = os.Remove(path)
 		}
 	}
+
+	host, port, err := net.SplitHostPort(connInfo.Address)
+	if err != nil {
+		return git.PushRefOptions{}, cleanup, errors.Wrap(err, "unable to parse sandbox SSH address")
+	}
+
+	alias := fmt.Sprintf("rwx-sandbox-%d-%d", os.Getpid(), time.Now().UnixNano())
 
 	keyFile, err := os.CreateTemp("", "rwx-sandbox-key-*")
 	if err != nil {
@@ -1679,29 +1687,24 @@ func sandboxGitPushOptions(localHead string, connInfo *api.SandboxConnectionInfo
 	keyPath := keyFile.Name()
 	paths = append(paths, keyPath)
 	if err := keyFile.Close(); err != nil {
-		cleanup()
-		return git.PushRefOptions{}, func() {}, err
+		return git.PushRefOptions{}, cleanup, err
 	}
 	if err := os.WriteFile(keyPath, []byte(connInfo.PrivateUserKey), 0o600); err != nil {
-		cleanup()
-		return git.PushRefOptions{}, func() {}, err
+		return git.PushRefOptions{}, cleanup, err
 	}
 
 	knownHostsFile, err := os.CreateTemp("", "rwx-sandbox-known-hosts-*")
 	if err != nil {
-		cleanup()
-		return git.PushRefOptions{}, func() {}, err
+		return git.PushRefOptions{}, cleanup, err
 	}
 	knownHostsPath := knownHostsFile.Name()
 	paths = append(paths, knownHostsPath)
 	if err := knownHostsFile.Close(); err != nil {
-		cleanup()
-		return git.PushRefOptions{}, func() {}, err
+		return git.PushRefOptions{}, cleanup, err
 	}
 	knownHosts := fmt.Sprintf("%s %s\n", alias, strings.TrimSpace(connInfo.PublicHostKey))
 	if err := os.WriteFile(knownHostsPath, []byte(knownHosts), 0o600); err != nil {
-		cleanup()
-		return git.PushRefOptions{}, func() {}, err
+		return git.PushRefOptions{}, cleanup, err
 	}
 
 	sshCommand := shellescape.QuoteCommand([]string{
@@ -1719,7 +1722,7 @@ func sandboxGitPushOptions(localHead string, connInfo *api.SandboxConnectionInfo
 
 	return git.PushRefOptions{
 		Remote:  fmt.Sprintf("%s@%s:.", rwxCLISSHUser, alias),
-		Refspec: fmt.Sprintf("%s:%s", localHead, remoteRef),
+		Refspec: fmt.Sprintf("+%s:%s", localHead, sandboxPushRef),
 		Env:     []string{"GIT_SSH_COMMAND=" + sshCommand, "GIT_LFS_SKIP_PUSH=1"},
 	}, cleanup, nil
 }
@@ -1808,6 +1811,16 @@ func (s Service) applyPatchToSandbox(command string, patch []byte) error {
 		return errors.WrapSentinel(fmt.Errorf("failed to sync changes to sandbox: git apply failed with exit code %d", exitCode), errors.ErrPatch)
 	}
 	return nil
+}
+
+// snapshotSandboxSyncRefForExec records the post-sync baseline. A new sandbox
+// stages only local dirty paths so server pre-applied files aren't baked into
+// the baseline; a reused sandbox already matches local state.
+func (s Service) snapshotSandboxSyncRefForExec(isNewSandbox bool, paths []string) error {
+	if isNewSandbox {
+		return s.snapshotSandboxSyncRefForPaths(paths)
+	}
+	return s.snapshotSandboxSyncRef()
 }
 
 func (s Service) snapshotSandboxSyncRef() error {

--- a/internal/cli/service_sandbox_internal_test.go
+++ b/internal/cli/service_sandbox_internal_test.go
@@ -6,6 +6,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSandboxLFSFilesFromFsckOutput(t *testing.T) {
+	oid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	t.Run("parses a single missing object and ignores the repair status line", func(t *testing.T) {
+		output := "objects: openError: large.bin (" + oid + ") could not be checked: no such file or directory\n" +
+			"objects: repair: moving corrupt objects to /sandbox/.git/lfs/bad"
+		require.Equal(t, []string{"large.bin"}, sandboxLFSFilesFromFsckOutput(output))
+	})
+
+	t.Run("parses multiple objects across categories", func(t *testing.T) {
+		output := "objects: openError: a/one.bin (" + oid + ") could not be checked: no such file or directory\n" +
+			"objects: corruptObject: two.bin (" + oid + ") is corrupt\n" +
+			"objects: repair: moving corrupt objects to /sandbox/.git/lfs/bad"
+		require.Equal(t, []string{"a/one.bin", "two.bin"}, sandboxLFSFilesFromFsckOutput(output))
+	})
+
+	t.Run("preserves a file path that itself contains a parenthesis", func(t *testing.T) {
+		output := "objects: openError: data (final).bin (" + oid + ") could not be checked: no such file or directory"
+		require.Equal(t, []string{"data (final).bin"}, sandboxLFSFilesFromFsckOutput(output))
+	})
+
+	t.Run("dedupes repeated files", func(t *testing.T) {
+		output := "objects: openError: dup.bin (" + oid + ") could not be checked: x\n" +
+			"objects: corruptObject: dup.bin (" + oid + ") is corrupt"
+		require.Equal(t, []string{"dup.bin"}, sandboxLFSFilesFromFsckOutput(output))
+	})
+
+	t.Run("returns nothing for status-only or unparseable output", func(t *testing.T) {
+		require.Empty(t, sandboxLFSFilesFromFsckOutput(""))
+		require.Empty(t, sandboxLFSFilesFromFsckOutput("objects: repair: moving corrupt objects to /sandbox/.git/lfs/bad"))
+		require.Empty(t, sandboxLFSFilesFromFsckOutput("some unrelated git output\nnot an objects line"))
+	})
+}
+
 func TestParseNewFilePaths(t *testing.T) {
 	t.Run("returns paths only for new-file additions", func(t *testing.T) {
 		patch := []byte(`diff --git a/tracked.txt b/tracked.txt

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1311,7 +1311,16 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Equal(t, 0, result.ExitCode)
 		require.False(t, syncPatchApplied)
 		require.Contains(t, setup.mockStderr.String(), "LFS file(s) changed")
-		require.Contains(t, strings.Join(commands, "\n"), "update-ref refs/rwx-sync HEAD")
+		// The post-exec revert also runs `update-ref refs/rwx-sync HEAD`; match
+		// the snapshot's commit step to confirm the LFS-skip path took it.
+		snapshotTaken := false
+		for _, cmd := range commands {
+			if strings.Contains(cmd, "commit --allow-empty") && strings.Contains(cmd, "update-ref refs/rwx-sync HEAD") {
+				snapshotTaken = true
+				break
+			}
+		}
+		require.True(t, snapshotTaken, "LFS-skip path should snapshot refs/rwx-sync")
 	})
 
 	t.Run("returns error when git apply fails", func(t *testing.T) {
@@ -1556,7 +1565,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Equal(t, runID, result.RunID)
 		require.Contains(t, pushOpts.Remote, "rwx-cli@rwx-sandbox-")
 		require.True(t, strings.HasSuffix(pushOpts.Remote, ":."))
-		require.True(t, strings.HasPrefix(pushOpts.Refspec, localHead+":refs/rwx/push/"))
+		require.Equal(t, "+"+localHead+":refs/rwx/sync-push", pushOpts.Refspec)
 		require.Len(t, pushOpts.Env, 2)
 		require.Contains(t, pushOpts.Env[0], "GIT_SSH_COMMAND=ssh")
 		require.Contains(t, pushOpts.Env[0], "-F /dev/null")
@@ -1674,7 +1683,9 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
 			commandOrder = append(commandOrder, cmd)
 			if strings.Contains(cmd, "git lfs fsck --objects") {
-				return 2, "objects: missing: large.bin (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)\n", nil
+				// Mirror real `git lfs fsck` output: a per-object error line plus a
+				// trailing `repair:` status line that must not be parsed as a file.
+				return 1, "objects: openError: large.bin (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) could not be checked: no such file or directory\nobjects: repair: moving corrupt objects to /sandbox/.git/lfs/bad\n", nil
 			}
 			return 0, "", nil
 		}
@@ -1694,7 +1705,9 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Contains(t, err.Error(), "  large.bin")
 		require.Contains(t, err.Error(), "To recover, push your changes and reset the sandbox.")
 		require.NotContains(t, err.Error(), "Git LFS check output:")
-		require.NotContains(t, err.Error(), "objects: missing: large.bin")
+		require.NotContains(t, err.Error(), "objects: openError")
+		require.NotContains(t, err.Error(), "2 LFS file(s)")
+		require.NotContains(t, err.Error(), "moving corrupt objects")
 
 		pushIndex := slices.IndexFunc(commandOrder, func(cmd string) bool {
 			return strings.HasPrefix(cmd, "git push ")
@@ -1705,6 +1718,113 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.NotEqual(t, -1, pushIndex)
 		require.NotEqual(t, -1, fsckIndex)
 		require.Less(t, pushIndex, fsckIndex)
+	})
+
+	t.Run("checkout failure surfaces the LFS error when fsck finds missing objects", func(t *testing.T) {
+		setup := setupTest(t)
+
+		runID := "run-checkout-fail-lfs"
+		address := "192.168.1.1:22"
+		localHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		oid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+		setup.mockGit.MockGetHead = localHead
+		setup.mockGit.MockGetBranch = "feature/checkout-fail-lfs"
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        address,
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error { return nil }
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
+			switch {
+			case strings.Contains(cmd, "checkout -f"):
+				return 1, nil
+			case strings.Contains(cmd, "cat-file -e"):
+				return 0, nil // commit already present -> no push
+			case strings.Contains(cmd, "rev-parse --verify -q refs/rwx-sync"):
+				return 1, nil
+			default:
+				return 0, nil
+			}
+		}
+		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
+			if strings.Contains(cmd, "git lfs fsck --objects") {
+				return 1, "objects: openError: large.bin (" + oid + ") could not be checked: no such file or directory\nobjects: repair: moving corrupt objects to /sandbox/.git/lfs/bad\n", nil
+			}
+			return 0, "", nil
+		}
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      runID,
+			Json:       true,
+			Sync:       true,
+		})
+
+		require.Nil(t, result)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "1 LFS file(s) changed locally and cannot be synced to the sandbox:")
+		require.Contains(t, err.Error(), "  large.bin")
+		require.NotContains(t, err.Error(), "failed to reset sandbox to local git state")
+	})
+
+	t.Run("checkout failure surfaces the checkout error when the LFS check cannot run", func(t *testing.T) {
+		setup := setupTest(t)
+
+		runID := "run-checkout-fail-transport"
+		address := "192.168.1.1:22"
+		localHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+		setup.mockGit.MockGetHead = localHead
+		setup.mockGit.MockGetBranch = "feature/checkout-fail-transport"
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        address,
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error { return nil }
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
+			switch {
+			case strings.Contains(cmd, "checkout -f"):
+				return 1, nil
+			case strings.Contains(cmd, "cat-file -e"):
+				return 0, nil // commit already present -> no push
+			case strings.Contains(cmd, "rev-parse --verify -q refs/rwx-sync"):
+				return 1, nil
+			default:
+				return 0, nil
+			}
+		}
+		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
+			if strings.Contains(cmd, "git lfs fsck --objects") {
+				return 0, "", fmt.Errorf("ssh connection lost")
+			}
+			return 0, "", nil
+		}
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      runID,
+			Json:       true,
+			Sync:       true,
+		})
+
+		require.Nil(t, result)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to reset sandbox to local git state")
+		require.NotContains(t, err.Error(), "LFS file(s) changed locally")
+		require.NotContains(t, err.Error(), "failed to check sandbox Git LFS objects")
 	})
 
 	t.Run("new sandbox sync removes pre-applied new files and snapshots only local dirty paths", func(t *testing.T) {


### PR DESCRIPTION
Follow-up fixes from a code review of #532 (git-push commit sync), which has since merged to `main`. This branch is based off the merged `main`.

## Fixes

- **LFS fsck parser counted a status line as a file.** Real `git lfs fsck --objects` output for one missing object is two `objects:`-prefixed lines — the per-object `openError` line *and* a `repair: moving corrupt objects to …` status line. The old colon-split parser treated the `repair:` line as a second changed file, so the error reported the wrong count and a bogus `.git/lfs/bad` path. The parser now matches only per-object lines (those with a trailing `(<oid>)`) and skips status lines. Verified against git-lfs 3.7.1.
- **Sandbox ref accumulation.** Commit sync now force-pushes to a single fixed ref `refs/rwx/sync-push` instead of a unique `refs/rwx/push/<pid>-<nano>` per exec, so the sandbox's ref namespace no longer accumulates dangling refs (pushes are serialized by the sandbox lock, and the commit stays reachable through checkout).
- **Checkout error masking.** The LFS check is split into `checkSandboxLFSObjects` returning `(missing, checkErr)`; the checkout-failure branch surfaces only a real missing-objects finding and lets the original checkout error through when the LFS check itself can't run (e.g. SSH transport error).
- **`refs/rwx-sync` snapshot in the dirty-LFS skip path** now respects `isNewSandbox` (path-scoped for new sandboxes) to match the normal sync path, instead of an unconditional `add -A`.
- **Temp-file cleanup** in `sandboxGitPushOptions` is now consistent (`defer cleanup()` before the error check; no private-key temp file left in `/tmp` on any path) and uses a single timestamp.
