### PR TITLE
Enrich rwx results --json from the results details endpoint

### DIFF
--- a/.rwx/integration/dispatch-test.yml
+++ b/.rwx/integration/dispatch-test.yml
@@ -72,7 +72,7 @@ tasks:
         exit 1
       fi
 
-      prompt=$(echo "$kickoff" | tail -1 | jq -r '.Prompt')
+      prompt=$(echo "$kickoff" | tail -1 | jq -r '.ResultPrompt')
       if ! echo "$prompt" | grep -q "fail-fast"; then
         echo "Expected prompt to include 'fail-fast', but it did not."
         echo "$kickoff"
@@ -110,7 +110,7 @@ tasks:
         exit 1
       fi
 
-      prompt=$(echo "$kickoff" | tail -1 | jq -r '.Prompt')
+      prompt=$(echo "$kickoff" | tail -1 | jq -r '.ResultPrompt')
       if ! echo "$prompt" | grep -q "fail-fast"; then
         echo "Expected prompt to include 'fail-fast', but it did not."
         echo "$kickoff"

--- a/.rwx/integration/results-test.yml
+++ b/.rwx/integration/results-test.yml
@@ -110,7 +110,7 @@ tasks:
         exit 1
       fi
 
-      prompt=$(echo "$result" | jq -r '.Prompt // empty')
+      prompt=$(echo "$result" | jq -r '.ResultPrompt // empty')
 
       if ! echo "$prompt" | grep -q "will-fail-fast"; then
         echo "Expected prompt to include 'will-fail-fast', but it did not."

--- a/.rwx/integration/run-test.yml
+++ b/.rwx/integration/run-test.yml
@@ -134,7 +134,7 @@ tasks:
         exit 1
       fi
 
-      prompt=$(echo "$kickoff" | jq -r '.Prompt // empty')
+      prompt=$(echo "$kickoff" | jq -r '.ResultPrompt // empty')
 
       if ! echo "$prompt" | grep -q "will-fail-fast"; then
         echo "Expected prompt to include 'will-fail-fast', but it did not."

--- a/cmd/rwx/dispatch.go
+++ b/cmd/rwx/dispatch.go
@@ -112,14 +112,14 @@ var (
 						RunID        string
 						RunURL       string
 						ResultStatus string
-						Prompt       string `json:",omitempty"`
+						ResultPrompt string `json:",omitempty"`
 					}{
 						RunID:        runs[0].RunID,
 						RunURL:       runs[0].RunURL,
 						ResultStatus: waitResult.ResultStatus,
 					}
 					if promptErr == nil {
-						jsonOutput.Prompt = promptResult.Prompt
+						jsonOutput.ResultPrompt = promptResult.Prompt
 					}
 					waitResultJson, err := json.Marshal(jsonOutput)
 					if err != nil {

--- a/cmd/rwx/results.go
+++ b/cmd/rwx/results.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/rwx-cloud/rwx/internal/api"
 	"github.com/rwx-cloud/rwx/internal/cli"
@@ -28,7 +29,16 @@ var (
 		GroupID: "outputs",
 		Use:     "results [run-id | run-id --task <key>]",
 		Short:   "Get results for a run",
-		Args:    cobra.MaximumNArgs(1),
+		Long: `Get results for a run.
+
+The default output is an LLM-friendly prompt for investigating run failures: the
+run's status plus a failure summary you can hand to a coding agent.
+
+Pass --output json to get structured run and task fields instead. For the full
+list of JSON fields, see https://rwx.com/docs/results or run:
+
+    rwx docs pull /results`,
+		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return requireAccessToken()
 		},
@@ -99,7 +109,32 @@ var (
 				if promptErr == nil {
 					jsonOutput.Prompt = promptResult.Prompt
 				}
-				resultJson, err := json.Marshal(jsonOutput)
+
+				baseJson, err := json.Marshal(jsonOutput)
+				if err != nil {
+					return err
+				}
+				var base map[string]any
+				if err := json.Unmarshal(baseJson, &base); err != nil {
+					return err
+				}
+
+				// Fetch the enriched payload and fold it into the base output. An
+				// empty object means enrichment is not enabled for the org, so the
+				// merge is a no-op. Pass the original run/task identifier (not the
+				// resolved run ID) so a task-scoped lookup stays task-scoped.
+				details, err := service.GetRunDetails(cli.GetRunDetailsConfig{
+					RunID:   runID,
+					TaskKey: ResultsTaskKey,
+				})
+				if err != nil {
+					return err
+				}
+				if len(details) > 0 {
+					base = MergeEnrichedResults(base, details)
+				}
+
+				resultJson, err := json.Marshal(base)
 				if err != nil {
 					return err
 				}
@@ -192,4 +227,66 @@ func HandleAmbiguousDefinitionPathError(err error, branch, repo string) error {
 	}
 
 	return err
+}
+
+// MergeEnrichedResults overlays the enriched /details payload onto the base JSON
+// map. The enriched payload uses snake_case keys, which are rewritten to
+// PascalCase to match the casing of the base payload. The enriched id is kept and
+// surfaced as ID (mirroring the run/task id already exposed as RunID/TaskID), so
+// callers can read it under any of those keys. Existing base keys are preserved on
+// collision.
+func MergeEnrichedResults(base, details map[string]any) map[string]any {
+	merged := make(map[string]any, len(base)+len(details))
+	for key, value := range base {
+		merged[key] = value
+	}
+	for key, value := range pascalCaseKeys(details).(map[string]any) {
+		if _, exists := merged[key]; !exists {
+			merged[key] = value
+		}
+	}
+
+	return merged
+}
+
+// pascalCaseKeys recursively rewrites map keys from snake_case to PascalCase,
+// recursing into nested maps and slices. Non-map/slice values are returned
+// unchanged.
+func pascalCaseKeys(v any) any {
+	switch value := v.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(value))
+		for key, nested := range value {
+			result[pascalCase(key)] = pascalCaseKeys(nested)
+		}
+		return result
+	case []any:
+		for i, element := range value {
+			value[i] = pascalCaseKeys(element)
+		}
+		return value
+	default:
+		return v
+	}
+}
+
+// pascalCase converts a snake_case identifier to PascalCase by upper-casing the
+// first rune of each underscore-delimited segment (e.g. completed_runtime_seconds
+// -> CompletedRuntimeSeconds). The "id" segment is treated as an initialism and
+// rendered as "ID" to match the base payload's RunID/TaskID keys.
+func pascalCase(key string) string {
+	var builder strings.Builder
+	for _, segment := range strings.Split(key, "_") {
+		if segment == "" {
+			continue
+		}
+		if strings.EqualFold(segment, "id") {
+			builder.WriteString("ID")
+			continue
+		}
+		runes := []rune(segment)
+		builder.WriteString(strings.ToUpper(string(runes[0])))
+		builder.WriteString(string(runes[1:]))
+	}
+	return builder.String()
 }

--- a/cmd/rwx/results.go
+++ b/cmd/rwx/results.go
@@ -99,7 +99,7 @@ list of JSON fields, see https://rwx.com/docs/results or run:
 					TaskID       string `json:",omitempty"`
 					ResultStatus string
 					Completed    bool
-					Prompt       string `json:",omitempty"`
+					ResultPrompt string `json:",omitempty"`
 				}{
 					RunID:        result.RunID,
 					TaskID:       result.TaskID,
@@ -107,7 +107,7 @@ list of JSON fields, see https://rwx.com/docs/results or run:
 					Completed:    result.Completed,
 				}
 				if promptErr == nil {
-					jsonOutput.Prompt = promptResult.Prompt
+					jsonOutput.ResultPrompt = promptResult.Prompt
 				}
 
 				baseJson, err := json.Marshal(jsonOutput)

--- a/cmd/rwx/results_test.go
+++ b/cmd/rwx/results_test.go
@@ -78,3 +78,51 @@ func TestHandleAmbiguousDefinitionPathError(t *testing.T) {
 		require.Equal(t, err, result)
 	})
 }
+
+func TestMergeEnrichedResults(t *testing.T) {
+	t.Run("PascalCases enriched keys, including nested maps and slices", func(t *testing.T) {
+		base := map[string]any{"RunID": "abc123"}
+		details := map[string]any{
+			"started_at": "2026-06-04T17:02:11Z",
+			"status":     map[string]any{"finished_status": "failed"},
+			"tasks": []any{
+				map[string]any{"id": "task_def456", "completed_runtime_seconds": float64(250)},
+			},
+		}
+
+		merged := rwx.MergeEnrichedResults(base, details)
+
+		require.Equal(t, "abc123", merged["RunID"])
+		require.Equal(t, "2026-06-04T17:02:11Z", merged["StartedAt"])
+		require.Equal(t, map[string]any{"FinishedStatus": "failed"}, merged["Status"])
+		require.Equal(t, []any{map[string]any{"ID": "task_def456", "CompletedRuntimeSeconds": float64(250)}}, merged["Tasks"])
+	})
+
+	t.Run("keeps the enriched id as ID alongside the base id keys", func(t *testing.T) {
+		base := map[string]any{"RunID": "abc123"}
+		details := map[string]any{"id": "abc123", "branch": "main"}
+
+		merged := rwx.MergeEnrichedResults(base, details)
+
+		require.Equal(t, "abc123", merged["ID"])
+		require.Equal(t, "abc123", merged["RunID"])
+		require.Equal(t, "main", merged["Branch"])
+	})
+
+	t.Run("preserves base keys on collision", func(t *testing.T) {
+		base := map[string]any{"Branch": "base-value"}
+		details := map[string]any{"branch": "enriched-value"}
+
+		merged := rwx.MergeEnrichedResults(base, details)
+
+		require.Equal(t, "base-value", merged["Branch"])
+	})
+
+	t.Run("returns base unchanged for empty details", func(t *testing.T) {
+		base := map[string]any{"RunID": "abc123", "ResultStatus": "failed"}
+
+		merged := rwx.MergeEnrichedResults(base, map[string]any{})
+
+		require.Equal(t, map[string]any{"RunID": "abc123", "ResultStatus": "failed"}, merged)
+	})
+}

--- a/cmd/rwx/run.go
+++ b/cmd/rwx/run.go
@@ -92,7 +92,7 @@ var (
 				DefinitionPath   string
 				Message          string
 				ResultStatus     string `json:",omitempty"`
-				Prompt           string `json:",omitempty"`
+				ResultPrompt     string `json:",omitempty"`
 			}{
 				RunID:            runResult.RunID,
 				RunURL:           runResult.RunURL,
@@ -137,7 +137,7 @@ var (
 				if useJson {
 					jsonOutput.ResultStatus = waitResult.ResultStatus
 					if err == nil {
-						jsonOutput.Prompt = promptResult.Prompt
+						jsonOutput.ResultPrompt = promptResult.Prompt
 					}
 					waitResultJson, err := json.Marshal(jsonOutput)
 					if err != nil {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1103,6 +1103,37 @@ func (c Client) RunStatus(cfg RunStatusConfig) (RunStatusResult, error) {
 	return result, nil
 }
 
+func (c Client) GetRunDetails(cfg RunDetailsConfig) (map[string]any, error) {
+	params := url.Values{}
+	if cfg.TaskKey != "" {
+		params.Set("run_id", cfg.RunID)
+		params.Set("task_key", cfg.TaskKey)
+	} else {
+		params.Set("id", cfg.RunID)
+	}
+	endpoint := "/mint/api/results/details?" + params.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create new HTTP request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.RoundTrip(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "HTTP request failed")
+	}
+	defer resp.Body.Close()
+
+	result := map[string]any{}
+	if err = decodeResponseJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (c Client) GetRunPrompt(runID string) (string, error) {
 	endpoint := fmt.Sprintf("/mint/api/results/prompt?id=%s", url.QueryEscape(runID))
 

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -337,6 +337,11 @@ type RunStatusConfig struct {
 	FailFast       bool
 }
 
+type RunDetailsConfig struct {
+	RunID   string
+	TaskKey string
+}
+
 type RunStatus struct {
 	Result string `json:"result"`
 }

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -39,6 +39,7 @@ type APIClient interface {
 	TaskKeyStatus(api.TaskKeyStatusConfig) (api.TaskStatusResult, error)
 	TaskIDStatus(api.TaskIDStatusConfig) (api.TaskStatusResult, error)
 	RunStatus(api.RunStatusConfig) (api.RunStatusResult, error)
+	GetRunDetails(api.RunDetailsConfig) (map[string]any, error)
 	GetLogDownloadRequest(taskId string) (api.LogDownloadRequestResult, error)
 	GetLogDownloadRequestByTaskKey(runID, taskKey string) (api.LogDownloadRequestResult, error)
 	DownloadLogs(api.LogDownloadRequestResult, ...int) ([]byte, error)

--- a/internal/cli/service_details.go
+++ b/internal/cli/service_details.go
@@ -1,0 +1,17 @@
+package cli
+
+import (
+	"github.com/rwx-cloud/rwx/internal/api"
+)
+
+type GetRunDetailsConfig struct {
+	RunID   string
+	TaskKey string
+}
+
+func (s Service) GetRunDetails(cfg GetRunDetailsConfig) (map[string]any, error) {
+	return s.APIClient.GetRunDetails(api.RunDetailsConfig{
+		RunID:   cfg.RunID,
+		TaskKey: cfg.TaskKey,
+	})
+}

--- a/internal/cli/service_details_test.go
+++ b/internal/cli/service_details_test.go
@@ -1,0 +1,43 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/cli"
+	"github.com/rwx-cloud/rwx/internal/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_GetRunDetails(t *testing.T) {
+	t.Run("passes the run ID and task key through to the API", func(t *testing.T) {
+		setup := setupTest(t)
+
+		setup.mockAPI.MockGetRunDetails = func(cfg api.RunDetailsConfig) (map[string]any, error) {
+			require.Equal(t, "run-123", cfg.RunID)
+			require.Equal(t, "ci.rspec", cfg.TaskKey)
+			return map[string]any{"id": "run-123"}, nil
+		}
+
+		details, err := setup.service.GetRunDetails(cli.GetRunDetailsConfig{
+			RunID:   "run-123",
+			TaskKey: "ci.rspec",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{"id": "run-123"}, details)
+	})
+
+	t.Run("returns error when API fails", func(t *testing.T) {
+		setup := setupTest(t)
+
+		setup.mockAPI.MockGetRunDetails = func(cfg api.RunDetailsConfig) (map[string]any, error) {
+			return nil, errors.New("422 Unprocessable Entity")
+		}
+
+		details, err := setup.service.GetRunDetails(cli.GetRunDetailsConfig{RunID: "run-123"})
+
+		require.Nil(t, details)
+		require.Error(t, err)
+	})
+}

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -34,6 +34,7 @@ type API struct {
 	MockTaskKeyStatus                           func(api.TaskKeyStatusConfig) (api.TaskStatusResult, error)
 	MockTaskIDStatus                            func(api.TaskIDStatusConfig) (api.TaskStatusResult, error)
 	MockRunStatus                               func(api.RunStatusConfig) (api.RunStatusResult, error)
+	MockGetRunDetails                           func(api.RunDetailsConfig) (map[string]any, error)
 	MockGetLogDownloadRequest                   func(string) (api.LogDownloadRequestResult, error)
 	MockGetLogDownloadRequestByTaskKey          func(string, string) (api.LogDownloadRequestResult, error)
 	MockDownloadLogs                            func(api.LogDownloadRequestResult) ([]byte, error)
@@ -271,6 +272,14 @@ func (c *API) RunStatus(cfg api.RunStatusConfig) (api.RunStatusResult, error) {
 	}
 
 	return api.RunStatusResult{}, errors.New("MockRunStatus was not configured")
+}
+
+func (c *API) GetRunDetails(cfg api.RunDetailsConfig) (map[string]any, error) {
+	if c.MockGetRunDetails != nil {
+		return c.MockGetRunDetails(cfg)
+	}
+
+	return nil, errors.New("MockGetRunDetails was not configured")
 }
 
 func (c *API) GetLogDownloadRequest(taskId string) (api.LogDownloadRequestResult, error) {


### PR DESCRIPTION
### Background

- Linear: [RWX-962](https://linear.app/rwx-cloud/issue/RWX-962) (also relates to [RWX-897](https://linear.app/rwx-cloud/issue/RWX-897))
- Server-side endpoint: rwx-cloud/cloud#7626

We want to expose more detailed information about runs and tasks via `rwx results --json`. Before launch, a docs page at rwx.com/docs/results will list the available attributes, so the help text refers to that rather than baking the docs into the client.

### Problem

`rwx results --json` returns a fixed shape focused on the actionable failure prompt. The new `/mint/api/results/details` endpoint returns a richer curated payload, but the CLI doesn't consume it.

### Solution

- Fetch the curated payload from `/mint/api/results/details` and fold it into the base JSON output.
- Enriched snake_case keys are rewritten to PascalCase to match the existing output casing. The enriched `id` is surfaced as `ID` alongside `RunID`/`TaskID`.
- An empty payload (enrichment not enabled for the org) leaves the base output unchanged, so this is a no-op until the endpoint is rolled out.
- Task-scoped lookups stay task-scoped: the original run/task identifier is passed through rather than the resolved run ID.
- The plain-text (non-JSON) output is unchanged.

The `--billing` / `--performance` augmentation flags were **descoped** from this PR to keep it focused on the core enrichment. Their implementation is stashed in [RWX-989](https://linear.app/rwx-cloud/issue/RWX-989/re-add-billing-performance-augmentation-flags-to-rwx-results-json) for re-add later.

### Example outputs

Help text:

```
╰─⠠⠵ ./rwx results --help
Get results for a run.

The default output is an LLM-friendly prompt for investigating run failures: the
run's status plus a failure summary you can hand to a coding agent.

Pass --output json to get structured run and task fields instead. For the full
list of JSON fields, see https://rwx.com/docs/results or run:

    rwx docs pull /results

Usage:
  rwx results [run-id | run-id --task <key>] [flags]

Flags:
      --branch string       get results for a specific branch instead of the current git branch
      --commit string       get results for a specific commit SHA
      --definition string   get results for a specific definition path
      --fail-fast           stop waiting when failures are available (only has an effect when used with --wait)
  -h, --help                help for results
      --open                open the run in a browser
      --repo string         get results for a specific repository instead of the current git repository
      --task string         task key (e.g., ci.checks.lint); resolves the task by key instead of ID
      --wait                poll for the run to complete and report the result status

Global Flags:
      --access-token string   the access token for RWX (default "$RWX_ACCESS_TOKEN")
      --output string         output format: text or json (default "text")
```

Command task piped into jq (abridged):

```
╰─⠠⠵ ./rwx results f068b078bca8b14180335cde89859698 | jq
{
  "ArtifactCount": 1,
  "AttemptCount": 1,
  "Completed": true,
  "CompletedAt": "2026-06-02T13:05:28.873Z",
  "Key": "write-artifact",
  "ResultStatus": "succeeded",
  "RunID": "611b86e40127478bb6bd4ce9a196b159",
  "StartedAt": "2026-06-02T13:05:27.290Z",
  "TaskID": "f068b078bca8b14180335cde89859698",
  "TaskStatus": {
    "AbortedStatus": "not_applicable",
    "Execution": "finished",
    "FinishedStatus": "executed",
    "Result": "succeeded",
    "WaitingStatus": "not_applicable"
  },
  "TaskType": "command"
}
```

#### Further confirmation needed

- [ ] Verify end-to-end against the live `/mint/api/results/details` endpoint once it ships (the merge is a no-op against the current empty response).
