### PR TITLE
Fix sandbox sync snapshot for staged deletes

### DIFF
--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1834,7 +1834,7 @@ func (s Service) snapshotSandboxSyncRefForPaths(paths []string) error {
 		for i, path := range paths {
 			quoted[i] = quoteShellArg(path)
 		}
-		script += "/usr/bin/git add -A -- " + strings.Join(quoted, " ") + " && "
+		script += "/usr/bin/git update-index --add --remove -- " + strings.Join(quoted, " ") + " && "
 	} else if paths == nil {
 		script += "/usr/bin/git add -A && "
 	}

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1916,10 +1916,104 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.NotEqual(t, -1, applyIndex)
 		require.NotEqual(t, -1, snapshotIndex)
 		require.Less(t, cleanIndex, applyIndex)
-		require.Contains(t, order[snapshotIndex], "/usr/bin/git add -A --")
+		require.Contains(t, order[snapshotIndex], "/usr/bin/git update-index --add --remove --")
 		require.Contains(t, order[snapshotIndex], "dir with space/quote")
 		require.Contains(t, order[snapshotIndex], "file.txt")
 		require.NotContains(t, order[snapshotIndex], "/usr/bin/git add -A &&")
+	})
+
+	t.Run("new sandbox sync snapshots staged deletions with unstaged edits", func(t *testing.T) {
+		setup := setupTest(t)
+
+		configFile := setup.absConfig(".rwx/sandbox.yml")
+		require.NoError(t, os.WriteFile(configFile, []byte("base:\n  image: ubuntu:24.04\ntasks:\n  - key: sandbox\n    run: rwx-sandbox\n"), 0o644))
+		localHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		deletedPath := "deleted.txt"
+		editedPath := "edited.txt"
+		stagedDeletePatch := []byte("diff --git a/" + deletedPath + " b/" + deletedPath + "\ndeleted file mode 100644\nindex c42fa8d..0000000\n--- a/" + deletedPath + "\n+++ /dev/null\n@@ -1 +0,0 @@\n-deleted-content\n")
+		unstagedEditPatch := []byte("diff --git a/" + editedPath + " b/" + editedPath + "\nindex c42fa8d..5bd8a42 100644\n--- a/" + editedPath + "\n+++ b/" + editedPath + "\n@@ -1 +1 @@\n-old-content\n+new-content\n")
+
+		setup.mockGit.MockGetBranch = "feature/new-sandbox"
+		setup.mockGit.MockGetHead = localHead
+		setup.mockGit.MockGetCommit = "base"
+		setup.mockGit.MockGetOriginUrl = "git@github.com:example/repo.git"
+		setup.mockGit.MockGeneratePatchFile = git.PatchFile{}
+		setup.mockGit.MockGenerateDirtyPatches = func() (git.DirtyPatches, error) {
+			return git.DirtyPatches{
+				Staged:   stagedDeletePatch,
+				Unstaged: unstagedEditPatch,
+				Files:    []string{deletedPath, editedPath},
+			}, nil
+		}
+
+		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
+			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+		}
+		setup.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+			return &api.InitiateRunResult{
+				RunID:  "run-new",
+				RunURL: "https://cloud.rwx.com/runs/run-new",
+			}, nil
+		}
+		setup.mockAPI.MockCreateSandboxToken = func(cfg api.CreateSandboxTokenConfig) (*api.CreateSandboxTokenResult, error) {
+			return &api.CreateSandboxTokenResult{Token: "new-token"}, nil
+		}
+		setup.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+			return &api.PackageVersionsResult{}, nil
+		}
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error { return nil }
+
+		var order []string
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
+			switch {
+			case strings.Contains(cmd, "rev-parse --verify -q refs/rwx-sync"):
+				return 1, nil
+			case strings.Contains(cmd, "cat-file -e"):
+				return 0, nil
+			case strings.Contains(cmd, "update-ref refs/rwx-sync HEAD") && strings.Contains(cmd, "/usr/bin/git add -A --") && strings.Contains(cmd, deletedPath):
+				return 128, nil
+			}
+			order = append(order, cmd)
+			return 0, nil
+		}
+		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
+			return 0, "", nil
+		}
+		var appliedPatches []string
+		setup.mockSSH.MockExecuteCommandWithStdinAndCombinedOutput = func(command string, stdin io.Reader) (int, string, error) {
+			order = append(order, command)
+			data, _ := io.ReadAll(stdin)
+			appliedPatches = append(appliedPatches, string(data))
+			return 0, "", nil
+		}
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"true"},
+			Json:       true,
+			Sync:       true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "run-new", result.RunID)
+		require.Equal(t, []string{string(stagedDeletePatch), string(unstagedEditPatch)}, appliedPatches)
+
+		snapshotIndex := slices.IndexFunc(order, func(cmd string) bool {
+			return strings.Contains(cmd, "update-ref refs/rwx-sync HEAD")
+		})
+		require.NotEqual(t, -1, snapshotIndex)
+		require.Contains(t, order[snapshotIndex], "/usr/bin/git update-index --add --remove --")
+		require.Contains(t, order[snapshotIndex], deletedPath)
+		require.Contains(t, order[snapshotIndex], editedPath)
+		require.NotContains(t, order[snapshotIndex], "/usr/bin/git add -A --")
 	})
 
 	t.Run("fetches remote refs without pushing when fetch provides local head", func(t *testing.T) {

--- a/test/integration/sandbox-staged-delete-sync.sh
+++ b/test/integration/sandbox-staged-delete-sync.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/sandbox-helpers.sh"
+
+DELETED_FILE="CONTRIBUTING.md"
+EDITED_FILE="README.md"
+EDIT_MARKER="integration staged delete sync marker"
+
+cleanup() {
+  git restore --staged "${DELETED_FILE}" 2>/dev/null || true
+  git restore "${DELETED_FILE}" "${EDITED_FILE}" 2>/dev/null || true
+  rm -f setup-artifact.txt
+  "${RWX_CLI}" sandbox stop 2>/dev/null || true
+}
+trap cleanup EXIT
+
+git rm "${DELETED_FILE}"
+printf '\n%s\n' "${EDIT_MARKER}" >> "${EDITED_FILE}"
+
+"${RWX_CLI}" sandbox exec \
+  "${SCRIPT_DIR}/definitions/sandbox-setup-sync.yml" \
+  --init "ref=${COMMIT_SHA}" \
+  -- sh -c "test ! -e '${DELETED_FILE}' && grep -q '${EDIT_MARKER}' '${EDITED_FILE}'"
+
+echo "PASS: fresh sandbox sync handled staged deletion with unstaged edit"


### PR DESCRIPTION
## Summary

Fix fresh sandbox sync snapshot creation when local dirty state includes a staged deletion and a separate unstaged edit.

The fresh-sandbox snapshot path now uses:

```sh
git update-index --add --remove -- <dirty paths>
```

instead of:

```sh
git add -A -- <dirty paths>
```

## What was wrong

Before running a sandbox command, the CLI syncs local dirty state into the sandbox and then creates `refs/rwx-sync`. That ref is the pull baseline: after the command finishes, the CLI diffs the sandbox against `refs/rwx-sync` so it only pulls back changes made by the command, not the local dirty changes it just pushed.

For fresh sandboxes, the CLI snapshots only the local dirty paths. This is intentional: a fresh sandbox may already contain setup-task outputs created before `rwx-sandbox`, and a full `git add -A` would bake those setup outputs into `refs/rwx-sync`, preventing them from being pulled back.

The staged-delete case broke that selective snapshot. The staged patch is applied first with `git apply --index`, so the deleted path is already gone from both the sandbox worktree and sandbox index. The subsequent snapshot command still included that path:

```sh
git add -A -- deleted.txt edited.txt
```

Git fails with:

```text
fatal: pathspec 'deleted.txt' did not match any files
```

That aborts sync before the sandbox command runs.

## Why fresh and reused sandboxes differ

Reused sandboxes snapshot with full-tree staging because they should already reflect the local baseline:

```sh
git add -A
```

That path does not pass an explicit deleted pathspec, so it does not hit the pathspec failure.

Fresh sandboxes use selective staging:

```sh
git add -A -- <dirty paths>
```

That selective path is where an already-applied staged deletion can become an invalid pathspec.

## How this fixes it

`git update-index --add --remove -- <dirty paths>` preserves the selective fresh-sandbox behavior while handling all dirty path states in one batched git command:

- modified paths are added to the index
- new paths are added to the index
- unstaged deletions are removed from the index
- staged deletions that are already removed from the index do not fail pathspec matching

This keeps setup-task outputs out of `refs/rwx-sync`, avoids one git process per dirty path, and allows staged deletions plus unstaged edits to sync into a fresh sandbox.
