### PR TITLE
Harden skill update against a non-semver latest version

### DIFF
--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -225,7 +225,7 @@ func (s Service) SkillUpdate(symlink string) (*SkillUpdateResult, error) {
 	}
 	latestVersion, err := semver.NewVersion(latestVersionStr)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to parse latest skill version")
+		return &SkillUpdateResult{}, nil
 	}
 
 	var entries []SkillUpdateEntry

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -356,6 +356,25 @@ func TestSkillUpdate(t *testing.T) {
 		require.Equal(t, "skipped", result.Entries[0].Action)
 		require.Equal(t, "marketplace", result.Entries[0].Installation.Source)
 	})
+
+	t.Run("unparseable latest version returns empty entries", func(t *testing.T) {
+		s := setupSkillTest(t)
+		seedSkillFile(t, s.tmp, "1.0.0")
+
+		s.mockAPI.MockGetSkillLatestVersion = func() (string, error) {
+			return "dev", nil
+		}
+
+		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+
+		var err error
+		s.service, err = cli.NewService(s.config)
+		require.NoError(t, err)
+
+		result, err := s.service.SkillUpdate("")
+		require.NoError(t, err)
+		require.Empty(t, result.Entries)
+	})
 }
 
 func TestSkillInstall(t *testing.T) {


### PR DESCRIPTION
I was looking into what we could do to prevent false positive nudges for updating the rwx skill when using a fake github server-side. One thing I considered was having the server return `dev` as a version, but the CLI would have blown up if I'd done that.

This PR fixes that CLI vulnerability, though we'll actually just be returning a lower semver from the server instead (https://github.com/rwx-cloud/cloud/pull/7685), so this change is purely defensive.