### PR TITLE
Anchor rwx run patch to the repository root

### DIFF
--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -74,6 +74,7 @@ type GitClient interface {
 	GetHeadCommit() (string, error)
 	GetCommit() (string, error)
 	GetOriginUrl() string
+	RelativePathToTopLevel(path string) string
 	GeneratePatchFile(destDir string, pathspec []string) (git.PatchFile, error)
 	GeneratePatch(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error)
 	GenerateDirtyPatches() (git.DirtyPatches, error)

--- a/internal/cli/service_run.go
+++ b/internal/cli/service_run.go
@@ -197,8 +197,17 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 	}
 
 	if patchable {
+		// Anchor the patch to the repository root with git's :(top) magic so it
+		// captures changes everywhere in the repo, not just the current working
+		// directory. A bare "." pathspec is relative to cwd, which silently scoped
+		// the patch to a subtree when `rwx run` was invoked from a subdirectory.
+		patchPathspec := []string{".", ":!" + relativeRunDefinitionPath}
+		if topRelativeRunDefinitionPath := s.GitClient.RelativePathToTopLevel(runDefinitionPath); topRelativeRunDefinitionPath != "" {
+			patchPathspec = []string{":(top)", ":(top,exclude)" + topRelativeRunDefinitionPath}
+		}
+
 		var patchErr error
-		patchFile, patchErr = s.GitClient.GeneratePatchFile(patchDir, []string{".", ":!" + relativeRunDefinitionPath})
+		patchFile, patchErr = s.GitClient.GeneratePatchFile(patchDir, patchPathspec)
 		if patchErr != nil {
 			errorMessage = patchErr.Error()
 			fmt.Fprintf(s.Stderr, "Warning: failed to generate patch: %s\n\n", errorMessage)

--- a/internal/cli/service_run_patch_test.go
+++ b/internal/cli/service_run_patch_test.go
@@ -246,6 +246,91 @@ func TestService_InitiatingRunPatch(t *testing.T) {
 		require.Contains(t, s.mockStderr.String(), "Warning: failed to generate patch: unable to generate patch data")
 	})
 
+	t.Run("anchors the patch pathspec to the repo top level", func(t *testing.T) {
+		s := setupTest(t)
+		s.mockGit.MockGetCommit = "3e76c8295cd0ce4decbf7b56253c902ce296cb25"
+
+		var receivedRunDefinitionPath string
+		s.mockGit.MockRelativePathToTopLevel = func(path string) string {
+			receivedRunDefinitionPath = path
+			return ".rwx/rwx.yml"
+		}
+
+		rwxDir := filepath.Join(s.tmp, ".rwx")
+		err := os.MkdirAll(rwxDir, 0o755)
+		require.NoError(t, err)
+
+		definitionsFile := filepath.Join(rwxDir, "rwx.yml")
+		definition := "on:\n  cli:\n    init:\n      sha: ${{ event.git.sha }}\n\nbase:\n  os: ubuntu 24.04\n  tag: 1.0\n\ntasks:\n  - key: foo\n    run: echo 'bar'\n"
+		err = os.WriteFile(definitionsFile, []byte(definition), 0o644)
+		require.NoError(t, err)
+
+		s.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+			return &api.PackageVersionsResult{
+				LatestMajor: make(map[string]string),
+				LatestMinor: make(map[string]map[string]string),
+			}, nil
+		}
+		s.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+			return &api.InitiateRunResult{
+				RunID:  "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+				RunURL: "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+			}, nil
+		}
+
+		_, err = s.service.InitiateRun(cli.InitiateRunConfig{
+			RwxDirectory: rwxDir,
+			MintFilePath: definitionsFile,
+			Patchable:    true,
+		})
+		require.NoError(t, err)
+
+		// The exclusion is computed from the resolved run definition path.
+		require.Equal(t, definitionsFile, receivedRunDefinitionPath)
+		// The patch is anchored to the repo root so coverage is independent of cwd.
+		require.Equal(t, []string{":(top)", ":(top,exclude).rwx/rwx.yml"}, s.mockGit.GeneratePatchFilePathspec)
+	})
+
+	t.Run("falls back to a cwd-relative pathspec when the top level is unknown", func(t *testing.T) {
+		s := setupTest(t)
+		s.mockGit.MockGetCommit = "3e76c8295cd0ce4decbf7b56253c902ce296cb25"
+		// MockRelativePathToTopLevel is unset, so it returns "" (top level unknown).
+
+		rwxDir := filepath.Join(s.tmp, ".rwx")
+		err := os.MkdirAll(rwxDir, 0o755)
+		require.NoError(t, err)
+
+		definitionsFile := filepath.Join(rwxDir, "rwx.yml")
+		definition := "on:\n  cli:\n    init:\n      sha: ${{ event.git.sha }}\n\nbase:\n  os: ubuntu 24.04\n  tag: 1.0\n\ntasks:\n  - key: foo\n    run: echo 'bar'\n"
+		err = os.WriteFile(definitionsFile, []byte(definition), 0o644)
+		require.NoError(t, err)
+
+		s.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+			return &api.PackageVersionsResult{
+				LatestMajor: make(map[string]string),
+				LatestMinor: make(map[string]map[string]string),
+			}, nil
+		}
+		s.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+			return &api.InitiateRunResult{
+				RunID:  "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+				RunURL: "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+			}, nil
+		}
+
+		_, err = s.service.InitiateRun(cli.InitiateRunConfig{
+			RwxDirectory: rwxDir,
+			MintFilePath: definitionsFile,
+			Patchable:    true,
+		})
+		require.NoError(t, err)
+
+		pathspec := s.mockGit.GeneratePatchFilePathspec
+		require.Len(t, pathspec, 2)
+		require.Equal(t, ".", pathspec[0])
+		require.True(t, strings.HasPrefix(pathspec[1], ":!"), "expected a cwd-relative exclude, got %q", pathspec[1])
+	})
+
 	t.Run("when the run is not patchable", func(t *testing.T) {
 		// it launches a run but does not patch
 		result := initiateRun(t, git.PatchFile{}, api.PatchMetadata{})

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -469,7 +469,15 @@ func (c *Client) GeneratePatch(pathspec []string) ([]byte, *LFSChangedFilesMetad
 }
 
 func (c *Client) GenerateDirtyPatches() (DirtyPatches, error) {
-	cleanup, err := c.AddUntrackedFilesForPatch(nil)
+	// Anchor the untracked-file lookup to the repository root with git's :(top)
+	// magic so the sandbox sync captures untracked files everywhere in the repo,
+	// not just under the current working directory. Falls back to the cwd-scoped
+	// lookup if the top level can't be resolved.
+	var untrackedPathspec []string
+	if c.GetTopLevel() != "" {
+		untrackedPathspec = []string{":(top)"}
+	}
+	cleanup, err := c.AddUntrackedFilesForPatch(untrackedPathspec)
 	if err != nil {
 		cleanup = func() {}
 	}

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -76,7 +76,9 @@ func (c *Client) RelativePathToTopLevel(path string) string {
 		return ""
 	}
 
-	return rel
+	// Git pathspecs always use forward slashes, even on Windows where
+	// filepath.Rel returns backslash-separated paths.
+	return filepath.ToSlash(rel)
 }
 
 func (c *Client) GetBranch() string {
@@ -352,7 +354,7 @@ func (c *Client) generatePatchData(pathspec []string) patchResult {
 }
 
 func (c *Client) GeneratePatchFile(destDir string, pathspec []string) (PatchFile, error) {
-	cleanup, err := c.AddUntrackedFilesForPatch()
+	cleanup, err := c.AddUntrackedFilesForPatch(pathspec)
 	if err != nil {
 		cleanup = func() {}
 	}
@@ -388,10 +390,19 @@ func (c *Client) GeneratePatchFile(destDir string, pathspec []string) (PatchFile
 }
 
 // AddUntrackedFilesForPatch temporarily adds untracked files with intent-to-add
-// so they appear in git diff. Returns a cleanup function to undo the add.
-func (c *Client) AddUntrackedFilesForPatch() (cleanup func(), err error) {
+// so they appear in git diff. The pathspec must match the one used to generate
+// the patch, so that intent-to-add coverage is scoped identically to the diff
+// (e.g. a :(top) pathspec captures untracked files across the whole repo, not
+// just those under the current working directory). Returns a cleanup function
+// to undo the add.
+func (c *Client) AddUntrackedFilesForPatch(pathspec []string) (cleanup func(), err error) {
 	// Get untracked files
-	cmd := exec.Command(c.Binary, "ls-files", "--others", "--exclude-standard")
+	lsArgs := []string{"ls-files", "--others", "--exclude-standard"}
+	if len(pathspec) > 0 {
+		lsArgs = append(lsArgs, "--")
+		lsArgs = append(lsArgs, pathspec...)
+	}
+	cmd := exec.Command(c.Binary, lsArgs...)
 	cmd.Dir = c.Dir
 	output, err := cmd.Output()
 	if err != nil {
@@ -434,7 +445,7 @@ func (c *Client) AddUntrackedFilesForPatch() (cleanup func(), err error) {
 // Returns (nil, nil, nil) if no changes or unable to generate patch.
 func (c *Client) GeneratePatch(pathspec []string) ([]byte, *LFSChangedFilesMetadata, error) {
 	// Add untracked files temporarily so they appear in the diff
-	cleanup, err := c.AddUntrackedFilesForPatch()
+	cleanup, err := c.AddUntrackedFilesForPatch(pathspec)
 	if err != nil {
 		// Non-fatal: proceed without untracked files
 		cleanup = func() {}
@@ -458,7 +469,7 @@ func (c *Client) GeneratePatch(pathspec []string) ([]byte, *LFSChangedFilesMetad
 }
 
 func (c *Client) GenerateDirtyPatches() (DirtyPatches, error) {
-	cleanup, err := c.AddUntrackedFilesForPatch()
+	cleanup, err := c.AddUntrackedFilesForPatch(nil)
 	if err != nil {
 		cleanup = func() {}
 	}

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -48,6 +48,37 @@ func (c *Client) GetTopLevel() string {
 	return strings.TrimSpace(string(out))
 }
 
+// RelativePathToTopLevel expresses path relative to the repository's top-level
+// directory, so it can be used in a :(top)-anchored pathspec independent of the
+// current working directory. It returns "" when the top level can't be
+// determined or path lies outside the work tree.
+func (c *Client) RelativePathToTopLevel(path string) string {
+	topLevel := c.GetTopLevel()
+	if topLevel == "" {
+		return ""
+	}
+
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(c.Dir, path)
+	}
+
+	// Resolve symlinks so both paths share a base; e.g. on macOS /var is a
+	// symlink to /private/var and git reports the resolved top-level path.
+	if resolved, err := filepath.EvalSymlinks(topLevel); err == nil {
+		topLevel = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+
+	rel, err := filepath.Rel(topLevel, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return ""
+	}
+
+	return rel
+}
+
 func (c *Client) GetBranch() string {
 	cmd := exec.Command(c.Binary, "branch", "--show-current")
 	cmd.Dir = c.Dir

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -579,6 +579,29 @@ func TestGeneratePatchFile(t *testing.T) {
 			require.Equal(t, []string{}, patchFile.UntrackedFiles.Files)
 			require.Equal(t, 0, patchFile.UntrackedFiles.Count)
 		})
+
+		t.Run("captures changes outside cwd when anchored to the repo top level", func(t *testing.T) {
+			tempDir, _ := repoFixture(t, "testdata/GeneratePatchFile-toplevel")
+
+			// Invoke from a nested subdirectory to prove coverage is independent of cwd.
+			client := &git.Client{Binary: "git", Dir: filepath.Join(tempDir, "repo", "nested")}
+
+			rel := client.RelativePathToTopLevel(filepath.Join(tempDir, "repo", ".rwx", "rwx.yml"))
+			require.Equal(t, filepath.Join(".rwx", "rwx.yml"), rel)
+
+			patchFile, err := client.GeneratePatchFile(t.TempDir(), []string{":(top)", ":(top,exclude)" + rel})
+			require.NoError(t, err)
+			require.True(t, patchFile.Written)
+
+			patch, err := os.ReadFile(patchFile.Path)
+			require.NoError(t, err)
+			// Changes at the repo root and in a sibling subtree are included even
+			// though cwd is nested/.
+			require.Contains(t, string(patch), "root-change.txt")
+			require.Contains(t, string(patch), "nested-change.txt")
+			// The run definition is excluded.
+			require.NotContains(t, string(patch), "rwx.yml")
+		})
 	})
 }
 

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -399,6 +399,36 @@ func TestGenerateDirtyPatches(t *testing.T) {
 	require.Equal(t, "staged.txt", cachedNames)
 }
 
+func TestGenerateDirtyPatchesFromSubdirectory(t *testing.T) {
+	repo := t.TempDir()
+	mustGit(t, repo, "init")
+	mustGit(t, repo, "config", "user.email", "test@example.com")
+	mustGit(t, repo, "config", "user.name", "Test")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\n"), 0o644))
+	require.NoError(t, os.Mkdir(filepath.Join(repo, "nested"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "nested", "nested-tracked.txt"), []byte("base\n"), 0o644))
+	mustGit(t, repo, "add", ".")
+	mustGit(t, repo, "commit", "-m", "base")
+
+	// Changes spread across the repo, with untracked files both at the root and in
+	// the nested subdirectory we'll invoke from.
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("base\nroot-change\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "root-untracked.txt"), []byte("root-untracked\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "nested", "nested-untracked.txt"), []byte("nested-untracked\n"), 0o644))
+
+	// Driving git from a subdirectory must not scope the untracked-file lookup to
+	// that subtree; the root untracked file has to be captured too.
+	client := &git.Client{Binary: "git", Dir: filepath.Join(repo, "nested")}
+	patches, err := client.GenerateDirtyPatches()
+	require.NoError(t, err)
+
+	require.Contains(t, string(patches.Unstaged), "tracked.txt")
+	require.Contains(t, string(patches.Unstaged), "root-untracked.txt")
+	require.Contains(t, string(patches.Unstaged), "nested-untracked.txt")
+	require.ElementsMatch(t, []string{"tracked.txt", "root-untracked.txt", "nested/nested-untracked.txt"}, patches.Files)
+	require.ElementsMatch(t, []string{"root-untracked.txt", "nested/nested-untracked.txt"}, patches.NewFiles)
+}
+
 func TestPushRef(t *testing.T) {
 	source := t.TempDir()
 	mustGit(t, source, "init")

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -596,8 +596,9 @@ func TestGeneratePatchFile(t *testing.T) {
 			patch, err := os.ReadFile(patchFile.Path)
 			require.NoError(t, err)
 			// Changes at the repo root and in a sibling subtree are included even
-			// though cwd is nested/.
+			// though cwd is nested/, including untracked files outside cwd.
 			require.Contains(t, string(patch), "root-change.txt")
+			require.Contains(t, string(patch), "root-untracked.txt")
 			require.Contains(t, string(patch), "nested-change.txt")
 			// The run definition is excluded.
 			require.NotContains(t, string(patch), "rwx.yml")

--- a/internal/git/testdata/GeneratePatchFile-toplevel
+++ b/internal/git/testdata/GeneratePatchFile-toplevel
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eou pipefail
+
+mkdir origin
+pushd origin > /dev/null
+git init > /dev/null
+git commit --allow-empty -m "Initial commit" > /dev/null
+
+git rev-parse HEAD
+
+popd > /dev/null
+
+git clone origin repo > /dev/null 2>&1
+
+pushd repo > /dev/null
+# a change at the repo root
+touch root-change.txt
+git add root-change.txt
+# a change in a nested subdirectory we'll invoke from
+mkdir -p nested
+touch nested/nested-change.txt
+git add nested/nested-change.txt
+# the run definition we want excluded from the patch
+mkdir .rwx
+touch .rwx/rwx.yml
+git add .rwx/rwx.yml
+popd > /dev/null

--- a/internal/git/testdata/GeneratePatchFile-toplevel
+++ b/internal/git/testdata/GeneratePatchFile-toplevel
@@ -13,9 +13,11 @@ popd > /dev/null
 git clone origin repo > /dev/null 2>&1
 
 pushd repo > /dev/null
-# a change at the repo root
+# a staged change at the repo root
 touch root-change.txt
 git add root-change.txt
+# an untracked file at the repo root (outside the nested cwd)
+echo "untracked at root" > root-untracked.txt
 # a change in a nested subdirectory we'll invoke from
 mkdir -p nested
 touch nested/nested-change.txt

--- a/internal/mocks/git.go
+++ b/internal/mocks/git.go
@@ -15,6 +15,7 @@ type Git struct {
 	MockGetCommit              string
 	MockGetCommitError         error
 	MockGetOriginUrl           string
+	MockRelativePathToTopLevel func(path string) string
 	MockGeneratePatchFile      git.PatchFile
 	MockGeneratePatchFileError error
 	MockGeneratePatch          func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error)
@@ -49,6 +50,13 @@ func (c *Git) GetCommit() (string, error) {
 
 func (c *Git) GetOriginUrl() string {
 	return c.MockGetOriginUrl
+}
+
+func (c *Git) RelativePathToTopLevel(path string) string {
+	if c.MockRelativePathToTopLevel != nil {
+		return c.MockRelativePathToTopLevel(path)
+	}
+	return ""
 }
 
 func (c *Git) GeneratePatchFile(destDir string, pathspec []string) (git.PatchFile, error) {

--- a/internal/mocks/git.go
+++ b/internal/mocks/git.go
@@ -26,6 +26,10 @@ type Git struct {
 	MockApplyPatchReject       func(patch []byte) *exec.Cmd
 	MockIsInstalled            bool
 	MockIsInsideWorkTree       bool
+
+	// GeneratePatchFilePathspec records the pathspec passed to the most recent
+	// GeneratePatchFile call, for asserting how callers construct it.
+	GeneratePatchFilePathspec []string
 }
 
 func (c *Git) GetBranch() string {
@@ -60,6 +64,8 @@ func (c *Git) RelativePathToTopLevel(path string) string {
 }
 
 func (c *Git) GeneratePatchFile(destDir string, pathspec []string) (git.PatchFile, error) {
+	c.GeneratePatchFilePathspec = pathspec
+
 	if c.MockGeneratePatchFileError != nil {
 		return git.PatchFile{}, c.MockGeneratePatchFileError
 	}


### PR DESCRIPTION
### Background

[RWX-958](https://linear.app/rwx-cloud/issue/RWX-958/rwx-run-patch-is-scoped-to-the-current-directory-silently-omitting). Follow-up to RWX-957. Surfaced via a [customer support thread](https://rwxhq.slack.com/archives/C083W41Q399/p1780331975000819).

### Problem

`rwx run` and sandbox sync built their patch of local changes with cwd-relative git operations. Run from a subdirectory, the patch silently scoped to that subtree and dropped changes elsewhere in the repo — with no error, since an empty/partial diff isn't one.

### Solution

- Anchor the run patch to the repo root with git's `:(top)` magic (excluding the run definition), so coverage is independent of cwd. Falls back to the prior cwd-relative pathspec if the top level can't be resolved. This also covers sandbox *creation*, which shares the same `GeneratePatchFile` path.
- Anchor the sandbox *sync* path (`GenerateDirtyPatches`) the same way. Its `git diff` was already whole-repo, but `git ls-files` is cwd-relative, so untracked files outside cwd were dropped on each sync.
- Tests: git-package tests driving real git from a nested subdir (run patch and sandbox sync), plus service-level pathspec/fallback assertions.

Not included: the issue's "warn on empty patch + dirty tree" mitigation — framed as a substitute for the real fix, and a correct version risks false positives. Can add a tightly-scoped warning if wanted.

#### Further confirmation needed

- [ ] From a repo subdirectory with uncommitted changes elsewhere, run `rwx run <file>` and confirm they're in the submitted patch.
- [ ] From a repo subdirectory, drive a sandbox with untracked files elsewhere and confirm they sync.
