### PR TITLE
Surface the underlying git error when patch generation fails

### DIFF
--- a/internal/cli/service_run.go
+++ b/internal/cli/service_run.go
@@ -201,7 +201,22 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 		patchFile, patchErr = s.GitClient.GeneratePatchFile(patchDir, []string{".", ":!" + relativeRunDefinitionPath})
 		if patchErr != nil {
 			errorMessage = patchErr.Error()
-			fmt.Fprintf(s.Stderr, "Warning: failed to generate patch: %s\n\n", errorMessage)
+			fmt.Fprintf(s.Stderr, "Warning: %s\n\n", errorMessage)
+
+			// Telemetry gets a stable, PII-free classification — never raw git
+			// stderr, which embeds customer file paths, branch names, and layout.
+			telemetryProps := map[string]any{
+				"failed_command": "unknown",
+				"exit_code":      -1,
+				"reason":         "unknown",
+			}
+			var pe *git.PatchError
+			if errors.As(patchErr, &pe) {
+				telemetryProps["failed_command"] = pe.Command
+				telemetryProps["exit_code"] = pe.ExitCode
+				telemetryProps["reason"] = pe.Reason()
+			}
+			s.recordTelemetry("run.patch_error", telemetryProps)
 		}
 	}
 

--- a/internal/cli/service_run_patch_test.go
+++ b/internal/cli/service_run_patch_test.go
@@ -243,7 +243,66 @@ func TestService_InitiatingRunPatch(t *testing.T) {
 			Patchable:    true,
 		})
 		require.NoError(t, err)
-		require.Contains(t, s.mockStderr.String(), "Warning: failed to generate patch: unable to generate patch data")
+		require.Contains(t, s.mockStderr.String(), "Warning: unable to generate patch data")
+
+		// A non-PatchError failure still records the event, bucketed as unknown.
+		event := findEvent(s.drainEvents(), "run.patch_error")
+		require.NotNil(t, event)
+		require.Equal(t, "unknown", event.Props["failed_command"])
+		require.Equal(t, -1, event.Props["exit_code"])
+		require.Equal(t, "unknown", event.Props["reason"])
+	})
+
+	t.Run("when patch generation fails with a git command error", func(t *testing.T) {
+		s := setupTest(t)
+		s.mockGit.MockGetCommit = "3e76c8295cd0ce4decbf7b56253c902ce296cb25"
+		s.mockGit.MockGeneratePatchFileError = &git.PatchError{
+			Command:  "diff_name_only",
+			Display:  "git diff --name-only",
+			Stderr:   "fatal: bad object 9a3b1c4e",
+			ExitCode: 128,
+		}
+
+		rwxDir := filepath.Join(s.tmp, ".rwx")
+		err := os.MkdirAll(rwxDir, 0o755)
+		require.NoError(t, err)
+
+		definitionsFile := filepath.Join(rwxDir, "rwx.yml")
+		definition := "on:\n  cli:\n    init:\n      sha: ${{ event.git.sha }}\n\nbase:\n  os: ubuntu 24.04\n  tag: 1.0\n\ntasks:\n  - key: foo\n    run: echo 'bar'\n"
+		err = os.WriteFile(definitionsFile, []byte(definition), 0o644)
+		require.NoError(t, err)
+
+		s.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+			return &api.PackageVersionsResult{
+				LatestMajor: make(map[string]string),
+				LatestMinor: make(map[string]map[string]string),
+			}, nil
+		}
+		s.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+			// The run metadata carries the descriptive message (the user's own repo data).
+			require.Equal(t, "failed to generate patch (git diff --name-only): fatal: bad object 9a3b1c4e", cfg.Patch.ErrorMessage)
+			return &api.InitiateRunResult{
+				RunID:  "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+				RunURL: "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+			}, nil
+		}
+
+		_, err = s.service.InitiateRun(cli.InitiateRunConfig{
+			RwxDirectory: rwxDir,
+			MintFilePath: definitionsFile,
+			Patchable:    true,
+		})
+		require.NoError(t, err)
+
+		// The user-facing warning names the command and passes git's stderr through verbatim.
+		require.Contains(t, s.mockStderr.String(), "Warning: failed to generate patch (git diff --name-only): fatal: bad object 9a3b1c4e")
+
+		// Telemetry gets the stable bucket — exit code and a classified reason, no raw stderr.
+		event := findEvent(s.drainEvents(), "run.patch_error")
+		require.NotNil(t, event)
+		require.Equal(t, "diff_name_only", event.Props["failed_command"])
+		require.Equal(t, 128, event.Props["exit_code"])
+		require.Equal(t, "shallow_clone", event.Props["reason"])
 	})
 
 	t.Run("when the run is not patchable", func(t *testing.T) {

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -248,11 +248,71 @@ type patchResult struct {
 	ok        bool
 }
 
+// PatchError identifies which git command failed while generating a patch,
+// along with its exit code and stderr, so callers can show the underlying git
+// error to the user and record a stable, PII-free bucket in telemetry.
+type PatchError struct {
+	Command  string // stable identifier for telemetry: diff_name_only, check_attr, ls_files, diff_patch
+	Display  string // human-readable command, e.g. "git diff --name-only"
+	Stderr   string // trimmed git stderr (the user's own repo data)
+	ExitCode int    // process exit code, or -1 if the command never started
+}
+
+func (e *PatchError) Error() string {
+	if e.Stderr == "" {
+		return fmt.Sprintf("failed to generate patch (%s)", e.Display)
+	}
+	return fmt.Sprintf("failed to generate patch (%s): %s", e.Display, e.Stderr)
+}
+
+// Reason buckets the git stderr into a stable category for telemetry. Raw
+// stderr must never be sent to telemetry — it embeds customer file paths,
+// branch names, and repo layout.
+func (e *PatchError) Reason() string {
+	s := strings.ToLower(e.Stderr)
+	switch {
+	case strings.Contains(s, "bad object"), strings.Contains(s, "shallow"):
+		return "shallow_clone"
+	case strings.Contains(s, "beyond a symbolic link"):
+		return "beyond_symlink"
+	case strings.Contains(s, "external filter"), strings.Contains(s, "filter-process"):
+		return "missing_external_filter"
+	case strings.Contains(s, "signal: killed"), strings.Contains(s, "out of memory"), strings.Contains(s, "cannot allocate memory"):
+		return "oom_killed"
+	default:
+		return "unknown"
+	}
+}
+
+// newPatchError builds a PatchError from a failed exec, extracting the exit
+// code and stderr from an *exec.ExitError when available. fallbackStderr is
+// used when the error doesn't carry captured stderr (e.g. CombinedOutput).
+func newPatchError(command, display string, err error, fallbackStderr string) *PatchError {
+	pe := &PatchError{Command: command, Display: display, ExitCode: -1}
+
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		pe.ExitCode = exitErr.ExitCode()
+		pe.Stderr = strings.TrimSpace(string(exitErr.Stderr))
+	}
+
+	if pe.Stderr == "" {
+		pe.Stderr = strings.TrimSpace(fallbackStderr)
+	}
+	if pe.Stderr == "" {
+		pe.Stderr = strings.TrimSpace(err.Error())
+	}
+
+	return pe
+}
+
 // generatePatchData generates patch data for working tree changes relative to the base commit on origin.
-func (c *Client) generatePatchData(pathspec []string) patchResult {
+// On a git command failure it returns a *PatchError identifying which command failed and why.
+func (c *Client) generatePatchData(pathspec []string) (patchResult, *PatchError) {
 	sha, err := c.GetCommit()
 	if sha == "" || err != nil {
-		return patchResult{}
+		// GetCommit failures are pre-filtered upstream in InitiateRun; treat as
+		// "nothing to patch" here rather than a git command failure.
+		return patchResult{}, nil
 	}
 
 	diffArgs := []string{"diff", sha, "--name-only"}
@@ -265,12 +325,12 @@ func (c *Client) generatePatchData(pathspec []string) patchResult {
 
 	files, err := cmd.Output()
 	if err != nil {
-		return patchResult{}
+		return patchResult{}, newPatchError("diff_name_only", "git diff --name-only", err, "")
 	}
 
-	lfsChanged, err := c.lfsFilesForPaths(strings.Split(strings.TrimSpace(string(files)), "\n"))
-	if err != nil {
-		return patchResult{}
+	lfsChanged, lfsErr := c.lfsFilesForPaths(strings.Split(strings.TrimSpace(string(files)), "\n"))
+	if lfsErr != nil {
+		return patchResult{}, lfsErr
 	}
 
 	if lfsChanged.Count > 0 {
@@ -278,7 +338,7 @@ func (c *Client) generatePatchData(pathspec []string) patchResult {
 			sha: sha,
 			lfs: lfsChanged,
 			ok:  true,
-		}
+		}, nil
 	}
 
 	lsFilesArgs := []string{"ls-files", "--others", "--exclude-standard"}
@@ -291,7 +351,7 @@ func (c *Client) generatePatchData(pathspec []string) patchResult {
 
 	untracked, err := cmd.Output()
 	if err != nil {
-		return patchResult{}
+		return patchResult{}, newPatchError("ls_files", "git ls-files --others --exclude-standard", err, "")
 	}
 
 	untrackedFiles := strings.Fields(string(untracked))
@@ -306,7 +366,7 @@ func (c *Client) generatePatchData(pathspec []string) patchResult {
 
 	patch, err := cmd.Output()
 	if err != nil {
-		return patchResult{}
+		return patchResult{}, newPatchError("diff_patch", "git diff -p --binary", err, "")
 	}
 
 	return patchResult{
@@ -317,7 +377,7 @@ func (c *Client) generatePatchData(pathspec []string) patchResult {
 			Count: len(untrackedFiles),
 		},
 		ok: true,
-	}
+	}, nil
 }
 
 func (c *Client) GeneratePatchFile(destDir string, pathspec []string) (PatchFile, error) {
@@ -327,7 +387,10 @@ func (c *Client) GeneratePatchFile(destDir string, pathspec []string) (PatchFile
 	}
 	defer cleanup()
 
-	data := c.generatePatchData(pathspec)
+	data, patchErr := c.generatePatchData(pathspec)
+	if patchErr != nil {
+		return PatchFile{}, patchErr
+	}
 	if !data.ok {
 		return PatchFile{}, fmt.Errorf("unable to generate patch data")
 	}
@@ -410,8 +473,8 @@ func (c *Client) GeneratePatch(pathspec []string) ([]byte, *LFSChangedFilesMetad
 	}
 	defer cleanup()
 
-	data := c.generatePatchData(pathspec)
-	if !data.ok {
+	data, patchErr := c.generatePatchData(pathspec)
+	if patchErr != nil || !data.ok {
 		return nil, nil, nil
 	}
 
@@ -555,7 +618,7 @@ func (c *Client) HasCommit(sha string) bool {
 	return cmd.Run() == nil
 }
 
-func (c *Client) lfsFilesForPaths(files []string) (LFSChangedFilesMetadata, error) {
+func (c *Client) lfsFilesForPaths(files []string) (LFSChangedFilesMetadata, *PatchError) {
 	lfsChangedFiles := []string{}
 
 	for _, file := range files {
@@ -566,9 +629,11 @@ func (c *Client) lfsFilesForPaths(files []string) (LFSChangedFilesMetadata, erro
 		cmd := exec.Command(c.Binary, "check-attr", "filter", "--", file)
 		cmd.Dir = c.Dir
 
+		// CombinedOutput mixes stderr into attrs, so pass it as the fallback
+		// stderr for the PatchError (the *exec.ExitError won't carry .Stderr).
 		attrs, err := cmd.CombinedOutput()
 		if err != nil {
-			return LFSChangedFilesMetadata{}, err
+			return LFSChangedFilesMetadata{}, newPatchError("check_attr", "git check-attr filter", err, string(attrs))
 		}
 
 		if strings.Contains(string(attrs), "filter: lfs") {

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -579,7 +579,44 @@ func TestGeneratePatchFile(t *testing.T) {
 			require.Equal(t, []string{}, patchFile.UntrackedFiles.Files)
 			require.Equal(t, 0, patchFile.UntrackedFiles.Count)
 		})
+
+		t.Run("returns a PatchError identifying the failing git command", func(t *testing.T) {
+			tempDir, _ := repoFixture(t, "testdata/GeneratePatchFile-diff")
+			client := &git.Client{Binary: "git", Dir: filepath.Join(tempDir, "repo")}
+
+			// An invalid pathspec magic makes `git diff --name-only` fail
+			// deterministically, exercising the error-capture path.
+			_, err := client.GeneratePatchFile(t.TempDir(), []string{":(top,bogusmagic)x"})
+			require.Error(t, err)
+
+			var pe *git.PatchError
+			require.ErrorAs(t, err, &pe)
+			require.Equal(t, "diff_name_only", pe.Command)
+			require.Equal(t, 128, pe.ExitCode)
+			require.Contains(t, pe.Stderr, "Invalid pathspec magic")
+			// The underlying git stderr is surfaced in the error message.
+			require.Contains(t, pe.Error(), "failed to generate patch (git diff --name-only):")
+		})
 	})
+}
+
+func TestPatchErrorReason(t *testing.T) {
+	cases := []struct {
+		stderr string
+		want   string
+	}{
+		{"fatal: bad object 9a3b1c4e", "shallow_clone"},
+		{"fatal: pathspec '.rwx' is beyond a symbolic link", "beyond_symlink"},
+		{"error: external filter 'git-lfs filter-process' failed", "missing_external_filter"},
+		{"signal: killed", "oom_killed"},
+		{"fatal: something else entirely", "unknown"},
+		{"", "unknown"},
+	}
+
+	for _, tc := range cases {
+		pe := &git.PatchError{Stderr: tc.stderr}
+		require.Equal(t, tc.want, pe.Reason(), "stderr: %q", tc.stderr)
+	}
 }
 
 func TestIsAncestor(t *testing.T) {


### PR DESCRIPTION
### Background

[RWX-957](https://linear.app/rwx-cloud/issue/RWX-957/surface-the-underlying-git-error-when-patch-generation-fails-in-rwx). Surfaced via a [customer support thread](https://rwxhq.slack.com/archives/C083W41Q399/p1780331975000819) (sibling to RWX-958).

### Problem

When `rwx run` failed to generate a patch of local changes, it printed one opaque warning for any of four distinct git command failures (`diff --name-only`, `check-attr`, `ls-files`, `diff -p`), discarding git's stderr:

```
Warning: failed to generate patch: unable to generate patch data
```

Neither the user nor our telemetry could tell which command failed or why (shallow clone, pathspec beyond a symlink, missing external filter, OOM-killed diff).

### Solution

- Add `git.PatchError` (failing command + exit code + stderr); `generatePatchData` builds it at each failure site and threads it through `GeneratePatchFile`.
- **User-facing:** the warning now names the command and passes git's stderr through verbatim:

```
Warning: failed to generate patch (git diff --name-only): fatal: bad object 9a3b1c4e
```

- **Telemetry:** new `run.patch_error` event with `failed_command` (`diff_name_only` / `check_attr` / `ls_files` / `diff_patch`), `exit_code`, and a `reason` bucket (`shallow_clone` / `beyond_symlink` / `missing_external_filter` / `oom_killed` / `unknown`). Raw stderr is never sent to telemetry — it embeds customer paths and layout.
- Tests: a real failing git command (asserts `PatchError` fields), a `Reason()` classifier table, and service-level tests for the warning + telemetry props.

#### Further confirmation needed

- [ ] OK to show raw git stderr in the warning + cloud run metadata (vs. sanitized)?
- [ ] `run.patch_error` event name + bucket vocab fit our telemetry schema?
