### PR TITLE
Deprecate --output in favor of --format for stdout format selection

### DIFF
--- a/cmd/rwx/image/pull.go
+++ b/cmd/rwx/image/pull.go
@@ -34,7 +34,7 @@ func InitPull(requireAccessToken func() error, getService func() cli.Service, us
 			return err
 		},
 		Short: "Pull an existing RWX task as an OCI image",
-		Use:   "pull <taskId> [--output json]",
+		Use:   "pull <taskId> [--format json]",
 	}
 
 	PullCmd.Flags().StringArrayVar(&pullTags, "tag", []string{}, "tag the pulled image (can be specified multiple times)")

--- a/cmd/rwx/image/push.go
+++ b/cmd/rwx/image/push.go
@@ -37,7 +37,7 @@ func InitPush(requireAccessToken func() error, getService func() cli.Service, us
 			return err
 		},
 		Short: "Push an RWX task to an OCI reference",
-		Use:   "push <task-id> --to <reference> [--to <reference>] [--output json] [--open] [--no-wait]",
+		Use:   "push <task-id> --to <reference> [--to <reference>] [--format json] [--open] [--no-wait]",
 	}
 
 	PushCmd.Flags().StringArrayVar(&pushImageReferences, "to", []string{}, "the qualified OCI reference to push the image to (can be specified multiple times)")

--- a/cmd/rwx/lint.go
+++ b/cmd/rwx/lint.go
@@ -84,7 +84,11 @@ func LintShouldFail(result *cli.LintResult, warningsAsErrors bool) bool {
 func init() {
 	lintCmd.Flags().BoolVar(&LintWarningsAsErrors, "warnings-as-errors", false, "treat warnings as errors")
 	lintCmd.Flags().StringVarP(&LintRwxDirectory, "dir", "d", "", "the directory your RWX configuration files are located in, typically `.rwx`. By default, the CLI traverses up until it finds a `.rwx` directory.")
+	lintCmd.Flags().StringVar(&LintOutputFormat, "format", "multiline", "output format: text, multiline, oneline, json, none")
 	lintCmd.Flags().StringVarP(&LintOutputFormat, "output", "o", "multiline", "output format: text, multiline, oneline, json, none")
+	if err := lintCmd.Flags().MarkDeprecated("output", "use --format instead"); err != nil {
+		panic(err)
+	}
 	lintCmd.Flags().DurationVar(&LintTimeout, "timeout", 30*time.Second, "timeout for the LSP check operation")
 	lintCmd.Flags().BoolVar(&LintFix, "fix", false, "automatically apply available fixes")
 }

--- a/cmd/rwx/lint.go
+++ b/cmd/rwx/lint.go
@@ -27,7 +27,7 @@ var (
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat := LintOutputFormat
-			if Json {
+			if cmd.Flags().Changed("json") {
 				outputFormat = "json"
 			}
 

--- a/cmd/rwx/main.go
+++ b/cmd/rwx/main.go
@@ -73,7 +73,7 @@ func recordTelemetry(err error, start time.Time) {
 	telem.Record("cli.command", map[string]any{
 		"command":       commandName,
 		"flags":         flagNames,
-		"output_format": Output,
+		"output_format": Format,
 		"duration_ms":   time.Since(start).Milliseconds(),
 		"success":       err == nil && !unknownSubcommand,
 	})

--- a/cmd/rwx/root.go
+++ b/cmd/rwx/root.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/rwx-cloud/rwx/cmd/rwx/config"
 	"github.com/rwx-cloud/rwx/internal/accesstoken"
@@ -25,7 +26,6 @@ import (
 
 var (
 	AccessToken string
-	Json        bool
 	Format      string
 
 	rwxHost            string
@@ -44,6 +44,10 @@ var (
 		SilenceUsage:  true,
 		Version:       config.Version,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("format") && cmd.Flags().Changed("json") {
+				return errors.New("--format and --json cannot be used together")
+			}
+
 			fileBackend, err := internalconfig.NewFileBackend([]string{
 				filepath.Join("~", ".config", "rwx"),
 				filepath.Join("~", ".mint"),
@@ -152,7 +156,32 @@ func addRwxDirFlag(cmd *cobra.Command) {
 }
 
 func useJsonOutput() bool {
-	return Format == "json" || Json
+	return Format == "json"
+}
+
+// jsonFlagValue is a bool-shaped flag value that writes to the shared format
+// variable, so --json and --format have a single source of truth.
+type jsonFlagValue struct {
+	format *string
+}
+
+func (j *jsonFlagValue) String() string {
+	return strconv.FormatBool(*j.format == "json")
+}
+
+func (j *jsonFlagValue) Set(value string) error {
+	enabled, err := strconv.ParseBool(value)
+	if err != nil {
+		return err
+	}
+	if enabled {
+		*j.format = "json"
+	}
+	return nil
+}
+
+func (j *jsonFlagValue) Type() string {
+	return "bool"
 }
 
 func init() {
@@ -174,13 +203,13 @@ func init() {
 	}
 
 	rootCmd.PersistentFlags().StringVar(&AccessToken, "access-token", "$RWX_ACCESS_TOKEN", "the access token for RWX")
-	rootCmd.PersistentFlags().BoolVar(&Json, "json", false, "output json data to stdout")
-	_ = rootCmd.PersistentFlags().MarkHidden("json")
 	rootCmd.PersistentFlags().StringVar(&Format, "format", "text", "output format: text or json")
 	rootCmd.PersistentFlags().StringVar(&Format, "output", "text", "output format: text or json")
 	if err := rootCmd.PersistentFlags().MarkDeprecated("output", "use --format instead"); err != nil {
 		panic(err)
 	}
+	jsonFlag := rootCmd.PersistentFlags().VarPF(&jsonFlagValue{format: &Format}, "json", "", "output json data to stdout")
+	jsonFlag.NoOptDefVal = "true"
 
 	// Define command groups for help output ordering
 	rootCmd.AddGroup(&cobra.Group{ID: "execution", Title: "Execution:"})

--- a/cmd/rwx/root.go
+++ b/cmd/rwx/root.go
@@ -26,7 +26,7 @@ import (
 var (
 	AccessToken string
 	Json        bool
-	Output      string
+	Format      string
 
 	rwxHost            string
 	docsHost           = "www.rwx.com"
@@ -152,7 +152,7 @@ func addRwxDirFlag(cmd *cobra.Command) {
 }
 
 func useJsonOutput() bool {
-	return Output == "json" || Json
+	return Format == "json" || Json
 }
 
 func init() {
@@ -176,7 +176,11 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&AccessToken, "access-token", "$RWX_ACCESS_TOKEN", "the access token for RWX")
 	rootCmd.PersistentFlags().BoolVar(&Json, "json", false, "output json data to stdout")
 	_ = rootCmd.PersistentFlags().MarkHidden("json")
-	rootCmd.PersistentFlags().StringVar(&Output, "output", "text", "output format: text or json")
+	rootCmd.PersistentFlags().StringVar(&Format, "format", "text", "output format: text or json")
+	rootCmd.PersistentFlags().StringVar(&Format, "output", "text", "output format: text or json")
+	if err := rootCmd.PersistentFlags().MarkDeprecated("output", "use --format instead"); err != nil {
+		panic(err)
+	}
 
 	// Define command groups for help output ordering
 	rootCmd.AddGroup(&cobra.Group{ID: "execution", Title: "Execution:"})


### PR DESCRIPTION
## Why

`--output` currently has two conflicting meanings: the global persistent flag selects stdout format (`text`/`json`), `lint` overrides it with its own format set, and `logs`/`artifacts download` shadow it with a download *path*. This makes `rwx logs --output json` mean a path named `json`.

## What

- `--json` is promoted from hidden to first-class and is the preferred way to request JSON; no flags is the preferred way to get text. It's a bool-shaped `pflag.Value` that writes `json` into the same `Format` variable as `--format`, so there's a single source of truth (the separate `Json` bool is gone).
- New persistent `--format` flag supports all format options (`text`/`json` globally); global `--output` stays as a hidden deprecated alias bound to the same variable, so both spellings keep working (deprecated use prints `Flag --output has been deprecated, use --format instead`).
- `--format` and `--json` together error: `--format and --json cannot be used together`. The check is by flag name in `PersistentPreRunE`, so it also covers `lint`'s local `--format`; `logs`/`artifacts download` are unaffected since their local flag is the path `--output`.
- `lint` gets a local `--format` (same format set, `multiline` default); its `--output`/`-o` is deprecated the same way.
- `logs` and `artifacts download` keep `--output` for paths, unaffected by the deprecation: cobra resolves their local flags before the inherited persistent one (verified). Side effect: `rwx logs --format json --output ./dir` now works — previously the path flag shadowed format selection entirely.
- `image pull`/`image push` usage strings updated to `[--format json]`.
- `cli.command` telemetry: `output_format` prop key unchanged; `--json` now correctly reports as `json` there since it writes `Format`.

## Notes for review

- `--format` + deprecated `--output` bind to one variable, so passing both resolves last-one-wins (same as repeating a flag) rather than erroring like the logs `--output-dir` aliases do — those had genuinely different semantics; these share a value domain.
- The deprecated `--output` is deliberately outside the `--json` exclusivity check — a name-based check would false-positive on the path `--output` of `logs`/`artifacts download`. Combining it with `--json` is last-flag-wins (both write `Format`); in `lint`, `--json` always beats `-o`/`--output`.
- `-o` stays on lint's deprecated alias, so it warns. If we want a long-lived shorthand it should move to `--format`.