### PR TITLE
Fail on LFS patch sync changes

### DIFF
--- a/cmd/rwx/run.go
+++ b/cmd/rwx/run.go
@@ -184,7 +184,16 @@ var (
 
 		},
 		Short: "Launch a run from a local RWX definitions file",
-		Use:   "run <file> [flags]",
+		Long: `Launch a run from a local RWX definitions file.
+
+FILE PATCHING
+  When possible, RWX uploads a git patch for local uncommitted changes with
+  the run. This includes staged changes, unstaged changes, and untracked files.
+
+  Git LFS changes cannot be included in the run patch and will produce an
+  error. Commit and push those changes before starting the run.
+`,
+		Use: "run <file> [flags]",
 	}
 )
 

--- a/cmd/rwx/sandbox.go
+++ b/cmd/rwx/sandbox.go
@@ -21,7 +21,16 @@ var sandboxCmd = &cobra.Command{
 var sandboxStartCmd = &cobra.Command{
 	Use:   "start [config-file]",
 	Short: "Start a sandbox without executing a command",
-	Args:  cobra.MaximumNArgs(1),
+	Long: `Start a sandbox without executing a command.
+
+FILE PATCHING
+  When starting a new sandbox, RWX launches a run from the sandbox config and
+  includes a git patch for local uncommitted changes when possible.
+
+  Git LFS changes cannot be included in the initial sandbox patch and will
+  produce an error. Commit and push those changes before starting the sandbox.
+`,
+	Args: cobra.MaximumNArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		return requireAccessToken()
 	},
@@ -149,7 +158,8 @@ FILE SYNCING
   automatically pulled back to the local working directory via git patch.
   This happens regardless of the command's exit code.
 
-  Note: Git LFS files cannot be synced and will produce an error.
+  If local changes include Git LFS files, syncing fails with an error before
+  the command runs.
 
 CONFIG FILE
   The sandbox configuration (default: .rwx/sandbox.yml) defines:

--- a/cmd/rwx/sandbox.go
+++ b/cmd/rwx/sandbox.go
@@ -149,7 +149,7 @@ FILE SYNCING
   automatically pulled back to the local working directory via git patch.
   This happens regardless of the command's exit code.
 
-  Note: Git LFS files cannot be synced and will generate a warning.
+  Note: Git LFS files cannot be synced and will produce an error.
 
 CONFIG FILE
   The sandbox configuration (default: .rwx/sandbox.yml) defines:

--- a/internal/cli/lfs_errors.go
+++ b/internal/cli/lfs_errors.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/rwx-cloud/rwx/internal/errors"
+	"github.com/rwx-cloud/rwx/internal/git"
+)
+
+const sandboxLFSRecovery = "To recover, push your changes and reset the sandbox."
+
+func runPatchLFSChangesError(changed git.LFSChangedFilesMetadata) error {
+	return lfsChangesError(changed, "cannot be included in the RWX run patch", "To recover, commit and push your changes, then retry rwx run.")
+}
+
+func sandboxLFSChangesError(changed git.LFSChangedFilesMetadata) error {
+	return lfsChangesError(changed, "cannot be synced to the sandbox", sandboxLFSRecovery)
+}
+
+func lfsChangesError(changed git.LFSChangedFilesMetadata, action, recovery string) error {
+	count := changed.Count
+	if count == 0 {
+		count = len(changed.Files)
+	}
+
+	return errors.WrapSentinel(
+		fmt.Errorf("%d LFS file(s) changed locally and %s:\n%s\n\n%s", count, action, indentLines(changed.Files), recovery),
+		errors.ErrPatch,
+	)
+}

--- a/internal/cli/service_run.go
+++ b/internal/cli/service_run.go
@@ -218,6 +218,9 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 			}
 			s.recordTelemetry("run.patch_error", telemetryProps)
 		}
+		if patchFile.LFSChangedFiles.Count > 0 {
+			return nil, runPatchLFSChangesError(patchFile.LFSChangedFiles)
+		}
 	}
 
 	// Load directory entries

--- a/internal/cli/service_run_patch_test.go
+++ b/internal/cli/service_run_patch_test.go
@@ -1,7 +1,7 @@
 package cli_test
 
 import (
-	"errors"
+	stderrors "errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +9,7 @@ import (
 
 	"github.com/rwx-cloud/rwx/internal/api"
 	"github.com/rwx-cloud/rwx/internal/cli"
+	"github.com/rwx-cloud/rwx/internal/errors"
 	"github.com/rwx-cloud/rwx/internal/git"
 	"github.com/rwx-cloud/rwx/internal/mocks"
 	"github.com/stretchr/testify/require"
@@ -163,7 +164,7 @@ func TestService_InitiatingRunPatch(t *testing.T) {
 		s := setupTest(t)
 		s.mockGit.MockIsInstalled = true
 		s.mockGit.MockIsInsideWorkTree = true
-		s.mockGit.MockGetCommitError = errors.New("no git remote named 'origin' is configured")
+		s.mockGit.MockGetCommitError = stderrors.New("no git remote named 'origin' is configured")
 
 		rwxDir := filepath.Join(s.tmp, ".rwx")
 		err := os.MkdirAll(rwxDir, 0o755)
@@ -206,7 +207,7 @@ func TestService_InitiatingRunPatch(t *testing.T) {
 		s.mockGit.MockGetCommit = "3e76c8295cd0ce4decbf7b56253c902ce296cb25"
 		s.mockGit.MockGetBranch = "main"
 		s.mockGit.MockGetOriginUrl = "git@github.com:example/repo.git"
-		s.mockGit.MockGeneratePatchFileError = errors.New("unable to generate patch data")
+		s.mockGit.MockGeneratePatchFileError = stderrors.New("unable to generate patch data")
 
 		rwxDir := filepath.Join(s.tmp, ".rwx")
 		err := os.MkdirAll(rwxDir, 0o755)
@@ -417,22 +418,41 @@ func TestService_InitiatingRunPatch(t *testing.T) {
 		})
 
 		t.Run("by default", func(t *testing.T) {
-			expectedPatchMetadata := api.PatchMetadata{
-				Sent:     true,
-				LFSFiles: lfsChangedFiles.Files,
-				LFSCount: lfsChangedFiles.Count,
+			s := setupTest(t)
+			s.mockGit.MockGetCommit = "3e76c8295cd0ce4decbf7b56253c902ce296cb25"
+			s.mockGit.MockGeneratePatchFile = patchFile
+
+			rwxDir := filepath.Join(s.tmp, ".rwx")
+			err := os.MkdirAll(rwxDir, 0o755)
+			require.NoError(t, err)
+
+			definitionsFile := filepath.Join(rwxDir, "rwx.yml")
+			definition := "on:\n  cli:\n    init:\n      sha: ${{ event.git.sha }}\n\nbase:\n  os: ubuntu 24.04\n  tag: 1.0\n\ntasks:\n  - key: foo\n    run: echo 'bar'\n"
+			err = os.WriteFile(definitionsFile, []byte(definition), 0o644)
+			require.NoError(t, err)
+
+			s.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+				return &api.PackageVersionsResult{
+					LatestMajor: make(map[string]string),
+					LatestMinor: make(map[string]map[string]string),
+				}, nil
+			}
+			s.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+				t.Fatalf("run should not be initiated when the patch contains LFS changes")
+				return nil, nil
 			}
 
-			result := initiateRun(t, patchFile, expectedPatchMetadata)
+			_, err = s.service.InitiateRun(cli.InitiateRunConfig{
+				RwxDirectory: rwxDir,
+				MintFilePath: definitionsFile,
+				Patchable:    true,
+			})
 
-			patched := false
-			for _, entry := range result.rwxDir {
-				if strings.Contains(entry.Path, ".patches/") {
-					patched = true
-				}
-			}
-
-			require.True(t, patched)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, errors.ErrPatch))
+			require.Contains(t, err.Error(), "1 LFS file(s) changed locally and cannot be included in the RWX run patch:")
+			require.Contains(t, err.Error(), "  bar.txt")
+			require.Contains(t, err.Error(), "To recover, commit and push your changes, then retry rwx run.")
 		})
 
 		t.Run("when init params match git params", func(t *testing.T) {

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1477,14 +1477,8 @@ func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHe
 	patchBytes = patches.Size()
 	if patches.LFSChangedFiles != nil && patches.LFSChangedFiles.Count > 0 {
 		lfsSkippedCount = patches.LFSChangedFiles.Count
-		if !jsonMode {
-			fmt.Fprintf(s.Stderr, "Warning: %d LFS file(s) changed locally and cannot be synced.\n", patches.LFSChangedFiles.Count)
-		}
-		if err := s.snapshotSandboxSyncRefForExec(isNewSandbox, patches.Files); err != nil {
-			syncPushErr = err
-			return patchBytes, syncPushErr
-		}
-		return patchBytes, nil
+		syncPushErr = sandboxLFSChangesError(*patches.LFSChangedFiles)
+		return patchBytes, syncPushErr
 	}
 
 	if isNewSandbox {
@@ -1605,14 +1599,13 @@ func (s Service) checkSandboxLFSObjects(localHead string) (missing error, checkE
 func sandboxLFSFsckError(localHead, output string, exitCode int) error {
 	output = strings.TrimSpace(output)
 	files := sandboxLFSFilesFromFsckOutput(output)
-	recovery := "To recover, push your changes and reset the sandbox."
 	if len(files) > 0 {
-		return fmt.Errorf("%d LFS file(s) changed locally and cannot be synced to the sandbox:\n%s\n\n%s", len(files), indentLines(files), recovery)
+		return fmt.Errorf("%d LFS file(s) changed locally and cannot be synced to the sandbox:\n%s\n\n%s", len(files), indentLines(files), sandboxLFSRecovery)
 	}
 	if output == "" {
-		return fmt.Errorf("LFS file(s) changed locally and cannot be synced to the sandbox for commit %s (git lfs fsck exit code %d).\n\n%s", localHead, exitCode, recovery)
+		return fmt.Errorf("LFS file(s) changed locally and cannot be synced to the sandbox for commit %s (git lfs fsck exit code %d).\n\n%s", localHead, exitCode, sandboxLFSRecovery)
 	}
-	return fmt.Errorf("LFS file(s) changed locally and cannot be synced to the sandbox for commit %s.\n\n%s\n\nGit LFS check output:\n%s", localHead, recovery, output)
+	return fmt.Errorf("LFS file(s) changed locally and cannot be synced to the sandbox for commit %s.\n\n%s\n\nGit LFS check output:\n%s", localHead, sandboxLFSRecovery, output)
 }
 
 // lfsFsckObjectLineRe matches a per-object `git lfs fsck` line (group 1 is the

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1203,12 +1203,13 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Equal(t, "__rwx_sandbox_sync_end__", commandOrder[snapshotIdx+1])
 	})
 
-	t.Run("warns and skips sync for LFS files", func(t *testing.T) {
+	t.Run("returns error for LFS files without syncing non-LFS changes", func(t *testing.T) {
 		setup := setupTest(t)
 
 		runID := "run-lfs-123"
 		address := "192.168.1.1:22"
 		syncPatchApplied := false
+		commandExecuted := false
 
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
 			return api.SandboxConnectionInfo{
@@ -1225,18 +1226,22 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 
 		setup.mockGit.MockGenerateDirtyPatches = func() (git.DirtyPatches, error) {
 			return git.DirtyPatches{
+				Staged:          []byte("diff --git a/non-lfs.txt b/non-lfs.txt\n"),
 				LFSChangedFiles: &git.LFSChangedFilesMetadata{Files: []string{"large.bin"}, Count: 1},
 			}, nil
 		}
 
-		setup.mockSSH.MockExecuteCommandWithStdin = func(command string, stdin io.Reader) (int, error) {
+		setup.mockSSH.MockExecuteCommandWithStdinAndCombinedOutput = func(command string, stdin io.Reader) (int, string, error) {
 			syncPatchApplied = true
-			return 0, nil
+			return 0, "", nil
 		}
 
 		var commands []string
 		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
 			commands = append(commands, cmd)
+			if cmd == "echo hello" {
+				commandExecuted = true
+			}
 			return 0, nil
 		}
 
@@ -1249,16 +1254,18 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
 			Command:    []string{"echo", "hello"},
 			RunID:      runID,
-			Json:       false, // Enable warning output
+			Json:       false,
 		})
 
-		require.NoError(t, err)
-		require.Equal(t, runID, result.RunID)
-		require.Equal(t, 0, result.ExitCode)
+		require.Nil(t, result)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, errors.ErrPatch))
 		require.False(t, syncPatchApplied)
-		require.Contains(t, setup.mockStderr.String(), "LFS file(s) changed")
-		// The post-exec revert also runs `update-ref refs/rwx-sync HEAD`; match
-		// the snapshot's commit step to confirm the LFS-skip path took it.
+		require.False(t, commandExecuted)
+		require.Contains(t, err.Error(), "1 LFS file(s) changed locally and cannot be synced to the sandbox:")
+		require.Contains(t, err.Error(), "  large.bin")
+		require.Contains(t, err.Error(), "To recover, push your changes and reset the sandbox.")
+		require.NotContains(t, setup.mockStderr.String(), "Warning:")
 		snapshotTaken := false
 		for _, cmd := range commands {
 			if strings.Contains(cmd, "commit --allow-empty") && strings.Contains(cmd, "update-ref refs/rwx-sync HEAD") {
@@ -1266,7 +1273,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 				break
 			}
 		}
-		require.True(t, snapshotTaken, "LFS-skip path should snapshot refs/rwx-sync")
+		require.False(t, snapshotTaken, "LFS error path should not snapshot refs/rwx-sync")
 	})
 
 	t.Run("returns error when git apply fails", func(t *testing.T) {

--- a/test/integration/sandbox-git-state-sync.sh
+++ b/test/integration/sandbox-git-state-sync.sh
@@ -284,25 +284,31 @@ echo "$lfs_push_output" | grep -q "To recover, push your changes and reset the s
 echo "Restarting sandbox after expected LFS sync failure"
 start_git_state_sandbox
 
-echo "Scenario: dirty LFS files are reported and skipped by patch sync"
+echo "Scenario: dirty LFS files fail before sandbox patch sync"
 git switch -C "${TEST_ID}-lfs-patch" "$ORIGINAL_HEAD" >/dev/null
 git lfs track "integration-lfs-patch.bin" >/dev/null
 printf '%s\n' "dirty lfs content" > integration-lfs-patch.bin
+rm -f integration-lfs-command-ran.txt
 
 lfs_patch_output_file=$(mktemp)
 lfs_patch_exit=0
-run_and_capture_output "$lfs_patch_output_file" "${RWX_CLI}" sandbox exec --id "$SANDBOX_RUN_ID" -- sh -c 'test ! -e integration-lfs-patch.bin' || lfs_patch_exit=$?
+run_and_capture_output "$lfs_patch_output_file" "${RWX_CLI}" sandbox exec --id "$SANDBOX_RUN_ID" -- sh -c 'echo command ran > integration-lfs-command-ran.txt' || lfs_patch_exit=$?
 lfs_patch_output=$(cat "$lfs_patch_output_file")
 rm -f "$lfs_patch_output_file"
-if [ "$lfs_patch_exit" -ne 0 ]; then
-  fail "sandbox exec failed while checking dirty LFS patch skip: ${lfs_patch_output}"
+if [ "$lfs_patch_exit" -eq 0 ]; then
+  fail "sandbox exec succeeded with a dirty LFS file"
 fi
-echo "$lfs_patch_output" | grep -q "Warning: 1 LFS file(s) changed locally and cannot be synced." || fail "missing dirty LFS warning: ${lfs_patch_output}"
+echo "$lfs_patch_output" | grep -q "1 LFS file(s) changed locally and cannot be synced to the sandbox" || fail "missing dirty LFS error: ${lfs_patch_output}"
+echo "$lfs_patch_output" | grep -q "integration-lfs-patch.bin" || fail "missing dirty LFS file path in error: ${lfs_patch_output}"
+echo "$lfs_patch_output" | grep -q "To recover, push your changes and reset the sandbox." || fail "missing dirty LFS recovery guidance: ${lfs_patch_output}"
 if [ ! -f integration-lfs-patch.bin ]; then
-  fail "dirty LFS file was removed locally after patch sync"
+  fail "dirty LFS file was removed locally after failed patch sync"
+fi
+if [ -f integration-lfs-command-ran.txt ]; then
+  fail "sandbox command ran despite dirty LFS sync failure"
 fi
 git reset -- .gitattributes integration-lfs-patch.bin >/dev/null 2>&1 || true
-rm -f .gitattributes integration-lfs-patch.bin
+rm -f .gitattributes integration-lfs-patch.bin integration-lfs-command-ran.txt
 
 echo "Scenario: staged and unstaged local state keep their shape in sandbox"
 git switch -C "${TEST_ID}-dirty-state" "$ORIGINAL_HEAD" >/dev/null


### PR DESCRIPTION
## Summary
- fail rwx run when the generated patch would include LFS changes
- fail sandbox sync when local dirty changes include LFS files instead of warning and continuing
- update sandbox help text and integration coverage for the new fail-fast behavior