### PR TITLE
Address run and sandbox audit findings

### DIFF
--- a/internal/cli/files.go
+++ b/internal/cli/files.go
@@ -244,6 +244,13 @@ func readRwxDirectoryEntries(paths []string, relativeTo string) ([]RwxDirectoryE
 
 	for _, path := range paths {
 		err := filepath.WalkDir(path, func(subpath string, de os.DirEntry, err error) error {
+			if err != nil {
+				if de == nil && os.IsNotExist(err) {
+					return os.ErrNotExist
+				}
+				return err
+			}
+
 			entry, entrySize, suberr := rwxDirectoryEntry(subpath, de, relativeTo)
 			if suberr != nil {
 				return suberr

--- a/internal/cli/files.go
+++ b/internal/cli/files.go
@@ -191,13 +191,21 @@ func findRwxDirectoryPath(configuredDirectory string) (string, error) {
 			return filepath.Join(workingDirectory, ".mint"), nil
 		}
 
-		if workingDirectory == string(os.PathSeparator) {
+		parentDir, ok := nextParentDirectory(workingDirectory)
+		if !ok {
 			return "", nil
 		}
 
-		parentDir, _ := filepath.Split(workingDirectory)
-		workingDirectory = filepath.Clean(parentDir)
+		workingDirectory = parentDir
 	}
+}
+
+func nextParentDirectory(directory string) (string, bool) {
+	parentDir := filepath.Clean(filepath.Dir(directory))
+	if parentDir == directory {
+		return "", false
+	}
+	return parentDir, true
 }
 
 // getFileOrDirectoryYAMLEntries gets a RwxDirectoryEntry for every given YAML file, or all YAML files in rwxDir when no files are provided.
@@ -336,8 +344,9 @@ func rwxDirectoryEntry(path string, de os.DirEntry, makePathRelativeTo string) (
 		if err != nil {
 			return RwxDirectoryEntry{}, contentLength, fmt.Errorf("unable to determine relative path of %q: %w", path, err)
 		}
-		relPath = filepath.ToSlash(rel) // Mint only supports unix-style path separators
+		relPath = rel
 	}
+	relPath = filepath.ToSlash(relPath) // Mint only supports unix-style path separators
 
 	return RwxDirectoryEntry{
 		Type:         entryType,

--- a/internal/cli/files_internal_test.go
+++ b/internal/cli/files_internal_test.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNextParentDirectory(t *testing.T) {
+	t.Run("returns parent for nested directory", func(t *testing.T) {
+		parent, ok := nextParentDirectory(filepath.Join("tmp", "project", "subdir"))
+		require.True(t, ok)
+		require.Equal(t, filepath.Join("tmp", "project"), parent)
+	})
+
+	t.Run("stops when parent is the same directory", func(t *testing.T) {
+		parent, ok := nextParentDirectory(filepath.Clean(string(os.PathSeparator)))
+		require.False(t, ok)
+		require.Empty(t, parent)
+	})
+}

--- a/internal/cli/files_internal_test.go
+++ b/internal/cli/files_internal_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,5 +20,23 @@ func TestNextParentDirectory(t *testing.T) {
 		parent, ok := nextParentDirectory(filepath.Clean(string(os.PathSeparator)))
 		require.False(t, ok)
 		require.Empty(t, parent)
+	})
+}
+
+func TestRwxDirectoryEntries(t *testing.T) {
+	t.Run("returns walk errors", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("directory permissions are not enforced the same way on Windows")
+		}
+
+		tmpDir := t.TempDir()
+		blockedDir := filepath.Join(tmpDir, "blocked")
+		require.NoError(t, os.Mkdir(blockedDir, 0o755))
+		require.NoError(t, os.Chmod(blockedDir, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(blockedDir, 0o755) })
+
+		_, err := rwxDirectoryEntries(tmpDir)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "reading rwx directory entries")
 	})
 }

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -73,6 +73,7 @@ type GitClient interface {
 	GetBranch() string
 	GetHead() string
 	GetHeadCommit() (string, error)
+	GetTopLevel() string
 	GetCommit() (string, error)
 	GetOriginUrl() string
 	GeneratePatchFile(destDir string, pathspec []string) (git.PatchFile, error)

--- a/internal/cli/sandbox_storage.go
+++ b/internal/cli/sandbox_storage.go
@@ -181,7 +181,6 @@ func LoadSandboxStorage() (*SandboxStorage, error) {
 	fd, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			storage.Version = sandboxStorageVersion
 			return storage, nil
 		}
 		return nil, errors.Wrapf(err, "unable to open %q", path)
@@ -198,9 +197,8 @@ func LoadSandboxStorage() (*SandboxStorage, error) {
 
 	if storage.Version < sandboxStorageVersion {
 		storage.Sandboxes = migrateOldSessionKeys(storage.Sandboxes)
+		storage.Version = sandboxStorageVersion
 	}
-	storage.Sandboxes = normalizeSessionKeys(storage.Sandboxes)
-	storage.Version = sandboxStorageVersion
 
 	return storage, nil
 }
@@ -215,9 +213,6 @@ func (s *SandboxStorage) Save() error {
 	if err := ensureSandboxStorageDir(dir); err != nil {
 		return errors.Wrapf(err, "unable to create directory for %q", path)
 	}
-
-	s.Version = sandboxStorageVersion
-	s.Sandboxes = normalizeSessionKeys(s.Sandboxes)
 
 	fd, err := os.CreateTemp(dir, ".sandboxes-*.json.tmp")
 	if err != nil {
@@ -266,7 +261,9 @@ func SessionKey(branch, configFile string) string {
 	if branch == "" {
 		branch = "detached"
 	}
-	configFile = AbsConfigFile(configFile)
+	if configFile != "" && !filepath.IsAbs(configFile) {
+		panic(fmt.Sprintf("SessionKey called with relative configFile: %q", configFile))
+	}
 	return fmt.Sprintf("%s:%s", branch, configFile)
 }
 
@@ -323,8 +320,6 @@ func (s *SandboxStorage) GetSessionsForBranch(branch string) []SandboxSession {
 }
 
 func (s *SandboxStorage) SetSession(branch, configFile string, session SandboxSession) {
-	configFile = AbsConfigFile(configFile)
-	session.ConfigFile = normalizeSessionConfigFile(session.ConfigFile, configFile)
 	key := SessionKey(branch, configFile)
 	s.Sandboxes[key] = session
 }
@@ -386,11 +381,9 @@ func (s *SandboxStorage) GetSessionByAncestry(branch, configFile string, checker
 	if !IsDetachedBranch(branch) || DetachedShortSHA(branch) == "" {
 		return nil, false
 	}
-	configFile = AbsConfigFile(configFile)
 
 	for key, session := range s.Sandboxes {
 		storedBranch, storedConfig := ParseSessionKey(key)
-		storedConfig = AbsConfigFile(storedConfig)
 		if storedConfig != configFile {
 			continue
 		}
@@ -403,7 +396,6 @@ func (s *SandboxStorage) GetSessionByAncestry(branch, configFile string, checker
 		}
 		if checker.IsAncestor(storedSHA, "HEAD") {
 			delete(s.Sandboxes, key)
-			session.ConfigFile = normalizeSessionConfigFile(session.ConfigFile, configFile)
 			newKey := SessionKey(branch, configFile)
 			s.Sandboxes[newKey] = session
 			return &session, true
@@ -444,12 +436,9 @@ func (s *SandboxStorage) GetSessionsForBranchByAncestry(branch string, checker A
 	var sessions []SandboxSession
 	for _, r := range toRekey {
 		delete(s.Sandboxes, r.oldKey)
-		configFile := AbsConfigFile(r.config)
-		session := r.session
-		session.ConfigFile = normalizeSessionConfigFile(session.ConfigFile, configFile)
-		newKey := SessionKey(branch, configFile)
-		s.Sandboxes[newKey] = session
-		sessions = append(sessions, session)
+		newKey := SessionKey(branch, r.config)
+		s.Sandboxes[newKey] = r.session
+		sessions = append(sessions, r.session)
 	}
 
 	return sessions
@@ -481,24 +470,6 @@ func migrateOldSessionKeys(sandboxes map[string]SandboxSession) map[string]Sandb
 		migrated[newKey] = session
 	}
 	return migrated
-}
-
-func normalizeSessionKeys(sandboxes map[string]SandboxSession) map[string]SandboxSession {
-	normalized := make(map[string]SandboxSession, len(sandboxes))
-	for key, session := range sandboxes {
-		branch, configFile := ParseSessionKey(key)
-		configFile = AbsConfigFile(configFile)
-		session.ConfigFile = normalizeSessionConfigFile(session.ConfigFile, configFile)
-		normalized[SessionKey(branch, configFile)] = session
-	}
-	return normalized
-}
-
-func normalizeSessionConfigFile(sessionConfigFile, keyConfigFile string) string {
-	if sessionConfigFile == "" || (keyConfigFile != "" && !filepath.IsAbs(sessionConfigFile)) {
-		return keyConfigFile
-	}
-	return AbsConfigFile(sessionConfigFile)
 }
 
 func migrateSessionKey(key string) string {

--- a/internal/cli/sandbox_storage.go
+++ b/internal/cli/sandbox_storage.go
@@ -181,6 +181,7 @@ func LoadSandboxStorage() (*SandboxStorage, error) {
 	fd, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
+			storage.Version = sandboxStorageVersion
 			return storage, nil
 		}
 		return nil, errors.Wrapf(err, "unable to open %q", path)
@@ -213,6 +214,10 @@ func (s *SandboxStorage) Save() error {
 	if err := ensureSandboxStorageDir(dir); err != nil {
 		return errors.Wrapf(err, "unable to create directory for %q", path)
 	}
+
+	// Stamp the version on every save; fresh storage would otherwise serialize
+	// without a version field (omitempty) and be treated as legacy on load.
+	s.Version = sandboxStorageVersion
 
 	fd, err := os.CreateTemp(dir, ".sandboxes-*.json.tmp")
 	if err != nil {

--- a/internal/cli/sandbox_storage.go
+++ b/internal/cli/sandbox_storage.go
@@ -181,6 +181,7 @@ func LoadSandboxStorage() (*SandboxStorage, error) {
 	fd, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
+			storage.Version = sandboxStorageVersion
 			return storage, nil
 		}
 		return nil, errors.Wrapf(err, "unable to open %q", path)
@@ -197,8 +198,9 @@ func LoadSandboxStorage() (*SandboxStorage, error) {
 
 	if storage.Version < sandboxStorageVersion {
 		storage.Sandboxes = migrateOldSessionKeys(storage.Sandboxes)
-		storage.Version = sandboxStorageVersion
 	}
+	storage.Sandboxes = normalizeSessionKeys(storage.Sandboxes)
+	storage.Version = sandboxStorageVersion
 
 	return storage, nil
 }
@@ -213,6 +215,9 @@ func (s *SandboxStorage) Save() error {
 	if err := ensureSandboxStorageDir(dir); err != nil {
 		return errors.Wrapf(err, "unable to create directory for %q", path)
 	}
+
+	s.Version = sandboxStorageVersion
+	s.Sandboxes = normalizeSessionKeys(s.Sandboxes)
 
 	fd, err := os.CreateTemp(dir, ".sandboxes-*.json.tmp")
 	if err != nil {
@@ -261,9 +266,7 @@ func SessionKey(branch, configFile string) string {
 	if branch == "" {
 		branch = "detached"
 	}
-	if configFile != "" && !filepath.IsAbs(configFile) {
-		panic(fmt.Sprintf("SessionKey called with relative configFile: %q", configFile))
-	}
+	configFile = AbsConfigFile(configFile)
 	return fmt.Sprintf("%s:%s", branch, configFile)
 }
 
@@ -320,6 +323,8 @@ func (s *SandboxStorage) GetSessionsForBranch(branch string) []SandboxSession {
 }
 
 func (s *SandboxStorage) SetSession(branch, configFile string, session SandboxSession) {
+	configFile = AbsConfigFile(configFile)
+	session.ConfigFile = normalizeSessionConfigFile(session.ConfigFile, configFile)
 	key := SessionKey(branch, configFile)
 	s.Sandboxes[key] = session
 }
@@ -381,9 +386,11 @@ func (s *SandboxStorage) GetSessionByAncestry(branch, configFile string, checker
 	if !IsDetachedBranch(branch) || DetachedShortSHA(branch) == "" {
 		return nil, false
 	}
+	configFile = AbsConfigFile(configFile)
 
 	for key, session := range s.Sandboxes {
 		storedBranch, storedConfig := ParseSessionKey(key)
+		storedConfig = AbsConfigFile(storedConfig)
 		if storedConfig != configFile {
 			continue
 		}
@@ -396,6 +403,7 @@ func (s *SandboxStorage) GetSessionByAncestry(branch, configFile string, checker
 		}
 		if checker.IsAncestor(storedSHA, "HEAD") {
 			delete(s.Sandboxes, key)
+			session.ConfigFile = normalizeSessionConfigFile(session.ConfigFile, configFile)
 			newKey := SessionKey(branch, configFile)
 			s.Sandboxes[newKey] = session
 			return &session, true
@@ -436,9 +444,12 @@ func (s *SandboxStorage) GetSessionsForBranchByAncestry(branch string, checker A
 	var sessions []SandboxSession
 	for _, r := range toRekey {
 		delete(s.Sandboxes, r.oldKey)
-		newKey := SessionKey(branch, r.config)
-		s.Sandboxes[newKey] = r.session
-		sessions = append(sessions, r.session)
+		configFile := AbsConfigFile(r.config)
+		session := r.session
+		session.ConfigFile = normalizeSessionConfigFile(session.ConfigFile, configFile)
+		newKey := SessionKey(branch, configFile)
+		s.Sandboxes[newKey] = session
+		sessions = append(sessions, session)
 	}
 
 	return sessions
@@ -470,6 +481,24 @@ func migrateOldSessionKeys(sandboxes map[string]SandboxSession) map[string]Sandb
 		migrated[newKey] = session
 	}
 	return migrated
+}
+
+func normalizeSessionKeys(sandboxes map[string]SandboxSession) map[string]SandboxSession {
+	normalized := make(map[string]SandboxSession, len(sandboxes))
+	for key, session := range sandboxes {
+		branch, configFile := ParseSessionKey(key)
+		configFile = AbsConfigFile(configFile)
+		session.ConfigFile = normalizeSessionConfigFile(session.ConfigFile, configFile)
+		normalized[SessionKey(branch, configFile)] = session
+	}
+	return normalized
+}
+
+func normalizeSessionConfigFile(sessionConfigFile, keyConfigFile string) string {
+	if sessionConfigFile == "" || (keyConfigFile != "" && !filepath.IsAbs(sessionConfigFile)) {
+		return keyConfigFile
+	}
+	return AbsConfigFile(sessionConfigFile)
 }
 
 func migrateSessionKey(key string) string {

--- a/internal/cli/sandbox_storage.go
+++ b/internal/cli/sandbox_storage.go
@@ -214,16 +214,28 @@ func (s *SandboxStorage) Save() error {
 		return errors.Wrapf(err, "unable to create directory for %q", path)
 	}
 
-	fd, err := os.Create(path)
+	fd, err := os.CreateTemp(dir, ".sandboxes-*.json.tmp")
 	if err != nil {
-		return errors.Wrapf(err, "unable to create %q", path)
+		return errors.Wrapf(err, "unable to create temporary sandbox storage file in %q", dir)
 	}
-	defer fd.Close()
+	tempPath := fd.Name()
+	defer os.Remove(tempPath)
 
 	encoder := json.NewEncoder(fd)
 	encoder.SetIndent("", "  ")
 	if err := encoder.Encode(s); err != nil {
-		return errors.Wrapf(err, "unable to write %q", path)
+		_ = fd.Close()
+		return errors.Wrapf(err, "unable to write %q", tempPath)
+	}
+	if err := fd.Sync(); err != nil {
+		_ = fd.Close()
+		return errors.Wrapf(err, "unable to sync %q", tempPath)
+	}
+	if err := fd.Close(); err != nil {
+		return errors.Wrapf(err, "unable to close %q", tempPath)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return errors.Wrapf(err, "unable to replace %q", path)
 	}
 
 	return nil

--- a/internal/cli/sandbox_storage_test.go
+++ b/internal/cli/sandbox_storage_test.go
@@ -342,6 +342,25 @@ func TestSandboxStorage_LoadAndSave(t *testing.T) {
 		require.Equal(t, "*\n", string(contents))
 	})
 
+	t.Run("does not leave temporary files after save", func(t *testing.T) {
+		tmpDir := setupTestStorageDir(t)
+
+		storage := &cli.SandboxStorage{
+			Sandboxes: make(map[string]cli.SandboxSession),
+		}
+		storage.SetSession("main", "/home/user/project/.rwx/sandbox.yml", cli.SandboxSession{
+			RunID:      "run-123",
+			ConfigFile: "/home/user/project/.rwx/sandbox.yml",
+		})
+
+		err := storage.Save()
+		require.NoError(t, err)
+
+		tempFiles, err := filepath.Glob(filepath.Join(tmpDir, ".rwx", "sandboxes", ".sandboxes-*.json.tmp"))
+		require.NoError(t, err)
+		require.Empty(t, tempFiles)
+	})
+
 	t.Run("creates directory structure if it does not exist", func(t *testing.T) {
 		tmpDir := setupTestStorageDir(t)
 

--- a/internal/cli/sandbox_storage_test.go
+++ b/internal/cli/sandbox_storage_test.go
@@ -1,7 +1,6 @@
 package cli_test
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,19 +23,6 @@ func TestSessionKey(t *testing.T) {
 	t.Run("preserves detached@sha format as-is", func(t *testing.T) {
 		key := cli.SessionKey("detached@abc1234", "/home/user/project/.rwx/sandbox.yml")
 		require.Equal(t, "detached@abc1234:/home/user/project/.rwx/sandbox.yml", key)
-	})
-
-	t.Run("normalizes relative config file", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		originalWd, err := os.Getwd()
-		require.NoError(t, err)
-		require.NoError(t, os.Chdir(tmpDir))
-		t.Cleanup(func() { _ = os.Chdir(originalWd) })
-
-		expectedConfig, err := filepath.Abs(".rwx/sandbox.yml")
-		require.NoError(t, err)
-		key := cli.SessionKey("main", ".rwx/sandbox.yml")
-		require.Equal(t, "main:"+expectedConfig, key)
 	})
 }
 
@@ -106,33 +92,6 @@ func TestSandboxStorage_SessionOperations(t *testing.T) {
 		require.True(t, found)
 		require.Equal(t, "run-123", retrieved.RunID)
 		require.Equal(t, "/home/user/project/.rwx/sandbox.yml", retrieved.ConfigFile)
-	})
-
-	t.Run("normalizes relative config files", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		originalWd, err := os.Getwd()
-		require.NoError(t, err)
-		require.NoError(t, os.Chdir(tmpDir))
-		t.Cleanup(func() { _ = os.Chdir(originalWd) })
-
-		storage := &cli.SandboxStorage{
-			Sandboxes: make(map[string]cli.SandboxSession),
-		}
-		storage.SetSession("main", ".rwx/sandbox.yml", cli.SandboxSession{
-			RunID:      "run-relative",
-			ConfigFile: ".rwx/sandbox.yml",
-		})
-
-		expectedConfig, err := filepath.Abs(".rwx/sandbox.yml")
-		require.NoError(t, err)
-		session, found := storage.GetSession("main", expectedConfig)
-		require.True(t, found)
-		require.Equal(t, "run-relative", session.RunID)
-		require.Equal(t, expectedConfig, session.ConfigFile)
-
-		session, found = storage.GetSession("main", ".rwx/sandbox.yml")
-		require.True(t, found)
-		require.Equal(t, expectedConfig, session.ConfigFile)
 	})
 
 	t.Run("SetSession and GetSession with ScopedToken", func(t *testing.T) {
@@ -462,48 +421,6 @@ func TestSandboxStorage_LoadAndSave(t *testing.T) {
 		session, found := storage.GetSession("main", "/home/user/project/.rwx/sandbox.yml")
 		require.True(t, found)
 		require.Equal(t, "run-old", session.RunID)
-	})
-
-	t.Run("migrates old-format relative config paths on load", func(t *testing.T) {
-		tmpDir := setupTestStorageDir(t)
-
-		sandboxesDir := filepath.Join(tmpDir, ".rwx", "sandboxes")
-		require.NoError(t, os.MkdirAll(sandboxesDir, 0o755))
-		storagePath := filepath.Join(sandboxesDir, "sandboxes.json")
-		oldKey := tmpDir + ":main:.rwx/sandbox.yml"
-		oldJSON := fmt.Sprintf(`{"sandboxes":{%q:{"runId":"run-old-relative","configFile":".rwx/sandbox.yml"}}}`, oldKey)
-		require.NoError(t, os.WriteFile(storagePath, []byte(oldJSON), 0o644))
-
-		storage, err := cli.LoadSandboxStorage()
-		require.NoError(t, err)
-		require.Len(t, storage.Sandboxes, 1)
-
-		expectedConfig := filepath.Join(tmpDir, ".rwx", "sandbox.yml")
-		session, found := storage.GetSession("main", expectedConfig)
-		require.True(t, found)
-		require.Equal(t, "run-old-relative", session.RunID)
-		require.Equal(t, expectedConfig, session.ConfigFile)
-	})
-
-	t.Run("normalizes current-version relative keys on load", func(t *testing.T) {
-		tmpDir := setupTestStorageDir(t)
-
-		sandboxesDir := filepath.Join(tmpDir, ".rwx", "sandboxes")
-		require.NoError(t, os.MkdirAll(sandboxesDir, 0o755))
-		storagePath := filepath.Join(sandboxesDir, "sandboxes.json")
-		currentJSON := `{"version":1,"sandboxes":{"main:.rwx/sandbox.yml":{"runId":"run-current-relative","configFile":".rwx/sandbox.yml"}}}`
-		require.NoError(t, os.WriteFile(storagePath, []byte(currentJSON), 0o644))
-
-		storage, err := cli.LoadSandboxStorage()
-		require.NoError(t, err)
-		require.Len(t, storage.Sandboxes, 1)
-
-		expectedConfig, err := filepath.Abs(".rwx/sandbox.yml")
-		require.NoError(t, err)
-		session, found := storage.GetSession("main", expectedConfig)
-		require.True(t, found)
-		require.Equal(t, "run-current-relative", session.RunID)
-		require.Equal(t, expectedConfig, session.ConfigFile)
 	})
 
 	t.Run("skips migration when version is current", func(t *testing.T) {

--- a/internal/cli/sandbox_storage_test.go
+++ b/internal/cli/sandbox_storage_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,6 +24,19 @@ func TestSessionKey(t *testing.T) {
 	t.Run("preserves detached@sha format as-is", func(t *testing.T) {
 		key := cli.SessionKey("detached@abc1234", "/home/user/project/.rwx/sandbox.yml")
 		require.Equal(t, "detached@abc1234:/home/user/project/.rwx/sandbox.yml", key)
+	})
+
+	t.Run("normalizes relative config file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		originalWd, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
+		t.Cleanup(func() { _ = os.Chdir(originalWd) })
+
+		expectedConfig, err := filepath.Abs(".rwx/sandbox.yml")
+		require.NoError(t, err)
+		key := cli.SessionKey("main", ".rwx/sandbox.yml")
+		require.Equal(t, "main:"+expectedConfig, key)
 	})
 }
 
@@ -92,6 +106,33 @@ func TestSandboxStorage_SessionOperations(t *testing.T) {
 		require.True(t, found)
 		require.Equal(t, "run-123", retrieved.RunID)
 		require.Equal(t, "/home/user/project/.rwx/sandbox.yml", retrieved.ConfigFile)
+	})
+
+	t.Run("normalizes relative config files", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		originalWd, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
+		t.Cleanup(func() { _ = os.Chdir(originalWd) })
+
+		storage := &cli.SandboxStorage{
+			Sandboxes: make(map[string]cli.SandboxSession),
+		}
+		storage.SetSession("main", ".rwx/sandbox.yml", cli.SandboxSession{
+			RunID:      "run-relative",
+			ConfigFile: ".rwx/sandbox.yml",
+		})
+
+		expectedConfig, err := filepath.Abs(".rwx/sandbox.yml")
+		require.NoError(t, err)
+		session, found := storage.GetSession("main", expectedConfig)
+		require.True(t, found)
+		require.Equal(t, "run-relative", session.RunID)
+		require.Equal(t, expectedConfig, session.ConfigFile)
+
+		session, found = storage.GetSession("main", ".rwx/sandbox.yml")
+		require.True(t, found)
+		require.Equal(t, expectedConfig, session.ConfigFile)
 	})
 
 	t.Run("SetSession and GetSession with ScopedToken", func(t *testing.T) {
@@ -421,6 +462,48 @@ func TestSandboxStorage_LoadAndSave(t *testing.T) {
 		session, found := storage.GetSession("main", "/home/user/project/.rwx/sandbox.yml")
 		require.True(t, found)
 		require.Equal(t, "run-old", session.RunID)
+	})
+
+	t.Run("migrates old-format relative config paths on load", func(t *testing.T) {
+		tmpDir := setupTestStorageDir(t)
+
+		sandboxesDir := filepath.Join(tmpDir, ".rwx", "sandboxes")
+		require.NoError(t, os.MkdirAll(sandboxesDir, 0o755))
+		storagePath := filepath.Join(sandboxesDir, "sandboxes.json")
+		oldKey := tmpDir + ":main:.rwx/sandbox.yml"
+		oldJSON := fmt.Sprintf(`{"sandboxes":{%q:{"runId":"run-old-relative","configFile":".rwx/sandbox.yml"}}}`, oldKey)
+		require.NoError(t, os.WriteFile(storagePath, []byte(oldJSON), 0o644))
+
+		storage, err := cli.LoadSandboxStorage()
+		require.NoError(t, err)
+		require.Len(t, storage.Sandboxes, 1)
+
+		expectedConfig := filepath.Join(tmpDir, ".rwx", "sandbox.yml")
+		session, found := storage.GetSession("main", expectedConfig)
+		require.True(t, found)
+		require.Equal(t, "run-old-relative", session.RunID)
+		require.Equal(t, expectedConfig, session.ConfigFile)
+	})
+
+	t.Run("normalizes current-version relative keys on load", func(t *testing.T) {
+		tmpDir := setupTestStorageDir(t)
+
+		sandboxesDir := filepath.Join(tmpDir, ".rwx", "sandboxes")
+		require.NoError(t, os.MkdirAll(sandboxesDir, 0o755))
+		storagePath := filepath.Join(sandboxesDir, "sandboxes.json")
+		currentJSON := `{"version":1,"sandboxes":{"main:.rwx/sandbox.yml":{"runId":"run-current-relative","configFile":".rwx/sandbox.yml"}}}`
+		require.NoError(t, os.WriteFile(storagePath, []byte(currentJSON), 0o644))
+
+		storage, err := cli.LoadSandboxStorage()
+		require.NoError(t, err)
+		require.Len(t, storage.Sandboxes, 1)
+
+		expectedConfig, err := filepath.Abs(".rwx/sandbox.yml")
+		require.NoError(t, err)
+		session, found := storage.GetSession("main", expectedConfig)
+		require.True(t, found)
+		require.Equal(t, "run-current-relative", session.RunID)
+		require.Equal(t, expectedConfig, session.ConfigFile)
 	})
 
 	t.Run("skips migration when version is current", func(t *testing.T) {

--- a/internal/cli/sandbox_storage_test.go
+++ b/internal/cli/sandbox_storage_test.go
@@ -327,6 +327,21 @@ func TestSandboxStorage_LoadAndSave(t *testing.T) {
 		require.Equal(t, "run-123", session.RunID)
 	})
 
+	t.Run("stamps current version on load and save", func(t *testing.T) {
+		tmpDir := setupTestStorageDir(t)
+
+		storage, err := cli.LoadSandboxStorage()
+		require.NoError(t, err)
+		require.Equal(t, 1, storage.Version)
+
+		require.NoError(t, storage.Save())
+
+		localPath := filepath.Join(tmpDir, ".rwx", "sandboxes", "sandboxes.json")
+		contents, err := os.ReadFile(localPath)
+		require.NoError(t, err)
+		require.Contains(t, string(contents), `"version": 1`)
+	})
+
 	t.Run("creates .gitignore in sandboxes dir", func(t *testing.T) {
 		tmpDir := setupTestStorageDir(t)
 

--- a/internal/cli/service_resolve_cli_params.go
+++ b/internal/cli/service_resolve_cli_params.go
@@ -183,6 +183,12 @@ func prependOnSection(yamlContent string, params map[string]any) string {
 		onSection.WriteString(fmt.Sprintf("      %s: %s\n", k, params[k]))
 	}
 
+	if strings.HasPrefix(yamlContent, "---\r\n") {
+		return "---\r\n" + onSection.String() + strings.TrimPrefix(yamlContent, "---\r\n")
+	}
+	if strings.HasPrefix(yamlContent, "---\n") {
+		return "---\n" + onSection.String() + strings.TrimPrefix(yamlContent, "---\n")
+	}
 	return onSection.String() + yamlContent
 }
 

--- a/internal/cli/service_resolve_cli_params.go
+++ b/internal/cli/service_resolve_cli_params.go
@@ -115,36 +115,18 @@ func extractCliGitParamNames(doc *YAMLDoc) []string {
 		return nil
 	}
 
-	seen := map[string]bool{}
-	collectGitParamNamesFromInitNode(cliInit, seen)
-	return sortedKeys(seen)
-}
-
-func collectGitParamNamesFromInitNode(node ast.Node, seen map[string]bool) {
-	if sequenceNode, ok := node.(*ast.SequenceNode); ok {
-		for _, element := range sequenceNode.Values {
-			collectGitParamNamesFromInitNode(element, seen)
-		}
-		return
-	}
-
-	mappingNode, ok := node.(*ast.MappingNode)
+	mappingNode, ok := cliInit.(*ast.MappingNode)
 	if !ok {
-		return
+		return nil
 	}
 
+	seen := map[string]bool{}
 	for _, field := range mappingNode.Values {
-		if field.Key.String() == "init" {
-			collectGitParamNamesFromInitNode(field.Value, seen)
-			continue
-		}
-		if field.Key.String() == "if" {
-			continue
-		}
 		if strings.Contains(field.Value.String(), "event.git.sha") {
 			seen[field.Key.String()] = true
 		}
 	}
+	return sortedKeys(seen)
 }
 
 func mergeGitParamNames(names ...[]string) []string {

--- a/internal/cli/service_resolve_cli_params.go
+++ b/internal/cli/service_resolve_cli_params.go
@@ -43,16 +43,19 @@ func resolveCliParams(yamlContent string) (string, []string, error) {
 		return "", nil, errors.Wrap(err, "failed to parse YAML")
 	}
 
-	// Skip if CLI init already has git event references
-	if cliInit := doc.TryReadStringAtPath("$.on.cli.init"); strings.Contains(cliInit, "event.git.") {
-		return yamlContent, nil, nil
-	}
-
 	gitParamsMap, err := extractGitParams(doc)
 	gitParamNames := getGitParamNames(gitParamsMap)
 	if err != nil {
 		return "", gitParamNames, err
 	}
+	gitParamNames = mergeGitParamNames(gitParamNames, extractCliGitParamNames(doc))
+
+	// Skip rewriting if CLI init already has git event references, but still
+	// return the git param names so callers can suppress HEAD-based patches.
+	if cliInit := doc.TryReadStringAtPath("$.on.cli.init"); strings.Contains(cliInit, "event.git.") {
+		return yamlContent, gitParamNames, nil
+	}
+
 	if len(gitParamsMap) == 0 {
 		return yamlContent, gitParamNames, nil
 	}
@@ -104,6 +107,66 @@ func getGitParamNames(params map[string]any) []string {
 	}
 	slices.Sort(names)
 	return names
+}
+
+func extractCliGitParamNames(doc *YAMLDoc) []string {
+	cliInit, err := doc.getNodeAtPath("$.on.cli.init")
+	if err != nil {
+		return nil
+	}
+
+	seen := map[string]bool{}
+	collectGitParamNamesFromInitNode(cliInit, seen)
+	return sortedKeys(seen)
+}
+
+func collectGitParamNamesFromInitNode(node ast.Node, seen map[string]bool) {
+	if sequenceNode, ok := node.(*ast.SequenceNode); ok {
+		for _, element := range sequenceNode.Values {
+			collectGitParamNamesFromInitNode(element, seen)
+		}
+		return
+	}
+
+	mappingNode, ok := node.(*ast.MappingNode)
+	if !ok {
+		return
+	}
+
+	for _, field := range mappingNode.Values {
+		if field.Key.String() == "init" {
+			collectGitParamNamesFromInitNode(field.Value, seen)
+			continue
+		}
+		if field.Key.String() == "if" {
+			continue
+		}
+		if strings.Contains(field.Value.String(), "event.git.sha") {
+			seen[field.Key.String()] = true
+		}
+	}
+}
+
+func mergeGitParamNames(names ...[]string) []string {
+	seen := map[string]bool{}
+	for _, group := range names {
+		for _, name := range group {
+			seen[name] = true
+		}
+	}
+	return sortedKeys(seen)
+}
+
+func sortedKeys(values map[string]bool) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
 }
 
 func prependOnSection(yamlContent string, params map[string]any) string {

--- a/internal/cli/service_resolve_cli_params_test.go
+++ b/internal/cli/service_resolve_cli_params_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -369,6 +370,31 @@ tasks:
 		require.Contains(t, string(fileContent), "on:")
 		require.Contains(t, string(fileContent), "cli:")
 		require.Contains(t, string(fileContent), "sha: ${{ event.git.sha }}")
+	})
+
+	t.Run("adds CLI trigger after document separator", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yml")
+		require.NoError(t, err)
+		defer tmpFile.Close()
+
+		content := `---
+tasks:
+  - key: clone
+    call: git/clone 1.8.1
+    with:
+      ref: ${{ init.sha }}
+`
+		_, err = tmpFile.WriteString(content)
+		require.NoError(t, err)
+
+		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		require.NoError(t, err)
+		require.True(t, result.Rewritten)
+
+		fileContent, err := os.ReadFile(tmpFile.Name())
+		require.NoError(t, err)
+		require.True(t, strings.HasPrefix(string(fileContent), "---\non:\n  cli:\n    init:\n      sha: ${{ event.git.sha }}\n"))
+		require.Contains(t, string(fileContent), "tasks:")
 	})
 
 	t.Run("adds CLI trigger when dispatch trigger has git params", func(t *testing.T) {

--- a/internal/cli/service_resolve_cli_params_test.go
+++ b/internal/cli/service_resolve_cli_params_test.go
@@ -166,6 +166,34 @@ tasks:
 		require.Equal(t, content, string(fileContent))
 	})
 
+	t.Run("returns CLI git param named init", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yml")
+		require.NoError(t, err)
+		defer tmpFile.Close()
+
+		content := `
+on:
+  cli:
+    init:
+      init: ${{ event.git.sha }}
+
+tasks:
+  - key: test
+    run: echo ${{ init.init }}
+`
+		_, err = tmpFile.WriteString(content)
+		require.NoError(t, err)
+
+		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		require.NoError(t, err)
+		require.False(t, result.Rewritten)
+		require.Equal(t, []string{"init"}, result.GitParams)
+
+		fileContent, err := os.ReadFile(tmpFile.Name())
+		require.NoError(t, err)
+		require.Equal(t, content, string(fileContent))
+	})
+
 	t.Run("adds CLI trigger when another trigger has git params", func(t *testing.T) {
 		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yml")
 		require.NoError(t, err)

--- a/internal/cli/service_resolve_cli_params_test.go
+++ b/internal/cli/service_resolve_cli_params_test.go
@@ -96,6 +96,7 @@ tasks:
 		result, err := ResolveCliParamsForFile(tmpFile.Name())
 		require.NoError(t, err)
 		require.False(t, result.Rewritten)
+		require.Equal(t, []string{"sha"}, result.GitParams)
 
 		fileContent, err := os.ReadFile(tmpFile.Name())
 		require.NoError(t, err)
@@ -127,6 +128,37 @@ tasks:
 		result, err := ResolveCliParamsForFile(tmpFile.Name())
 		require.NoError(t, err)
 		require.False(t, result.Rewritten)
+		require.Equal(t, []string{"commit-sha", "sha"}, result.GitParams)
+
+		fileContent, err := os.ReadFile(tmpFile.Name())
+		require.NoError(t, err)
+		require.Equal(t, content, string(fileContent))
+	})
+
+	t.Run("returns git clone ref param when CLI trigger already has git init params", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yml")
+		require.NoError(t, err)
+		defer tmpFile.Close()
+
+		content := `
+on:
+  cli:
+    init:
+      ref: ${{ event.git.sha }}
+
+tasks:
+  - key: clone
+    call: git/clone 1.8.1
+    with:
+      ref: ${{ init.ref }}
+`
+		_, err = tmpFile.WriteString(content)
+		require.NoError(t, err)
+
+		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		require.NoError(t, err)
+		require.False(t, result.Rewritten)
+		require.Equal(t, []string{"ref"}, result.GitParams)
 
 		fileContent, err := os.ReadFile(tmpFile.Name())
 		require.NoError(t, err)

--- a/internal/cli/service_run.go
+++ b/internal/cli/service_run.go
@@ -90,6 +90,38 @@ func appendWorkflowUploadEntry(entries []RwxDirectoryEntry, runDef RwxDirectoryE
 	return entries
 }
 
+func runPatchPathspec(gitRoot, runDefinitionPath, fallbackRunDefinitionPath string) []string {
+	pathspec := []string{":/"}
+	if runDefinitionPathspec := runDefinitionGitPath(gitRoot, runDefinitionPath, fallbackRunDefinitionPath); runDefinitionPathspec != "" {
+		pathspec = append(pathspec, ":(top,exclude)"+runDefinitionPathspec)
+	}
+	return pathspec
+}
+
+func runDefinitionGitPath(gitRoot, runDefinitionPath, fallbackRunDefinitionPath string) string {
+	if gitRoot != "" {
+		if absGitRoot, err := filepath.Abs(gitRoot); err == nil {
+			if absRunDefinitionPath, err := filepath.Abs(runDefinitionPath); err == nil {
+				if rel, err := filepath.Rel(absGitRoot, absRunDefinitionPath); err == nil && isRepoRelativePath(rel) {
+					return filepath.ToSlash(rel)
+				}
+			}
+		}
+	}
+
+	if isRepoRelativePath(fallbackRunDefinitionPath) {
+		return filepath.ToSlash(fallbackRunDefinitionPath)
+	}
+	return ""
+}
+
+func isRepoRelativePath(path string) bool {
+	if path == "" || path == "." || path == ".." || filepath.IsAbs(path) {
+		return false
+	}
+	return !strings.HasPrefix(path, ".."+string(filepath.Separator))
+}
+
 type InitiateRunConfig struct {
 	InitParameters map[string]string
 	Json           bool
@@ -198,7 +230,10 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 
 	if patchable {
 		var patchErr error
-		patchFile, patchErr = s.GitClient.GeneratePatchFile(patchDir, []string{".", ":!" + relativeRunDefinitionPath})
+		patchFile, patchErr = s.GitClient.GeneratePatchFile(
+			patchDir,
+			runPatchPathspec(s.GitClient.GetTopLevel(), runDefinitionPath, relativeRunDefinitionPath),
+		)
 		if patchErr != nil {
 			errorMessage = patchErr.Error()
 			fmt.Fprintf(s.Stderr, "Warning: %s\n\n", errorMessage)

--- a/internal/cli/service_run_patch_test.go
+++ b/internal/cli/service_run_patch_test.go
@@ -506,5 +506,55 @@ func TestService_InitiatingRunPatch(t *testing.T) {
 				require.False(t, strings.Contains(entry.Path, ".patches"), "expected no .patches entries when init params match git params, found: %s", entry.Path)
 			}
 		})
+
+		t.Run("when init params match existing CLI git clone params", func(t *testing.T) {
+			s := setupTest(t)
+			s.mockGit.MockGetCommit = "3e76c8295cd0ce4decbf7b56253c902ce296cb25"
+			s.mockGit.MockGeneratePatchFile = patchFile
+
+			rwxDir := filepath.Join(s.tmp, ".rwx")
+			err := os.MkdirAll(rwxDir, 0o755)
+			require.NoError(t, err)
+
+			definitionsFile := filepath.Join(rwxDir, "rwx.yml")
+			definition := "on:\n  cli:\n    init:\n      ref: ${{ event.git.sha }}\n\nbase:\n  os: ubuntu 24.04\n  tag: 1.0\n\ntasks:\n  - key: clone\n    call: git/clone 1.8.1\n    with:\n      ref: ${{ init.ref }}\n"
+
+			err = os.WriteFile(definitionsFile, []byte(definition), 0o644)
+			require.NoError(t, err)
+
+			runConfig := cli.InitiateRunConfig{
+				RwxDirectory: rwxDir,
+				MintFilePath: definitionsFile,
+				Patchable:    true,
+				InitParameters: map[string]string{
+					"ref": "3e76c8295cd0ce4decbf7b56253c902ce296cb25",
+				},
+			}
+
+			var receivedRwxDir []api.RwxDirectoryEntry
+			s.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+				return &api.PackageVersionsResult{
+					LatestMajor: make(map[string]string),
+					LatestMinor: make(map[string]map[string]string),
+				}, nil
+			}
+			s.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+				require.False(t, cfg.Patch.Sent)
+				receivedRwxDir = cfg.RwxDirectory
+				return &api.InitiateRunResult{
+					RunID:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+					RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+					TargetedTaskKeys: []string{},
+					DefinitionPath:   ".mint/mint.yml",
+				}, nil
+			}
+
+			_, err = s.service.InitiateRun(runConfig)
+			require.NoError(t, err)
+
+			for _, entry := range receivedRwxDir {
+				require.False(t, strings.Contains(entry.Path, ".patches"), "expected no .patches entries when init params match git params, found: %s", entry.Path)
+			}
+		})
 	})
 }

--- a/internal/cli/service_run_patch_test.go
+++ b/internal/cli/service_run_patch_test.go
@@ -78,6 +78,44 @@ func initiateRun(t *testing.T, patchFile git.PatchFile, expectedPatchMetadata ap
 }
 
 func TestService_InitiatingRunPatch(t *testing.T) {
+	t.Run("uses repository root pathspec when run from subdirectory", func(t *testing.T) {
+		s := setupTest(t)
+		s.mockGit.MockGetCommit = "3e76c8295cd0ce4decbf7b56253c902ce296cb25"
+		s.mockGit.MockGetTopLevel = s.tmp
+
+		rwxDir := filepath.Join(s.tmp, ".rwx")
+		definitionsFile := filepath.Join(rwxDir, "rwx.yml")
+		definition := "on:\n  cli:\n    init:\n      sha: ${{ event.git.sha }}\n\nbase:\n  os: ubuntu 24.04\n  tag: 1.0\n\ntasks:\n  - key: foo\n    run: echo 'bar'\n"
+		require.NoError(t, os.WriteFile(definitionsFile, []byte(definition), 0o644))
+
+		subdir := filepath.Join(s.tmp, "subdir")
+		require.NoError(t, os.Mkdir(subdir, 0o755))
+		require.NoError(t, os.Chdir(subdir))
+
+		s.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+			return &api.PackageVersionsResult{
+				LatestMajor: make(map[string]string),
+				LatestMinor: make(map[string]map[string]string),
+			}, nil
+		}
+		s.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+			return &api.InitiateRunResult{
+				RunID:            "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+				RunURL:           "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",
+				TargetedTaskKeys: []string{},
+				DefinitionPath:   ".mint/mint.yml",
+			}, nil
+		}
+
+		_, err := s.service.InitiateRun(cli.InitiateRunConfig{
+			Patchable:    true,
+			RwxDirectory: rwxDir,
+			MintFilePath: definitionsFile,
+		})
+		require.NoError(t, err)
+		require.Equal(t, []string{":/", ":(top,exclude).rwx/rwx.yml"}, s.mockGit.MockGeneratePatchPathspec)
+	})
+
 	t.Run("when git is not installed", func(t *testing.T) {
 		s := setupTest(t)
 		s.mockGit.MockIsInstalled = false

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1830,7 +1830,7 @@ func (s Service) snapshotSandboxSyncRefForPaths(paths []string) error {
 	} else if paths == nil {
 		script += "/usr/bin/git add -A && "
 	}
-	script += `/usr/bin/git -c user.name=rwx -c user.email=rwx commit --allow-empty -m rwx-sync >/dev/null 2>&1 && /usr/bin/git update-ref refs/rwx-sync HEAD && /usr/bin/git reset --mixed HEAD~1 >/dev/null 2>&1 && /usr/bin/git read-tree "$index_tree"`
+	script += `/usr/bin/git -c user.name=rwx -c user.email=rwx -c core.hooksPath=/dev/null commit --allow-empty --no-verify -m rwx-sync >/dev/null 2>&1 && /usr/bin/git update-ref refs/rwx-sync HEAD && /usr/bin/git reset --mixed HEAD~1 >/dev/null 2>&1 && /usr/bin/git read-tree "$index_tree"`
 
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
 	exitCode, err := s.SSHClient.ExecuteCommand("/bin/sh -lc " + quoteShellArg(script))

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -465,6 +465,8 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 				scopedToken = existingSession.ScopedToken
 				sessionRunURL = existingSession.RunURL
 				storedConfigHash = existingSession.ConfigHash
+				execCount = existingSession.ExecCount
+				resetNagShown = existingSession.ResetNagShown
 			}
 		}
 	} else {
@@ -764,7 +766,7 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 	var syncPushMs int64
 	var syncPushPatchBytes int
 	syncPushStart := time.Now()
-	patchBytes, err := s.prepareSandboxForExec(cfg.Json, isNewSandbox, localHeadForSync, connInfo)
+	patchBytes, err := s.prepareSandboxForExec(cfg.Json, isNewSandbox, isNewSandbox || execCount == 0, localHeadForSync, connInfo)
 	syncPushMs = time.Since(syncPushStart).Milliseconds()
 	syncPushPatchBytes = patchBytes
 	if err != nil {
@@ -1423,7 +1425,7 @@ func (s Service) revertSandboxToGitState(localHead string) error {
 	return nil
 }
 
-func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHead string, connInfo *api.SandboxConnectionInfo) (int, error) {
+func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, cleanPreAppliedNewFiles bool, localHead string, connInfo *api.SandboxConnectionInfo) (int, error) {
 	if localHead == "" {
 		return 0, fmt.Errorf("sandbox sync requires a git repository with a valid HEAD")
 	}
@@ -1481,7 +1483,7 @@ func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHe
 		return patchBytes, syncPushErr
 	}
 
-	if isNewSandbox {
+	if cleanPreAppliedNewFiles {
 		if err := s.removePreAppliedNewFilesFromSandbox(patches); err != nil {
 			syncPushErr = err
 			return patchBytes, syncPushErr

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1275,7 +1275,7 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 
 	// Include untracked files in the diff by adding them with intent-to-add
 	// Get untracked files, add with -N, get diff, then reset
-	lsExitCode, untrackedOutput, lsErr := s.SSHClient.ExecuteCommandWithOutput("/usr/bin/git ls-files -z --others --exclude-standard")
+	lsExitCode, untrackedOutput, lsErr := s.SSHClient.ExecuteCommandWithOutput(sandboxWorktreeRootCommand("/usr/bin/git ls-files -z --others --exclude-standard"))
 	if lsErr != nil {
 		_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 		return nil, 0, errors.Wrap(lsErr, "failed to list untracked files in sandbox")
@@ -1293,7 +1293,7 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 		for i, f := range untrackedFiles {
 			quotedFiles[i] = quoteShellArg(f)
 		}
-		addCmd := fmt.Sprintf("/usr/bin/git add -N -- %s", strings.Join(quotedFiles, " "))
+		addCmd := sandboxWorktreeRootCommand(fmt.Sprintf("/usr/bin/git add -N -- %s", strings.Join(quotedFiles, " ")))
 		addExitCode, _, addErr := s.SSHClient.ExecuteCommandWithOutput(addCmd)
 		if addErr != nil {
 			_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
@@ -1307,7 +1307,7 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 
 	// Get patch from sandbox (stdout only to avoid output capture issues after sync markers).
 	// Binary diffs need full indexes so local git apply can recreate new binary files.
-	exitCode, patch, err := s.SSHClient.ExecuteCommandWithOutput("/usr/bin/git diff --binary --full-index refs/rwx-sync")
+	exitCode, patch, err := s.SSHClient.ExecuteCommandWithOutput(sandboxWorktreeRootCommand("/usr/bin/git diff --binary --full-index refs/rwx-sync"))
 	patchBytes := len(patch)
 
 	// Reset the intent-to-add for untracked files
@@ -1316,7 +1316,7 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 		for i, f := range untrackedFiles {
 			quotedFiles[i] = quoteShellArg(f)
 		}
-		resetCmd := fmt.Sprintf("/usr/bin/git reset HEAD -- %s", strings.Join(quotedFiles, " "))
+		resetCmd := sandboxWorktreeRootCommand(fmt.Sprintf("/usr/bin/git reset HEAD -- %s", strings.Join(quotedFiles, " ")))
 		resetExitCode, _, resetErr := s.SSHClient.ExecuteCommandWithOutput(resetCmd)
 		if resetErr != nil {
 			fmt.Fprintf(s.Stderr, "Warning: failed to reset staged files in sandbox: %v\n", resetErr)
@@ -1398,7 +1398,7 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 func (s Service) revertSandbox() error {
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
 
-	exitCode, err := s.SSHClient.ExecuteCommand("/usr/bin/git checkout . >/dev/null 2>&1; /usr/bin/git clean -fd >/dev/null 2>&1; /usr/bin/git update-ref refs/rwx-sync HEAD 2>/dev/null")
+	exitCode, err := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand("/usr/bin/git checkout . >/dev/null 2>&1; /usr/bin/git clean -fd >/dev/null 2>&1; /usr/bin/git update-ref refs/rwx-sync HEAD 2>/dev/null"))
 
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 
@@ -1419,7 +1419,7 @@ func (s Service) revertSandboxToGitState(localHead string) error {
 		return err
 	}
 
-	exitCode, err := s.SSHClient.ExecuteCommand("/usr/bin/git clean -fd >/dev/null 2>&1; /usr/bin/git update-ref refs/rwx-sync HEAD 2>/dev/null")
+	exitCode, err := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand("/usr/bin/git clean -fd >/dev/null 2>&1; /usr/bin/git update-ref refs/rwx-sync HEAD 2>/dev/null"))
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 	if err != nil {
 		return errors.Wrap(err, "failed to clean sandbox after reset")
@@ -1532,7 +1532,7 @@ func (s Service) warnUnresolvedRejectFiles() {
 
 func (s Service) ensureSandboxHasCommit(localHead string, connInfo *api.SandboxConnectionInfo) error {
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
-	gitDirExitCode, gitDirErr := s.SSHClient.ExecuteCommand("test -d .git || test -f .git")
+	gitDirExitCode, gitDirErr := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand("test -d .git || test -f .git"))
 	if gitDirErr != nil {
 		_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 		return errors.Wrap(gitDirErr, "failed to check sandbox git directory")
@@ -1544,7 +1544,7 @@ func (s Service) ensureSandboxHasCommit(localHead string, connInfo *api.SandboxC
 
 	hasCommit := s.sandboxHasCommit(localHead)
 	if !hasCommit {
-		_, _ = s.SSHClient.ExecuteCommand("/usr/bin/git fetch --prune origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1")
+		_, _ = s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand("/usr/bin/git fetch --prune origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1"))
 		hasCommit = s.sandboxHasCommit(localHead)
 	}
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
@@ -1654,7 +1654,11 @@ func indentLines(lines []string) string {
 
 func sandboxLFSFsckCommand(localHead string) string {
 	script := fmt.Sprintf("if /usr/bin/git lfs version >/dev/null 2>&1; then /usr/bin/git lfs fsck --objects %s 2>&1; fi", quoteShellArg(localHead))
-	return "/bin/sh -lc " + quoteShellArg(script)
+	return sandboxWorktreeRootCommand(script)
+}
+
+func sandboxWorktreeRootCommand(script string) string {
+	return "/bin/sh -lc " + quoteShellArg("repo_root=$(/usr/bin/git rev-parse --show-toplevel) || exit 1; cd \"$repo_root\" || exit 1; "+script)
 }
 
 func sandboxGitPushOptions(localHead string, connInfo *api.SandboxConnectionInfo) (git.PushRefOptions, func(), error) {
@@ -1720,7 +1724,7 @@ func sandboxGitPushOptions(localHead string, connInfo *api.SandboxConnectionInfo
 }
 
 func (s Service) sandboxHasCommit(sha string) bool {
-	exitCode, err := s.SSHClient.ExecuteCommand(fmt.Sprintf("/usr/bin/git cat-file -e %s^{commit} >/dev/null 2>&1", quoteShellArg(sha)))
+	exitCode, err := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand(fmt.Sprintf("/usr/bin/git cat-file -e %s^{commit} >/dev/null 2>&1", quoteShellArg(sha))))
 	return err == nil && exitCode == 0
 }
 
@@ -1735,7 +1739,7 @@ func (s Service) checkoutSandboxHead(localHead string) error {
 		cmd = fmt.Sprintf("%s checkout -f -B %s %s >/dev/null 2>&1 && %s reset --hard %s >/dev/null 2>&1", git, quoteShellArg(branch), head, git, head)
 	}
 
-	exitCode, err := s.SSHClient.ExecuteCommand(cmd)
+	exitCode, err := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand(cmd))
 	if err != nil {
 		return errors.Wrap(err, "failed to reset sandbox to local git state")
 	}
@@ -1774,7 +1778,7 @@ func (s Service) removePreAppliedNewFilesFromSandbox(patches git.DirtyPatches) e
 	script := fmt.Sprintf("/usr/bin/git clean -f -- %s >/dev/null 2>&1", strings.Join(quoted, " "))
 
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
-	exitCode, err := s.SSHClient.ExecuteCommand("/bin/sh -lc " + quoteShellArg(script))
+	exitCode, err := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand(script))
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 	if err != nil {
 		return errors.Wrap(err, "failed to prepare new sandbox files for sync")
@@ -1787,7 +1791,7 @@ func (s Service) removePreAppliedNewFilesFromSandbox(patches git.DirtyPatches) e
 
 func (s Service) applyPatchToSandbox(command string, patch []byte) error {
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
-	exitCode, output, err := s.SSHClient.ExecuteCommandWithStdinAndCombinedOutput(command, bytes.NewReader(patch))
+	exitCode, output, err := s.SSHClient.ExecuteCommandWithStdinAndCombinedOutput(sandboxWorktreeRootCommand(command), bytes.NewReader(patch))
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 	if err != nil {
 		return errors.WrapSentinel(errors.Wrap(err, "failed to apply patch on sandbox"), errors.ErrPatch)
@@ -1833,7 +1837,7 @@ func (s Service) snapshotSandboxSyncRefForPaths(paths []string) error {
 	script += `/usr/bin/git -c user.name=rwx -c user.email=rwx -c core.hooksPath=/dev/null commit --allow-empty --no-verify -m rwx-sync >/dev/null 2>&1 && /usr/bin/git update-ref refs/rwx-sync HEAD && /usr/bin/git reset --mixed HEAD~1 >/dev/null 2>&1 && /usr/bin/git read-tree "$index_tree"`
 
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
-	exitCode, err := s.SSHClient.ExecuteCommand("/bin/sh -lc " + quoteShellArg(script))
+	exitCode, err := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand(script))
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 	if err != nil {
 		return errors.Wrap(err, "failed to create sync snapshot ref")

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1264,7 +1264,7 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 
 	// Include untracked files in the diff by adding them with intent-to-add
 	// Get untracked files, add with -N, get diff, then reset
-	lsExitCode, untrackedOutput, lsErr := s.SSHClient.ExecuteCommandWithOutput("/usr/bin/git ls-files --others --exclude-standard")
+	lsExitCode, untrackedOutput, lsErr := s.SSHClient.ExecuteCommandWithOutput("/usr/bin/git ls-files -z --others --exclude-standard")
 	if lsErr != nil {
 		_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 		return nil, 0, errors.Wrap(lsErr, "failed to list untracked files in sandbox")
@@ -1274,18 +1274,13 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 		return nil, 0, fmt.Errorf("failed to list untracked files in sandbox: git ls-files failed with exit code %d", lsExitCode)
 	}
 
-	untrackedFiles := []string{}
-	for _, f := range strings.Split(strings.TrimSpace(untrackedOutput), "\n") {
-		if f != "" {
-			untrackedFiles = append(untrackedFiles, f)
-		}
-	}
+	untrackedFiles := splitNULStrings(untrackedOutput)
 
 	// Add untracked files with intent-to-add
 	if len(untrackedFiles) > 0 {
 		quotedFiles := make([]string, len(untrackedFiles))
 		for i, f := range untrackedFiles {
-			quotedFiles[i] = fmt.Sprintf("'%s'", strings.ReplaceAll(f, "'", "'\\''"))
+			quotedFiles[i] = quoteShellArg(f)
 		}
 		addCmd := fmt.Sprintf("/usr/bin/git add -N -- %s", strings.Join(quotedFiles, " "))
 		addExitCode, _, addErr := s.SSHClient.ExecuteCommandWithOutput(addCmd)
@@ -1308,7 +1303,7 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 	if len(untrackedFiles) > 0 {
 		quotedFiles := make([]string, len(untrackedFiles))
 		for i, f := range untrackedFiles {
-			quotedFiles[i] = fmt.Sprintf("'%s'", strings.ReplaceAll(f, "'", "'\\''"))
+			quotedFiles[i] = quoteShellArg(f)
 		}
 		resetCmd := fmt.Sprintf("/usr/bin/git reset HEAD -- %s", strings.Join(quotedFiles, " "))
 		resetExitCode, _, resetErr := s.SSHClient.ExecuteCommandWithOutput(resetCmd)
@@ -1857,6 +1852,22 @@ func newFilePathsForDirtyPatches(patches git.DirtyPatches) []string {
 
 func quoteShellArg(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func splitNULStrings(output string) []string {
+	if output == "" {
+		return []string{}
+	}
+
+	parts := strings.Split(output, "\x00")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		values = append(values, part)
+	}
+	return values
 }
 
 // parsePatchFiles extracts file paths from a git patch

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -576,6 +576,7 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 		if cfgFile == "" {
 			cfgFile = FindDefaultSandboxConfigFile()
 		}
+		cfgFile = AbsConfigFile(cfgFile)
 
 		if !found {
 			// Check if a matching sandbox already exists remotely
@@ -597,7 +598,8 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 							branchMatch = gitClient.IsAncestor(storedSHA, "HEAD")
 						}
 					}
-					if branchMatch && state.ConfigFile == cfgFile {
+					stateConfigFile := AbsConfigFile(state.ConfigFile)
+					if branchMatch && stateConfigFile == cfgFile {
 						// Verify the remote sandbox is still alive before reusing.
 						// A ready sandbox reports Polling.Completed=true with Sandboxable=true;
 						// only skip when the run finished without becoming sandboxable.
@@ -919,13 +921,14 @@ func (s Service) ListSandboxes(cfg ListSandboxesConfig) (*ListSandboxesResult, e
 		if err != nil {
 			continue
 		}
+		stateConfigFile := AbsConfigFile(state.ConfigFile)
 		// Only create a local session if none exists for this key
-		if _, exists := storage.GetSession(state.Branch, state.ConfigFile); exists {
+		if _, exists := storage.GetSession(state.Branch, stateConfigFile); exists {
 			continue
 		}
-		storage.SetSession(state.Branch, state.ConfigFile, SandboxSession{
+		storage.SetSession(state.Branch, stateConfigFile, SandboxSession{
 			RunID:      run.ID,
-			ConfigFile: state.ConfigFile,
+			ConfigFile: stateConfigFile,
 			RunURL:     run.RunURL,
 		})
 		storageChanged = true

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -154,8 +154,14 @@ func (s Service) CheckExistingSandbox(configFile string) (*CheckExistingSandboxR
 	}
 	branch := GetCurrentGitBranch(cwd)
 
+	lockFile, lockErr := s.lockSandboxStorageWithInfo(false)
+	if lockErr != nil {
+		return nil, errors.Wrap(lockErr, "unable to lock sandbox storage")
+	}
+
 	storage, err := LoadSandboxStorage()
 	if err != nil {
+		UnlockSandboxStorage(lockFile)
 		return &CheckExistingSandboxResult{Exists: false}, nil
 	}
 
@@ -167,6 +173,8 @@ func (s Service) CheckExistingSandbox(configFile string) (*CheckExistingSandboxR
 			_ = storage.Save()
 		}
 	}
+	UnlockSandboxStorage(lockFile)
+
 	if !found {
 		return &CheckExistingSandboxResult{Exists: false}, nil
 	}

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -576,7 +576,6 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 		if cfgFile == "" {
 			cfgFile = FindDefaultSandboxConfigFile()
 		}
-		cfgFile = AbsConfigFile(cfgFile)
 
 		if !found {
 			// Check if a matching sandbox already exists remotely
@@ -598,8 +597,7 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 							branchMatch = gitClient.IsAncestor(storedSHA, "HEAD")
 						}
 					}
-					stateConfigFile := AbsConfigFile(state.ConfigFile)
-					if branchMatch && stateConfigFile == cfgFile {
+					if branchMatch && state.ConfigFile == cfgFile {
 						// Verify the remote sandbox is still alive before reusing.
 						// A ready sandbox reports Polling.Completed=true with Sandboxable=true;
 						// only skip when the run finished without becoming sandboxable.
@@ -921,14 +919,13 @@ func (s Service) ListSandboxes(cfg ListSandboxesConfig) (*ListSandboxesResult, e
 		if err != nil {
 			continue
 		}
-		stateConfigFile := AbsConfigFile(state.ConfigFile)
 		// Only create a local session if none exists for this key
-		if _, exists := storage.GetSession(state.Branch, stateConfigFile); exists {
+		if _, exists := storage.GetSession(state.Branch, state.ConfigFile); exists {
 			continue
 		}
-		storage.SetSession(state.Branch, stateConfigFile, SandboxSession{
+		storage.SetSession(state.Branch, state.ConfigFile, SandboxSession{
 			RunID:      run.ID,
-			ConfigFile: stateConfigFile,
+			ConfigFile: state.ConfigFile,
 			RunURL:     run.RunURL,
 		})
 		storageChanged = true

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -259,6 +259,33 @@ func TestService_ListSandboxes_BulkAPI(t *testing.T) {
 		require.Equal(t, "https://cloud.rwx.com/runs/run-remote", session.RunURL)
 	})
 
+	t.Run("normalizes relative remote config paths before saving", func(t *testing.T) {
+		setup := setupTest(t)
+		seedSandboxStorageMulti(t, setup.tmp, map[string]cli.SandboxSession{})
+
+		remoteCliState := cli.EncodeCliState("develop", ".rwx/sandbox.yml")
+		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
+			return &api.ListSandboxRunsResult{
+				Runs: []api.SandboxRunSummary{
+					{ID: "run-relative", RunURL: "https://cloud.rwx.com/runs/run-relative", CliState: remoteCliState},
+				},
+			}, nil
+		}
+
+		result, err := setup.service.ListSandboxes(cli.ListSandboxesConfig{Json: true})
+
+		require.NoError(t, err)
+		require.Len(t, result.Sandboxes, 1)
+		require.Equal(t, setup.absConfig(".rwx/sandbox.yml"), result.Sandboxes[0].ConfigFile)
+
+		storage, err := cli.LoadSandboxStorage()
+		require.NoError(t, err)
+		session, found := storage.GetSession("develop", setup.absConfig(".rwx/sandbox.yml"))
+		require.True(t, found)
+		require.Equal(t, "run-relative", session.RunID)
+		require.Equal(t, setup.absConfig(".rwx/sandbox.yml"), session.ConfigFile)
+	})
+
 	t.Run("skips remote runs without cli_state", func(t *testing.T) {
 		setup := setupTest(t)
 		seedSandboxStorageMulti(t, setup.tmp, map[string]cli.SandboxSession{})
@@ -3366,6 +3393,74 @@ func TestService_ExecSandbox_RecoverFromAPI(t *testing.T) {
 		require.True(t, found)
 		require.Equal(t, "run-recovered", session.RunID)
 		require.Equal(t, "recovered-token", session.ScopedToken)
+	})
+
+	t.Run("reuses remote sandbox with relative cli_state config file", func(t *testing.T) {
+		setup := setupTest(t)
+
+		originalHome := os.Getenv("HOME")
+		os.Setenv("HOME", setup.tmp)
+		t.Cleanup(func() { os.Setenv("HOME", originalHome) })
+
+		address := "192.168.1.1:22"
+		branch := "detached"
+		configFile := setup.absConfig(".rwx/sandbox.yml")
+		encodedState := cli.EncodeCliState(branch, ".rwx/sandbox.yml")
+
+		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
+			return &api.ListSandboxRunsResult{
+				Runs: []api.SandboxRunSummary{
+					{
+						ID:       "run-recovered-relative",
+						RunURL:   "https://cloud.rwx.com/runs/run-recovered-relative",
+						CliState: encodedState,
+					},
+				},
+			}, nil
+		}
+
+		setup.mockAPI.MockCreateSandboxToken = func(cfg api.CreateSandboxTokenConfig) (*api.CreateSandboxTokenResult, error) {
+			require.Equal(t, "run-recovered-relative", cfg.RunID)
+			return &api.CreateSandboxTokenResult{Token: "relative-token"}, nil
+		}
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			require.Equal(t, "run-recovered-relative", id)
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        address,
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
+			return nil
+		}
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
+			return 0, nil
+		}
+		setup.mockGit.MockGeneratePatch = func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error) {
+			return nil, nil, nil
+		}
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"echo", "hello"},
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "run-recovered-relative", result.RunID)
+		require.Equal(t, "https://cloud.rwx.com/runs/run-recovered-relative", result.RunURL)
+
+		storage, err := cli.LoadSandboxStorage()
+		require.NoError(t, err)
+		session, found := storage.GetSession(branch, configFile)
+		require.True(t, found)
+		require.Equal(t, "run-recovered-relative", session.RunID)
+		require.Equal(t, "relative-token", session.ScopedToken)
+		require.Equal(t, configFile, session.ConfigFile)
 	})
 
 	t.Run("falls through to auto-create when no remote match", func(t *testing.T) {

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1868,6 +1868,94 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.NotContains(t, order[snapshotIndex], "/usr/bin/git add -A &&")
 	})
 
+	t.Run("first exec after sandbox start removes pre-applied new files before sync", func(t *testing.T) {
+		setup := setupTest(t)
+
+		configFile := setup.absConfig(".rwx/sandbox.yml")
+		require.NoError(t, os.WriteFile(configFile, []byte("base:\n  image: ubuntu:24.04\ntasks:\n  - key: sandbox\n    run: rwx-sandbox\n"), 0o644))
+		localHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		newFilePath := "new-from-start.txt"
+		newFilePatch := []byte("diff --git a/" + newFilePath + " b/" + newFilePath + "\nnew file mode 100644\nindex 0000000..c42fa8d\n--- /dev/null\n+++ b/" + newFilePath + "\n@@ -0,0 +1 @@\n+local-change-content\n")
+
+		seedSandboxStorageMulti(t, setup.tmp, map[string]cli.SandboxSession{
+			cli.SessionKey("detached", configFile): {
+				RunID:       "run-started",
+				ConfigFile:  configFile,
+				ScopedToken: "start-token",
+			},
+		})
+
+		setup.mockGit.MockGetBranch = "feature/start-first-exec"
+		setup.mockGit.MockGetHead = localHead
+		setup.mockGit.MockGenerateDirtyPatches = func() (git.DirtyPatches, error) {
+			return git.DirtyPatches{
+				Staged:   newFilePatch,
+				Files:    []string{newFilePath},
+				NewFiles: []string{newFilePath},
+			}, nil
+		}
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			require.Equal(t, "run-started", runID)
+			require.Equal(t, "start-token", token)
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error { return nil }
+
+		var order []string
+		cleaned := false
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
+			switch {
+			case strings.Contains(cmd, "cat-file -e"):
+				return 0, nil
+			case strings.Contains(cmd, "git clean -f --"):
+				cleaned = true
+			}
+			order = append(order, cmd)
+			return 0, nil
+		}
+		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
+			return 0, "", nil
+		}
+		setup.mockSSH.MockExecuteCommandWithStdinAndCombinedOutput = func(command string, stdin io.Reader) (int, string, error) {
+			order = append(order, command)
+			data, _ := io.ReadAll(stdin)
+			require.Equal(t, string(newFilePatch), string(data))
+			if !cleaned {
+				return 1, "new-from-start.txt already exists", nil
+			}
+			return 0, "", nil
+		}
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"true"},
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "run-started", result.RunID)
+
+		cleanIndex := slices.IndexFunc(order, func(cmd string) bool {
+			return strings.Contains(cmd, "git clean -f --") && strings.Contains(cmd, newFilePath)
+		})
+		applyIndex := slices.Index(order, "/usr/bin/git apply --index --allow-empty -")
+		snapshotIndex := slices.IndexFunc(order, func(cmd string) bool {
+			return strings.Contains(cmd, "update-ref refs/rwx-sync HEAD")
+		})
+		require.NotEqual(t, -1, cleanIndex)
+		require.NotEqual(t, -1, applyIndex)
+		require.NotEqual(t, -1, snapshotIndex)
+		require.Less(t, cleanIndex, applyIndex)
+		require.Contains(t, order[snapshotIndex], "/usr/bin/git add -A &&")
+		require.NotContains(t, order[snapshotIndex], "/usr/bin/git update-index --add --remove --")
+	})
+
 	t.Run("new sandbox sync snapshots staged deletions with unstaged edits", func(t *testing.T) {
 		setup := setupTest(t)
 

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -95,6 +95,19 @@ func isSandboxPullDiffCommand(cmd string) bool {
 	return strings.Contains(cmd, "git diff") && strings.Contains(cmd, "refs/rwx-sync")
 }
 
+func requireSandboxWorktreeRootCommand(t *testing.T, cmd string, operation string) {
+	t.Helper()
+	require.Contains(t, cmd, "repo_root=$(/usr/bin/git rev-parse --show-toplevel)")
+	require.Contains(t, cmd, "cd \"$repo_root\"")
+	require.Contains(t, cmd, operation)
+}
+
+func sandboxCommandIndex(commands []string, operation string) int {
+	return slices.IndexFunc(commands, func(cmd string) bool {
+		return strings.Contains(cmd, operation)
+	})
+}
+
 func TestService_LockWaitOutput(t *testing.T) {
 	t.Run("no output when lock is uncontended", func(t *testing.T) {
 		setup := setupTest(t)
@@ -1087,7 +1100,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		}
 
 		setup.mockSSH.MockExecuteCommandWithStdinAndCombinedOutput = func(command string, stdin io.Reader) (int, string, error) {
-			require.Equal(t, "/usr/bin/git apply --allow-empty -", command)
+			requireSandboxWorktreeRootCommand(t, command, "/usr/bin/git apply --allow-empty -")
 			appliedPatch, _ = io.ReadAll(stdin)
 			patchApplied = true
 			return 0, "", nil
@@ -1405,7 +1418,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Contains(t, commandOrder, "echo hello")
 		// git apply uses stdin method
 		require.GreaterOrEqual(t, len(stdinCommandOrder), 1)
-		require.Equal(t, "/usr/bin/git apply --allow-empty -", stdinCommandOrder[0])
+		requireSandboxWorktreeRootCommand(t, stdinCommandOrder[0], "/usr/bin/git apply --allow-empty -")
 		// Sandbox should be reverted back to local git state after pull.
 		revertIdx := -1
 		for i, cmd := range commandOrder {
@@ -1553,10 +1566,14 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Contains(t, pushOpts.Env[0], "StrictHostKeyChecking=yes")
 		require.Contains(t, pushOpts.Env[0], "-p 22")
 		require.Equal(t, "GIT_LFS_SKIP_PUSH=1", pushOpts.Env[1])
-		require.Contains(t, strings.Join(commandOrder, "\n"), "git fetch --prune origin")
-		require.Contains(t, strings.Join(commandOrder, "\n"), "git checkout -f -B 'feature/sync' '"+localHead+"'")
-		require.Contains(t, strings.Join(commandOrder, "\n"), "git write-tree")
-		require.Contains(t, strings.Join(commandOrder, "\n"), "git clean -fd")
+		commandText := strings.Join(commandOrder, "\n")
+		require.Contains(t, commandText, "repo_root=$(/usr/bin/git rev-parse --show-toplevel)")
+		require.Contains(t, commandText, "git fetch --prune origin")
+		require.Contains(t, commandText, "git checkout -f -B")
+		require.Contains(t, commandText, "feature/sync")
+		require.Contains(t, commandText, localHead)
+		require.Contains(t, commandText, "git write-tree")
+		require.Contains(t, commandText, "git clean -fd")
 		for i, cmd := range commandOrder {
 			if strings.Contains(cmd, "cat-file -e") {
 				requireCommandWrappedBySyncMarkers(t, commandOrder, i)
@@ -1604,9 +1621,9 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Equal(t, "__rwx_sandbox_sync_end__", commandOrder[finalProbeIndex+1])
 		require.NotContains(t, commandOrder[pushIndex+1:finalProbeIndex], "__rwx_sandbox_sync_start__")
 		require.NotContains(t, commandOrder[pushIndex+1:finalProbeIndex], "__rwx_sandbox_sync_end__")
-		require.Equal(t, "/usr/bin/git apply --index --allow-empty -", stdinCommands[0])
+		requireSandboxWorktreeRootCommand(t, stdinCommands[0], "/usr/bin/git apply --index --allow-empty -")
 		require.Equal(t, "staged-patch", stdinPayloads[0])
-		require.Equal(t, "/usr/bin/git apply --allow-empty -", stdinCommands[1])
+		requireSandboxWorktreeRootCommand(t, stdinCommands[1], "/usr/bin/git apply --allow-empty -")
 		require.Equal(t, "unstaged-patch", stdinPayloads[1])
 	})
 
@@ -1883,7 +1900,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		cleanIndex := slices.IndexFunc(order, func(cmd string) bool {
 			return strings.Contains(cmd, "git clean -f --") && strings.Contains(cmd, "dir with space/quote") && strings.Contains(cmd, "file.txt")
 		})
-		applyIndex := slices.Index(order, "/usr/bin/git apply --index --allow-empty -")
+		applyIndex := sandboxCommandIndex(order, "/usr/bin/git apply --index --allow-empty -")
 		snapshotIndex := slices.IndexFunc(order, func(cmd string) bool {
 			return strings.Contains(cmd, "update-ref refs/rwx-sync HEAD")
 		})
@@ -1973,7 +1990,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		cleanIndex := slices.IndexFunc(order, func(cmd string) bool {
 			return strings.Contains(cmd, "git clean -f --") && strings.Contains(cmd, newFilePath)
 		})
-		applyIndex := slices.Index(order, "/usr/bin/git apply --index --allow-empty -")
+		applyIndex := sandboxCommandIndex(order, "/usr/bin/git apply --index --allow-empty -")
 		snapshotIndex := slices.IndexFunc(order, func(cmd string) bool {
 			return strings.Contains(cmd, "update-ref refs/rwx-sync HEAD")
 		})
@@ -2187,7 +2204,10 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, runID, result.RunID)
-		require.Contains(t, strings.Join(commands, "\n"), "git checkout -f --detach '"+localHead+"'")
+		commandText := strings.Join(commands, "\n")
+		require.Contains(t, commandText, "repo_root=$(/usr/bin/git rev-parse --show-toplevel)")
+		require.Contains(t, commandText, "git checkout -f --detach")
+		require.Contains(t, commandText, localHead)
 	})
 
 	t.Run("fails when pushing missing commits fails", func(t *testing.T) {
@@ -2569,15 +2589,19 @@ func TestService_ExecSandbox_Pull(t *testing.T) {
 		for _, cmd := range stdoutOnlyCommands {
 			if strings.Contains(cmd, "git ls-files") && strings.Contains(cmd, "--others") {
 				foundLsFiles = true
+				requireSandboxWorktreeRootCommand(t, cmd, "/usr/bin/git ls-files -z --others --exclude-standard")
 			}
 			if strings.Contains(cmd, "git add -N") {
 				foundAddN = true
+				requireSandboxWorktreeRootCommand(t, cmd, "/usr/bin/git add -N --")
 			}
 			if isSandboxPullDiffCommand(cmd) {
 				foundDiffRef = true
+				requireSandboxWorktreeRootCommand(t, cmd, "/usr/bin/git diff --binary --full-index refs/rwx-sync")
 			}
 			if strings.Contains(cmd, "git reset HEAD") {
 				foundReset = true
+				requireSandboxWorktreeRootCommand(t, cmd, "/usr/bin/git reset HEAD --")
 			}
 		}
 		require.True(t, foundLsFiles, "git ls-files should use stdout-only output")

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1224,6 +1224,8 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 			}
 		}
 		require.NotEqual(t, -1, snapshotIdx, "sync snapshot command should be present")
+		require.Contains(t, commandOrder[snapshotIdx], "-c core.hooksPath=/dev/null")
+		require.Contains(t, commandOrder[snapshotIdx], "commit --allow-empty --no-verify")
 		require.Greater(t, snapshotIdx, 0, "sync snapshot should not be first command")
 		require.Equal(t, "__rwx_sandbox_sync_start__", commandOrder[snapshotIdx-1])
 		require.Less(t, snapshotIdx, len(commandOrder)-1, "sync snapshot should not be last command")

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1485,7 +1485,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
 			commandOrder = append(commandOrder, cmd)
 			switch {
-			case strings.Contains(cmd, "git ls-files --others"):
+			case strings.Contains(cmd, "git ls-files") && strings.Contains(cmd, "--others"):
 				return 0, "", nil
 			case isSandboxPullDiffCommand(cmd):
 				return 0, "", nil
@@ -2501,8 +2501,8 @@ func TestService_ExecSandbox_Pull(t *testing.T) {
 
 		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
 			stdoutOnlyCommands = append(stdoutOnlyCommands, cmd)
-			if strings.Contains(cmd, "git ls-files --others") {
-				return 0, "untracked.txt\n", nil
+			if strings.Contains(cmd, "git ls-files") && strings.Contains(cmd, "--others") {
+				return 0, "untracked.txt\x00", nil
 			}
 			if isSandboxPullDiffCommand(cmd) {
 				pullDiffCommand = cmd
@@ -2538,7 +2538,7 @@ func TestService_ExecSandbox_Pull(t *testing.T) {
 		foundDiffRef := false
 		foundReset := false
 		for _, cmd := range stdoutOnlyCommands {
-			if strings.Contains(cmd, "git ls-files --others") {
+			if strings.Contains(cmd, "git ls-files") && strings.Contains(cmd, "--others") {
 				foundLsFiles = true
 			}
 			if strings.Contains(cmd, "git add -N") {
@@ -2557,6 +2557,69 @@ func TestService_ExecSandbox_Pull(t *testing.T) {
 		require.Contains(t, pullDiffCommand, "--binary")
 		require.Contains(t, pullDiffCommand, "--full-index")
 		require.True(t, foundReset, "git reset HEAD should use stdout-only output")
+	})
+
+	t.Run("pull stages untracked non-ASCII paths from NUL-delimited output", func(t *testing.T) {
+		setup := setupTest(t)
+
+		runID := "run-pull-nul-paths"
+		address := "192.168.1.1:22"
+		untrackedPath := "café.txt"
+		var addCommand string
+		var resetCommand string
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        address,
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
+			return nil
+		}
+
+		sandboxPatch := "diff --git a/caf\\303\\251.txt b/caf\\303\\251.txt\nnew file mode 100644\nindex 0000000..abc1234\n--- /dev/null\n+++ b/caf\\303\\251.txt\n@@ -0,0 +1 @@\n+new file\n"
+
+		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
+			switch {
+			case strings.Contains(cmd, "git ls-files"):
+				require.Contains(t, cmd, "-z")
+				return 0, untrackedPath + "\x00", nil
+			case strings.Contains(cmd, "git add -N"):
+				addCommand = cmd
+				return 0, "", nil
+			case isSandboxPullDiffCommand(cmd):
+				return 0, sandboxPatch, nil
+			case strings.Contains(cmd, "git reset HEAD"):
+				resetCommand = cmd
+				return 0, "", nil
+			default:
+				return 0, "", nil
+			}
+		}
+
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
+			return 0, nil
+		}
+
+		setup.mockGit.MockGeneratePatch = func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error) {
+			return nil, nil, nil
+		}
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: setup.absConfig(".rwx/sandbox.yml"),
+			Command:    []string{"echo", "hello"},
+			RunID:      runID,
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 0, result.ExitCode)
+		require.Contains(t, addCommand, "'"+untrackedPath+"'")
+		require.Contains(t, resetCommand, "'"+untrackedPath+"'")
 	})
 
 	t.Run("pull only includes sandbox exec-changed files", func(t *testing.T) {

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -272,33 +272,6 @@ func TestService_ListSandboxes_BulkAPI(t *testing.T) {
 		require.Equal(t, "https://cloud.rwx.com/runs/run-remote", session.RunURL)
 	})
 
-	t.Run("normalizes relative remote config paths before saving", func(t *testing.T) {
-		setup := setupTest(t)
-		seedSandboxStorageMulti(t, setup.tmp, map[string]cli.SandboxSession{})
-
-		remoteCliState := cli.EncodeCliState("develop", ".rwx/sandbox.yml")
-		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{
-				Runs: []api.SandboxRunSummary{
-					{ID: "run-relative", RunURL: "https://cloud.rwx.com/runs/run-relative", CliState: remoteCliState},
-				},
-			}, nil
-		}
-
-		result, err := setup.service.ListSandboxes(cli.ListSandboxesConfig{Json: true})
-
-		require.NoError(t, err)
-		require.Len(t, result.Sandboxes, 1)
-		require.Equal(t, setup.absConfig(".rwx/sandbox.yml"), result.Sandboxes[0].ConfigFile)
-
-		storage, err := cli.LoadSandboxStorage()
-		require.NoError(t, err)
-		session, found := storage.GetSession("develop", setup.absConfig(".rwx/sandbox.yml"))
-		require.True(t, found)
-		require.Equal(t, "run-relative", session.RunID)
-		require.Equal(t, setup.absConfig(".rwx/sandbox.yml"), session.ConfigFile)
-	})
-
 	t.Run("skips remote runs without cli_state", func(t *testing.T) {
 		setup := setupTest(t)
 		seedSandboxStorageMulti(t, setup.tmp, map[string]cli.SandboxSession{})
@@ -3419,74 +3392,6 @@ func TestService_ExecSandbox_RecoverFromAPI(t *testing.T) {
 		require.True(t, found)
 		require.Equal(t, "run-recovered", session.RunID)
 		require.Equal(t, "recovered-token", session.ScopedToken)
-	})
-
-	t.Run("reuses remote sandbox with relative cli_state config file", func(t *testing.T) {
-		setup := setupTest(t)
-
-		originalHome := os.Getenv("HOME")
-		os.Setenv("HOME", setup.tmp)
-		t.Cleanup(func() { os.Setenv("HOME", originalHome) })
-
-		address := "192.168.1.1:22"
-		branch := "detached"
-		configFile := setup.absConfig(".rwx/sandbox.yml")
-		encodedState := cli.EncodeCliState(branch, ".rwx/sandbox.yml")
-
-		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{
-				Runs: []api.SandboxRunSummary{
-					{
-						ID:       "run-recovered-relative",
-						RunURL:   "https://cloud.rwx.com/runs/run-recovered-relative",
-						CliState: encodedState,
-					},
-				},
-			}, nil
-		}
-
-		setup.mockAPI.MockCreateSandboxToken = func(cfg api.CreateSandboxTokenConfig) (*api.CreateSandboxTokenResult, error) {
-			require.Equal(t, "run-recovered-relative", cfg.RunID)
-			return &api.CreateSandboxTokenResult{Token: "relative-token"}, nil
-		}
-
-		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
-			require.Equal(t, "run-recovered-relative", id)
-			return api.SandboxConnectionInfo{
-				Sandboxable:    true,
-				Address:        address,
-				PrivateUserKey: sandboxPrivateTestKey,
-				PublicHostKey:  sandboxPublicTestKey,
-			}, nil
-		}
-
-		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
-			return nil
-		}
-		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
-			return 0, nil
-		}
-		setup.mockGit.MockGeneratePatch = func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error) {
-			return nil, nil, nil
-		}
-
-		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
-			ConfigFile: configFile,
-			Command:    []string{"echo", "hello"},
-			Json:       true,
-		})
-
-		require.NoError(t, err)
-		require.Equal(t, "run-recovered-relative", result.RunID)
-		require.Equal(t, "https://cloud.rwx.com/runs/run-recovered-relative", result.RunURL)
-
-		storage, err := cli.LoadSandboxStorage()
-		require.NoError(t, err)
-		session, found := storage.GetSession(branch, configFile)
-		require.True(t, found)
-		require.Equal(t, "run-recovered-relative", session.RunID)
-		require.Equal(t, "relative-token", session.ScopedToken)
-		require.Equal(t, configFile, session.ConfigFile)
 	})
 
 	t.Run("falls through to auto-create when no remote match", func(t *testing.T) {

--- a/internal/config/file_backend.go
+++ b/internal/config/file_backend.go
@@ -17,6 +17,11 @@ type FileBackend struct {
 	FallbackDirectories []string
 }
 
+const (
+	fileBackendDirMode  fs.FileMode = 0o700
+	fileBackendFileMode fs.FileMode = 0o600
+)
+
 func NewFileBackend(dirs []string) (*FileBackend, error) {
 	if len(dirs) < 1 {
 		return nil, fmt.Errorf("at least one directory must be provided")
@@ -87,17 +92,23 @@ func (f FileBackend) getFrom(dir, filename string) (string, error) {
 }
 
 func (f FileBackend) Set(filename, value string) error {
-	err := os.MkdirAll(f.PrimaryDirectory, os.ModePerm)
+	err := os.MkdirAll(f.PrimaryDirectory, fileBackendDirMode)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create %q", f.PrimaryDirectory)
 	}
+	if err := os.Chmod(f.PrimaryDirectory, fileBackendDirMode); err != nil {
+		return errors.Wrapf(err, "unable to chmod %q", f.PrimaryDirectory)
+	}
 
 	path := filepath.Join(f.PrimaryDirectory, filename)
-	fd, err := os.Create(path)
+	fd, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileBackendFileMode)
 	if err != nil {
 		return errors.Wrapf(err, "unable to create %q", path)
 	}
 	defer fd.Close()
+	if err := fd.Chmod(fileBackendFileMode); err != nil {
+		return errors.Wrapf(err, "unable to chmod %q", path)
+	}
 
 	_, err = io.WriteString(fd, value)
 	if err != nil {

--- a/internal/config/file_backend_test.go
+++ b/internal/config/file_backend_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"runtime"
 	"testing"
 
 	"github.com/rwx-cloud/rwx/internal/config"
@@ -152,20 +153,21 @@ func TestFileBackend_Set(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { os.RemoveAll(primaryTmpDir) })
 
-		require.NoError(t, os.Chmod(primaryTmpDir, 0o400))
+		require.NoError(t, os.Mkdir(path.Join(primaryTmpDir, "testfile"), 0o700))
 
 		backend, err := config.NewFileBackend([]string{primaryTmpDir})
 		require.NoError(t, err)
 
 		err = backend.Set("testfile", "the-value")
-		require.Contains(t, err.Error(), "permission denied")
-		require.ErrorIs(t, err, fs.ErrPermission)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unable to create")
 	})
 
 	t.Run("when the file is created", func(t *testing.T) {
 		primaryTmpDir, err := os.MkdirTemp(os.TempDir(), "file-backend-primary")
 		require.NoError(t, err)
 		t.Cleanup(func() { os.RemoveAll(primaryTmpDir) })
+		require.NoError(t, os.Chmod(primaryTmpDir, 0o755))
 
 		backend, err := config.NewFileBackend([]string{primaryTmpDir})
 		require.NoError(t, err)
@@ -179,5 +181,36 @@ func TestFileBackend_Set(t *testing.T) {
 		bytes, err := io.ReadAll(file)
 		require.NoError(t, err)
 		require.Equal(t, "the-value", string(bytes))
+
+		requireMode(t, primaryTmpDir, 0o700)
+		requireMode(t, path.Join(primaryTmpDir, "testfile"), 0o600)
 	})
+
+	t.Run("when the file already exists with permissive mode", func(t *testing.T) {
+		primaryTmpDir, err := os.MkdirTemp(os.TempDir(), "file-backend-primary")
+		require.NoError(t, err)
+		t.Cleanup(func() { os.RemoveAll(primaryTmpDir) })
+
+		filePath := path.Join(primaryTmpDir, "testfile")
+		require.NoError(t, os.WriteFile(filePath, []byte("old-value"), 0o644))
+
+		backend, err := config.NewFileBackend([]string{primaryTmpDir})
+		require.NoError(t, err)
+
+		err = backend.Set("testfile", "the-value")
+		require.NoError(t, err)
+
+		requireMode(t, filePath, 0o600)
+	})
+}
+
+func requireMode(t *testing.T, file string, mode fs.FileMode) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
+
+	info, err := os.Stat(file)
+	require.NoError(t, err)
+	require.Equal(t, mode, info.Mode().Perm())
 }

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -315,7 +315,7 @@ func (c *Client) generatePatchData(pathspec []string) (patchResult, *PatchError)
 		return patchResult{}, nil
 	}
 
-	diffArgs := []string{"diff", sha, "--name-only"}
+	diffArgs := []string{"diff", "-z", "--name-only", sha}
 	if len(pathspec) > 0 {
 		diffArgs = append(diffArgs, "--")
 		diffArgs = append(diffArgs, pathspec...)
@@ -328,7 +328,7 @@ func (c *Client) generatePatchData(pathspec []string) (patchResult, *PatchError)
 		return patchResult{}, newPatchError("diff_name_only", "git diff --name-only", err, "")
 	}
 
-	lfsChanged, lfsErr := c.lfsFilesForPaths(strings.Split(strings.TrimSpace(string(files)), "\n"))
+	lfsChanged, lfsErr := c.lfsFilesForPaths(splitNULPaths(files))
 	if lfsErr != nil {
 		return patchResult{}, lfsErr
 	}
@@ -341,7 +341,7 @@ func (c *Client) generatePatchData(pathspec []string) (patchResult, *PatchError)
 		}, nil
 	}
 
-	lsFilesArgs := []string{"ls-files", "--others", "--exclude-standard"}
+	lsFilesArgs := []string{"ls-files", "-z", "--others", "--exclude-standard"}
 	if len(pathspec) > 0 {
 		lsFilesArgs = append(lsFilesArgs, "--")
 		lsFilesArgs = append(lsFilesArgs, pathspec...)
@@ -354,7 +354,7 @@ func (c *Client) generatePatchData(pathspec []string) (patchResult, *PatchError)
 		return patchResult{}, newPatchError("ls_files", "git ls-files --others --exclude-standard", err, "")
 	}
 
-	untrackedFiles := strings.Fields(string(untracked))
+	untrackedFiles := splitNULPaths(untracked)
 
 	patchArgs := []string{"diff", sha, "-p", "--binary"}
 	if len(pathspec) > 0 {
@@ -423,21 +423,14 @@ func (c *Client) GeneratePatchFile(destDir string, pathspec []string) (PatchFile
 // so they appear in git diff. Returns a cleanup function to undo the add.
 func (c *Client) AddUntrackedFilesForPatch() (cleanup func(), err error) {
 	// Get untracked files
-	cmd := exec.Command(c.Binary, "ls-files", "--others", "--exclude-standard")
+	cmd := exec.Command(c.Binary, "ls-files", "-z", "--others", "--exclude-standard")
 	cmd.Dir = c.Dir
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}
 
-	// Split on newlines (not Fields) to handle filenames with spaces
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-	var files []string
-	for _, line := range lines {
-		if line != "" {
-			files = append(files, line)
-		}
-	}
+	files := splitNULPaths(output)
 
 	if len(files) == 0 {
 		return func() {}, nil // No untracked files, no-op cleanup
@@ -516,9 +509,7 @@ func (c *Client) GenerateDirtyPatches() (DirtyPatches, error) {
 		}
 
 		if strings.Contains(string(attrs), "filter: lfs") {
-			parts := strings.SplitN(string(attrs), ":", 2)
-			lfsFile := strings.TrimSpace(parts[0])
-			lfsChangedFiles = append(lfsChangedFiles, lfsFile)
+			lfsChangedFiles = append(lfsChangedFiles, file)
 		}
 	}
 
@@ -550,8 +541,8 @@ func (c *Client) changedFilesForDirtyPatch() ([]string, error) {
 	var files []string
 
 	for _, args := range [][]string{
-		{"diff", "--cached", "--name-only"},
-		{"diff", "--name-only"},
+		{"diff", "--cached", "-z", "--name-only"},
+		{"diff", "-z", "--name-only"},
 	} {
 		cmd := exec.Command(c.Binary, args...)
 		cmd.Dir = c.Dir
@@ -560,7 +551,7 @@ func (c *Client) changedFilesForDirtyPatch() ([]string, error) {
 			return nil, err
 		}
 
-		for _, file := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		for _, file := range splitNULPaths(out) {
 			if file == "" || seen[file] {
 				continue
 			}
@@ -577,8 +568,8 @@ func (c *Client) newFilesForDirtyPatch() ([]string, error) {
 	var files []string
 
 	for _, args := range [][]string{
-		{"diff", "--cached", "--name-only", "--diff-filter=A"},
-		{"diff", "--name-only", "--diff-filter=A"},
+		{"diff", "--cached", "-z", "--name-only", "--diff-filter=A"},
+		{"diff", "-z", "--name-only", "--diff-filter=A"},
 	} {
 		cmd := exec.Command(c.Binary, args...)
 		cmd.Dir = c.Dir
@@ -587,7 +578,7 @@ func (c *Client) newFilesForDirtyPatch() ([]string, error) {
 			return nil, err
 		}
 
-		for _, file := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		for _, file := range splitNULPaths(out) {
 			if file == "" || seen[file] {
 				continue
 			}
@@ -597,6 +588,22 @@ func (c *Client) newFilesForDirtyPatch() ([]string, error) {
 	}
 
 	return files, nil
+}
+
+func splitNULPaths(output []byte) []string {
+	if len(output) == 0 {
+		return []string{}
+	}
+
+	parts := bytes.Split(output, []byte{0})
+	paths := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		paths = append(paths, string(part))
+	}
+	return paths
 }
 
 func (c *Client) diffBytes(args ...string) ([]byte, error) {
@@ -637,9 +644,7 @@ func (c *Client) lfsFilesForPaths(files []string) (LFSChangedFilesMetadata, *Pat
 		}
 
 		if strings.Contains(string(attrs), "filter: lfs") {
-			parts := strings.SplitN(string(attrs), ":", 2)
-			lfsFile := strings.TrimSpace(parts[0])
-			lfsChangedFiles = append(lfsChangedFiles, lfsFile)
+			lfsChangedFiles = append(lfsChangedFiles, file)
 		}
 	}
 

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -422,9 +422,11 @@ func (c *Client) GeneratePatchFile(destDir string, pathspec []string) (PatchFile
 // AddUntrackedFilesForPatch temporarily adds untracked files with intent-to-add
 // so they appear in git diff. Returns a cleanup function to undo the add.
 func (c *Client) AddUntrackedFilesForPatch() (cleanup func(), err error) {
+	dir := c.applyDir()
+
 	// Get untracked files
 	cmd := exec.Command(c.Binary, "ls-files", "-z", "--others", "--exclude-standard")
-	cmd.Dir = c.Dir
+	cmd.Dir = dir
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -439,7 +441,7 @@ func (c *Client) AddUntrackedFilesForPatch() (cleanup func(), err error) {
 	// Add with intent-to-add
 	args := append([]string{"add", "-N", "--"}, files...)
 	cmd = exec.Command(c.Binary, args...)
-	cmd.Dir = c.Dir
+	cmd.Dir = dir
 	if err := cmd.Run(); err != nil {
 		return nil, err
 	}
@@ -448,7 +450,7 @@ func (c *Client) AddUntrackedFilesForPatch() (cleanup func(), err error) {
 	cleanup = func() {
 		args := append([]string{"reset", "HEAD", "--"}, files...)
 		cmd := exec.Command(c.Binary, args...)
-		cmd.Dir = c.Dir
+		cmd.Dir = dir
 		_ = cmd.Run() // Best effort cleanup
 	}
 
@@ -499,9 +501,10 @@ func (c *Client) GenerateDirtyPatches() (DirtyPatches, error) {
 	}
 
 	lfsChangedFiles := []string{}
+	dir := c.applyDir()
 	for _, file := range files {
 		cmd := exec.Command(c.Binary, "check-attr", "filter", "--", file)
-		cmd.Dir = c.Dir
+		cmd.Dir = dir
 
 		attrs, err := cmd.CombinedOutput()
 		if err != nil {
@@ -627,6 +630,7 @@ func (c *Client) HasCommit(sha string) bool {
 
 func (c *Client) lfsFilesForPaths(files []string) (LFSChangedFilesMetadata, *PatchError) {
 	lfsChangedFiles := []string{}
+	dir := c.applyDir()
 
 	for _, file := range files {
 		if file == "" {
@@ -634,7 +638,7 @@ func (c *Client) lfsFilesForPaths(files []string) (LFSChangedFilesMetadata, *Pat
 		}
 
 		cmd := exec.Command(c.Binary, "check-attr", "filter", "--", file)
-		cmd.Dir = c.Dir
+		cmd.Dir = dir
 
 		// CombinedOutput mixes stderr into attrs, so pass it as the fallback
 		// stderr for the PatchError (the *exec.ExitError won't carry .Stderr).

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -681,11 +681,18 @@ func (c *Client) IsAncestor(candidateSHA, headRef string) bool {
 	return cmd.Run() == nil
 }
 
+func (c *Client) applyDir() string {
+	if topLevel := c.GetTopLevel(); topLevel != "" {
+		return topLevel
+	}
+	return c.Dir
+}
+
 // ApplyPatch returns an exec.Cmd that applies a patch to the working directory.
 // The patch bytes should be provided to the command's stdin before running.
 func (c *Client) ApplyPatch(patch []byte) *exec.Cmd {
 	cmd := exec.Command(c.Binary, "apply", "--allow-empty", "-")
-	cmd.Dir = c.Dir
+	cmd.Dir = c.applyDir()
 	cmd.Stdin = bytes.NewReader(patch)
 	return cmd
 }
@@ -694,7 +701,7 @@ func (c *Client) ApplyPatch(patch []byte) *exec.Cmd {
 // which applies hunks that succeed and writes .rej files for hunks that fail.
 func (c *Client) ApplyPatchReject(patch []byte) *exec.Cmd {
 	cmd := exec.Command(c.Binary, "apply", "--reject", "--allow-empty", "-")
-	cmd.Dir = c.Dir
+	cmd.Dir = c.applyDir()
 	cmd.Stdin = bytes.NewReader(patch)
 	return cmd
 }

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -638,6 +638,30 @@ func TestGeneratePatchFile(t *testing.T) {
 			require.Equal(t, 0, patchFile.UntrackedFiles.Count)
 		})
 
+		t.Run("root pathspec includes changes outside current directory", func(t *testing.T) {
+			tempDir, sha := repoFixture(t, "testdata/GeneratePatchFile-diff-exclude")
+			repo := filepath.Join(tempDir, "repo")
+			subdir := filepath.Join(repo, "subdir")
+			require.NoError(t, os.Mkdir(subdir, 0o755))
+
+			client := &git.Client{Binary: "git", Dir: subdir}
+			patchFile, err := client.GeneratePatchFile(repo, []string{":/", ":(top,exclude).rwx"})
+			require.NoError(t, err)
+
+			require.Equal(t, true, patchFile.Written)
+			require.Equal(t, filepath.Join(repo, sha), patchFile.Path)
+
+			patch, err := os.ReadFile(patchFile.Path)
+			require.NoError(t, err)
+			require.Contains(t, string(patch), "included.txt")
+			require.Contains(t, string(patch), "untracked.txt")
+			require.NotContains(t, string(patch), "excluded.txt")
+			require.NotContains(t, string(patch), "untracked-excluded.txt")
+
+			require.Equal(t, []string{}, patchFile.UntrackedFiles.Files)
+			require.Equal(t, 0, patchFile.UntrackedFiles.Count)
+		})
+
 		t.Run("returns a PatchError identifying the failing git command", func(t *testing.T) {
 			tempDir, _ := repoFixture(t, "testdata/GeneratePatchFile-diff")
 			client := &git.Client{Binary: "git", Dir: filepath.Join(tempDir, "repo")}

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -383,6 +383,7 @@ func TestGenerateDirtyPatches(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(repo, "untracked.txt"), []byte("untracked\n"), 0o644))
 	require.NoError(t, os.Mkdir(filepath.Join(repo, "dir with space"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(repo, "dir with space", "quote'file.txt"), []byte("quoted\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "café.txt"), []byte("non-ascii\n"), 0o644))
 
 	client := &git.Client{Binary: "git", Dir: repo}
 	patches, err := client.GenerateDirtyPatches()
@@ -392,11 +393,36 @@ func TestGenerateDirtyPatches(t *testing.T) {
 	require.NotContains(t, string(patches.Staged), "untracked.txt")
 	require.Contains(t, string(patches.Unstaged), "tracked.txt")
 	require.Contains(t, string(patches.Unstaged), "untracked.txt")
-	require.ElementsMatch(t, []string{"staged.txt", "tracked.txt", "untracked.txt", "dir with space/quote'file.txt"}, patches.Files)
-	require.ElementsMatch(t, []string{"staged.txt", "untracked.txt", "dir with space/quote'file.txt"}, patches.NewFiles)
+	require.Contains(t, string(patches.Unstaged), "non-ascii")
+	require.ElementsMatch(t, []string{"staged.txt", "tracked.txt", "untracked.txt", "dir with space/quote'file.txt", "café.txt"}, patches.Files)
+	require.ElementsMatch(t, []string{"staged.txt", "untracked.txt", "dir with space/quote'file.txt", "café.txt"}, patches.NewFiles)
 
 	cachedNames := mustGit(t, repo, "diff", "--cached", "--name-only")
 	require.Equal(t, "staged.txt", cachedNames)
+}
+
+func TestGenerateDirtyPatches_LFSNonASCIIPath(t *testing.T) {
+	repo := t.TempDir()
+	mustGit(t, repo, "init")
+	mustGit(t, repo, "config", "user.email", "test@example.com")
+	mustGit(t, repo, "config", "user.name", "Test")
+
+	require.NoError(t, os.WriteFile(filepath.Join(repo, ".gitattributes"), []byte("*.bin filter=lfs\n"), 0o644))
+	lfsPath := "café.bin"
+	require.NoError(t, os.WriteFile(filepath.Join(repo, lfsPath), []byte("base\n"), 0o644))
+	mustGit(t, repo, "add", ".gitattributes", lfsPath)
+	mustGit(t, repo, "commit", "-m", "base")
+
+	require.NoError(t, os.WriteFile(filepath.Join(repo, lfsPath), []byte("changed\n"), 0o644))
+
+	client := &git.Client{Binary: "git", Dir: repo}
+	patches, err := client.GenerateDirtyPatches()
+	require.NoError(t, err)
+
+	require.NotNil(t, patches.LFSChangedFiles)
+	require.Equal(t, 1, patches.LFSChangedFiles.Count)
+	require.Equal(t, []string{lfsPath}, patches.LFSChangedFiles.Files)
+	require.Equal(t, []string{lfsPath}, patches.Files)
 }
 
 func TestPushRef(t *testing.T) {
@@ -557,6 +583,38 @@ func TestGeneratePatchFile(t *testing.T) {
 			require.Equal(t, 0, patchFile.UntrackedFiles.Count)
 			require.Equal(t, "", mustGit(t, client.Dir, "diff", "--cached", "--name-only"))
 			require.Contains(t, strings.Split(mustGit(t, client.Dir, "ls-files", "--others", "--exclude-standard"), "\n"), "untracked.txt")
+		})
+
+		t.Run("including non-ASCII untracked files", func(t *testing.T) {
+			tempDir := t.TempDir()
+			origin := filepath.Join(tempDir, "origin")
+			require.NoError(t, os.Mkdir(origin, 0o755))
+			mustGit(t, origin, "init")
+			mustGit(t, origin, "config", "user.email", "test@example.com")
+			mustGit(t, origin, "config", "user.name", "Test")
+			mustGit(t, origin, "commit", "--allow-empty", "-m", "base")
+
+			repo := filepath.Join(tempDir, "repo")
+			cmd := exec.Command("git", "clone", origin, repo)
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err, string(out))
+			sha := mustGit(t, repo, "rev-parse", "HEAD")
+
+			untrackedPath := "café.txt"
+			require.NoError(t, os.WriteFile(filepath.Join(repo, untrackedPath), []byte("non-ascii\n"), 0o644))
+
+			client := &git.Client{Binary: "git", Dir: repo}
+			patchFile, err := client.GeneratePatchFile(repo, nil)
+			require.NoError(t, err)
+			require.True(t, patchFile.Written)
+			require.Equal(t, filepath.Join(repo, sha), patchFile.Path)
+
+			patch, err := os.ReadFile(patchFile.Path)
+			require.NoError(t, err)
+			require.Contains(t, string(patch), "non-ascii")
+			require.Equal(t, "", mustGit(t, repo, "diff", "--cached", "--name-only"))
+			_, err = os.Stat(filepath.Join(repo, untrackedPath))
+			require.NoError(t, err)
 		})
 
 		t.Run("excluding paths via pathspec", func(t *testing.T) {

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -651,6 +651,43 @@ func TestIsAncestor(t *testing.T) {
 	})
 }
 
+func TestApplyPatch(t *testing.T) {
+	t.Run("applies root-relative patches from a subdirectory", func(t *testing.T) {
+		repo := t.TempDir()
+		var err error
+		repo, err = filepath.EvalSymlinks(repo)
+		require.NoError(t, err)
+		mustGit(t, repo, "init")
+		mustGit(t, repo, "config", "user.email", "test@example.com")
+		mustGit(t, repo, "config", "user.name", "Test")
+
+		rootFile := filepath.Join(repo, "root.txt")
+		subdir := filepath.Join(repo, "subdir")
+		require.NoError(t, os.MkdirAll(subdir, 0o755))
+		require.NoError(t, os.WriteFile(rootFile, []byte("old\n"), 0o644))
+		mustGit(t, repo, "add", "root.txt")
+		mustGit(t, repo, "commit", "-m", "initial")
+
+		require.NoError(t, os.WriteFile(rootFile, []byte("new\n"), 0o644))
+		diffCmd := exec.Command("git", "diff", "--binary")
+		diffCmd.Dir = repo
+		patch, err := diffCmd.Output()
+		require.NoError(t, err)
+		mustGit(t, repo, "reset", "--hard", "HEAD")
+
+		client := &git.Client{Binary: "git", Dir: subdir}
+		cmd := client.ApplyPatch(patch)
+		require.Equal(t, repo, cmd.Dir)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+
+		content, err := os.ReadFile(rootFile)
+		require.NoError(t, err)
+		require.Equal(t, "new\n", string(content))
+		require.Equal(t, repo, client.ApplyPatchReject(patch).Dir)
+	})
+}
+
 func TestCommitMismatchNote(t *testing.T) {
 	t.Run("returns note with short SHAs when commits differ", func(t *testing.T) {
 		note := git.CommitMismatchNote(

--- a/internal/mocks/git.go
+++ b/internal/mocks/git.go
@@ -12,11 +12,14 @@ type Git struct {
 	MockGetBranch              string
 	MockGetHead                string
 	MockGetHeadError           error
+	MockGetTopLevel            string
 	MockGetCommit              string
 	MockGetCommitError         error
 	MockGetOriginUrl           string
 	MockGeneratePatchFile      git.PatchFile
 	MockGeneratePatchFileError error
+	MockGeneratePatchFileFunc  func(destDir string, pathspec []string) (git.PatchFile, error)
+	MockGeneratePatchPathspec  []string
 	MockGeneratePatch          func(pathspec []string) ([]byte, *git.LFSChangedFilesMetadata, error)
 	MockGenerateDirtyPatches   func() (git.DirtyPatches, error)
 	MockHasCommit              func(sha string) bool
@@ -43,6 +46,10 @@ func (c *Git) GetHeadCommit() (string, error) {
 	return c.MockGetHead, c.MockGetHeadError
 }
 
+func (c *Git) GetTopLevel() string {
+	return c.MockGetTopLevel
+}
+
 func (c *Git) GetCommit() (string, error) {
 	return c.MockGetCommit, c.MockGetCommitError
 }
@@ -52,6 +59,11 @@ func (c *Git) GetOriginUrl() string {
 }
 
 func (c *Git) GeneratePatchFile(destDir string, pathspec []string) (git.PatchFile, error) {
+	c.MockGeneratePatchPathspec = append([]string(nil), pathspec...)
+	if c.MockGeneratePatchFileFunc != nil {
+		return c.MockGeneratePatchFileFunc(destDir, pathspec)
+	}
+
 	if c.MockGeneratePatchFileError != nil {
 		return git.PatchFile{}, c.MockGeneratePatchFileError
 	}


### PR DESCRIPTION
## Summary

This PR addresses the first tranche of findings from the run/sandbox correctness audit, focused on data-loss and sync-correctness paths around `rwx run` and `rwx sandbox`.

Key changes:

- Apply and generate git patches from the repository root, including sandbox-side git commands that run over SSH.
- Fix sandbox dirty-sync edge cases for new files, pre-applied new files, staged deletes, non-ASCII paths, quoted paths, and LFS-tracked changes.
- Preserve CLI trigger git params across repeated `--init` runs and keep YAML document separators intact when injecting triggers.
- Make sandbox storage safer by normalizing config paths, avoiding reachable panics, locking existing-session cleanup, and writing state atomically.
- Fix upload path handling for Windows root walk termination, slash normalization, and WalkDir error propagation.
- Bypass local git hooks for sandbox sync snapshot commits.
- Restrict config/token file permissions.

## Remaining work

The main remaining follow-ups are in sandbox lifecycle, output behavior, and a few path-handling edges:

- `exec --id <run> --reset` and reset recreating from the wrong config.
- `sandbox start --json` stdout/prompt behavior and `start --wait` on existing sandboxes.
- `run --debug` / `--wait` exit and JSON behavior.
- Scoped sandbox token overwrite in the API client.
- SSH combined-output buffer race.
- Windows session-key parsing.
- Symlinked run definitions and the symlinked-CWD upload path issue.

## Tests

- `/Users/kylekthompson/.local/share/mise/installs/go/1.24.1/bin/go test ./internal/cli`
- `git diff --check`