### PR TITLE
Handle the deferred-run (202) response in the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.direnv
 /.language-server
 /rwx
+/tmp/

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -311,6 +311,10 @@ func (c Client) InitiateRun(cfg InitiateRunConfig) (*InitiateRunResult, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusAccepted {
+		return parseDeferredRunResponse(resp.Body)
+	}
+
 	if resp.StatusCode != 201 {
 		msg := extractErrorMessage(resp.Body)
 		if msg == "" {
@@ -354,6 +358,59 @@ func (c Client) InitiateRun(cfg InitiateRunConfig) (*InitiateRunResult, error) {
 			Message:          respBody.SnakeMessage,
 		}, nil
 	}
+}
+
+func parseDeferredRunResponse(body io.Reader) (*InitiateRunResult, error) {
+	respBody := struct {
+		Status      string `json:"status"`
+		DeferredRun struct {
+			ID             string `json:"id"`
+			PlaceholderURL string `json:"placeholderUrl"`
+			PollingURL     string `json:"pollingUrl"`
+			ExpiresAt      string `json:"expiresAt"`
+		} `json:"deferredRun"`
+	}{}
+
+	if err := json.NewDecoder(body).Decode(&respBody); err != nil {
+		return nil, errors.Wrap(err, "unable to parse deferred run response")
+	}
+
+	return &InitiateRunResult{
+		Deferred:       true,
+		DeferredRunID:  respBody.DeferredRun.ID,
+		PlaceholderURL: respBody.DeferredRun.PlaceholderURL,
+		PollingURL:     respBody.DeferredRun.PollingURL,
+		ExpiresAt:      respBody.DeferredRun.ExpiresAt,
+	}, nil
+}
+
+// DeferredRunStatus polls the deferred-run status endpoint whose URL the server
+// returned in the 202 response. The URL is absolute, so RoundTrip leaves its
+// scheme/host intact.
+func (c Client) DeferredRunStatus(pollingURL string) (DeferredRunStatusResult, error) {
+	result := DeferredRunStatusResult{}
+
+	if pollingURL == "" {
+		return result, errors.New("deferred run response did not include a polling URL")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, pollingURL, nil)
+	if err != nil {
+		return result, errors.Wrap(err, "unable to create new HTTP request")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.RoundTrip(req)
+	if err != nil {
+		return result, errors.Wrap(err, "HTTP request failed")
+	}
+	defer resp.Body.Close()
+
+	if err = decodeResponseJSON(resp, &result); err != nil {
+		return result, err
+	}
+
+	return result, nil
 }
 
 func (c Client) InitiateDispatch(cfg InitiateDispatchConfig) (*InitiateDispatchResult, error) {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -93,6 +93,99 @@ func TestAPIClient_InitiateRun(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "123", result.RunID)
 	})
+
+	t.Run("parses a 202 deferred response", func(t *testing.T) {
+		bodyBytes := []byte(`{
+			"status": "deferred",
+			"deferredRun": {
+				"id": "deferred-123",
+				"placeholderUrl": "https://cloud.rwx.com/mint/org/runs/pending/deferred-123",
+				"pollingUrl": "https://cloud.rwx.com/mint/api/deferred_runs/deferred-123",
+				"expiresAt": "2026-06-12T00:07:00Z"
+			}
+		}`)
+
+		roundTrip := func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "202 Accepted",
+				StatusCode: 202,
+				Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
+			}, nil
+		}
+
+		c := api.NewClientWithRoundTrip(roundTrip)
+
+		result, err := c.InitiateRun(api.InitiateRunConfig{
+			TaskDefinitions: []api.RwxDirectoryEntry{
+				{Path: "foo", FileContents: "echo 'bar'", Permissions: 0o644, Type: "file"},
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, result.Deferred)
+		require.Equal(t, "deferred-123", result.DeferredRunID)
+		require.Equal(t, "https://cloud.rwx.com/mint/org/runs/pending/deferred-123", result.PlaceholderURL)
+		require.Equal(t, "https://cloud.rwx.com/mint/api/deferred_runs/deferred-123", result.PollingURL)
+		require.Equal(t, "2026-06-12T00:07:00Z", result.ExpiresAt)
+		require.Empty(t, result.RunID)
+	})
+
+}
+
+func TestAPIClient_DeferredRunStatus(t *testing.T) {
+	t.Run("returns an error when the polling URL is empty", func(t *testing.T) {
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			t.Fatal("should not make a request without a polling URL")
+			return nil, nil
+		})
+
+		_, err := c.DeferredRunStatus("")
+		require.Error(t, err)
+	})
+
+	t.Run("parses a pending response", func(t *testing.T) {
+		bodyBytes := []byte(`{"state": "pending", "polling": {"completed": false, "backoff_ms": 2000}}`)
+
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "/mint/api/deferred_runs/deferred-123", req.URL.Path)
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(bodyBytes))}, nil
+		})
+
+		result, err := c.DeferredRunStatus("https://cloud.rwx.com/mint/api/deferred_runs/deferred-123")
+		require.NoError(t, err)
+		require.Equal(t, api.DeferredRunStatePending, result.State)
+		require.False(t, result.Polling.Completed)
+		require.NotNil(t, result.Polling.BackoffMs)
+		require.Equal(t, 2000, *result.Polling.BackoffMs)
+	})
+
+	t.Run("parses a created response", func(t *testing.T) {
+		bodyBytes := []byte(`{"state": "created", "run_id": "run-789", "run_url": "https://cloud.rwx.com/mint/org/runs/run-789", "polling": {"completed": true}}`)
+
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(bodyBytes))}, nil
+		})
+
+		result, err := c.DeferredRunStatus("https://cloud.rwx.com/mint/api/deferred_runs/deferred-123")
+		require.NoError(t, err)
+		require.Equal(t, api.DeferredRunStateCreated, result.State)
+		require.Equal(t, "run-789", result.RunID)
+		require.Equal(t, "https://cloud.rwx.com/mint/org/runs/run-789", result.RunURL)
+		require.True(t, result.Polling.Completed)
+	})
+
+	t.Run("parses an expired response", func(t *testing.T) {
+		bodyBytes := []byte(`{"state": "expired", "failure_reason": "no task server became available", "polling": {"completed": true}}`)
+
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(bodyBytes))}, nil
+		})
+
+		result, err := c.DeferredRunStatus("https://cloud.rwx.com/mint/api/deferred_runs/deferred-123")
+		require.NoError(t, err)
+		require.Equal(t, api.DeferredRunStateExpired, result.State)
+		require.Equal(t, "no task server became available", result.FailureReason)
+		require.True(t, result.Polling.Completed)
+	})
 }
 
 func TestAPIClient_ObtainAuthCode(t *testing.T) {

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -64,6 +64,15 @@ type InitiateRunResult struct {
 	TargetedTaskKeys []string
 	DefinitionPath   string
 	Message          string
+
+	// Deferred and the fields below it are only populated when the API returns a
+	// 202 deferred response (an ephemeral org whose task servers are cold-starting).
+	// The run does not exist yet; PollingURL must be polled until it does.
+	Deferred       bool
+	DeferredRunID  string
+	PlaceholderURL string
+	PollingURL     string
+	ExpiresAt      string
 }
 
 func (c InitiateRunConfig) Validate() error {
@@ -299,6 +308,20 @@ const (
 type PollingResult struct {
 	Completed bool `json:"completed"`
 	BackoffMs *int `json:"backoff_ms,omitempty"`
+}
+
+const (
+	DeferredRunStatePending = "pending"
+	DeferredRunStateCreated = "created"
+	DeferredRunStateExpired = "expired"
+)
+
+type DeferredRunStatusResult struct {
+	State         string        `json:"state"`
+	RunID         string        `json:"run_id,omitempty"`
+	RunURL        string        `json:"run_url,omitempty"`
+	FailureReason string        `json:"failure_reason,omitempty"`
+	Polling       PollingResult `json:"polling"`
 }
 
 type TaskStatus struct {

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -19,6 +19,7 @@ type APIClient interface {
 	CreateSandboxToken(api.CreateSandboxTokenConfig) (*api.CreateSandboxTokenResult, error)
 	GetDispatch(api.GetDispatchConfig) (*api.GetDispatchResult, error)
 	InitiateRun(api.InitiateRunConfig) (*api.InitiateRunResult, error)
+	DeferredRunStatus(pollingURL string) (api.DeferredRunStatusResult, error)
 	InitiateDispatch(api.InitiateDispatchConfig) (*api.InitiateDispatchResult, error)
 	ObtainAuthCode(api.ObtainAuthCodeConfig) (*api.ObtainAuthCodeResult, error)
 	AcquireToken(tokenUrl string) (*api.AcquireTokenResult, error)

--- a/internal/cli/service_deferred.go
+++ b/internal/cli/service_deferred.go
@@ -18,7 +18,7 @@ const deferredRunDefaultBackoffMs = 2000
 // (print, --open, --wait, --debug) is unchanged.
 func (s Service) awaitDeferredRun(deferred *api.InitiateRunResult, cfg InitiateRunConfig) (*api.InitiateRunResult, error) {
 	if !cfg.Json {
-		fmt.Fprintf(s.Stdout, "Your organization's task servers are starting up. Your run will begin shortly.\nTrack it here: %s\n", deferred.PlaceholderURL)
+		fmt.Fprintf(s.Stdout, "Your run will begin shortly.\nTrack it here: %s\n", deferred.PlaceholderURL)
 	}
 
 	var stopSpinner func()

--- a/internal/cli/service_deferred.go
+++ b/internal/cli/service_deferred.go
@@ -1,0 +1,73 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/errors"
+)
+
+const deferredRunDefaultBackoffMs = 2000
+
+// awaitDeferredRun handles the 202 deferred response returned when an ephemeral
+// org's task servers are cold-starting. It prints the placeholder URL up front
+// (so a user who Ctrl+Cs can still open the page), then blocks polling the
+// deferred-run status endpoint until the run is created or expired. On success
+// it returns a result shaped like a normal created run so the caller's flow
+// (print, --open, --wait, --debug) is unchanged.
+func (s Service) awaitDeferredRun(deferred *api.InitiateRunResult, cfg InitiateRunConfig) (*api.InitiateRunResult, error) {
+	if !cfg.Json {
+		fmt.Fprintf(s.Stdout, "Your organization's task servers are starting up. Your run will begin shortly.\nTrack it here: %s\n", deferred.PlaceholderURL)
+	}
+
+	var stopSpinner func()
+	if !cfg.Json {
+		stopSpinner = Spin("Waiting for run to start...", s.StdoutIsTTY, s.Stdout)
+	}
+
+	waitStart := time.Now()
+	for {
+		status, err := s.APIClient.DeferredRunStatus(deferred.PollingURL)
+		if err != nil {
+			if stopSpinner != nil {
+				stopSpinner()
+			}
+			return nil, errors.Wrap(err, "unable to get deferred run status")
+		}
+
+		if status.Polling.Completed {
+			if stopSpinner != nil {
+				stopSpinner()
+			}
+
+			s.recordTelemetry("run.deferred", map[string]any{
+				"state":            status.State,
+				"wait_duration_ms": time.Since(waitStart).Milliseconds(),
+			})
+
+			switch status.State {
+			case api.DeferredRunStateCreated:
+				return &api.InitiateRunResult{
+					RunID:   status.RunID,
+					RunURL:  status.RunURL,
+					Message: fmt.Sprintf("Run is watchable at %s\n", status.RunURL),
+				}, nil
+			case api.DeferredRunStateExpired:
+				msg := status.FailureReason
+				if msg == "" {
+					msg = "The run could not be started before the request expired. Please try again."
+				}
+				return nil, errors.New(msg)
+			default:
+				return nil, errors.Errorf("deferred run finished in an unexpected state: %q", status.State)
+			}
+		}
+
+		backoffMs := deferredRunDefaultBackoffMs
+		if status.Polling.BackoffMs != nil {
+			backoffMs = *status.Polling.BackoffMs
+		}
+		time.Sleep(time.Duration(backoffMs) * time.Millisecond)
+	}
+}

--- a/internal/cli/service_deferred_test.go
+++ b/internal/cli/service_deferred_test.go
@@ -1,0 +1,121 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/cli"
+	"github.com/stretchr/testify/require"
+)
+
+// setupDeferredRunTest lays down a minimal valid run definition so InitiateRun
+// reaches the API call, and returns the run config to pass to InitiateRun.
+func setupDeferredRunTest(t *testing.T, s *testSetup) cli.InitiateRunConfig {
+	t.Helper()
+
+	s.mockAPI.MockGetDefaultBase = func() (api.DefaultBaseResult, error) {
+		return api.DefaultBaseResult{Image: "ubuntu:24.04", Config: "rwx/base 1.0.0", Arch: "x86_64"}, nil
+	}
+	s.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+		return &api.PackageVersionsResult{
+			LatestMajor: make(map[string]string),
+			LatestMinor: make(map[string]map[string]string),
+		}, nil
+	}
+
+	fileContent := "tasks:\n  - key: foo\n    run: echo 'bar'\nbase:\n  image: ubuntu:24.04\n  config: rwx/base 1.0.0\n"
+
+	workingDir := filepath.Join(s.tmp, "working")
+	require.NoError(t, os.MkdirAll(workingDir, 0o755))
+	require.NoError(t, os.Chdir(workingDir))
+	require.NoError(t, os.MkdirAll(filepath.Join(s.tmp, ".mint"), 0o755))
+
+	testFile := filepath.Join(s.tmp, ".mint", "test.yml")
+	require.NoError(t, os.WriteFile(testFile, []byte(fileContent), 0o644))
+
+	return cli.InitiateRunConfig{MintFilePath: testFile}
+}
+
+func TestService_InitiateRun_Deferred(t *testing.T) {
+	t.Run("polls until the deferred run is created, then resolves to the real run", func(t *testing.T) {
+		s := setupTest(t)
+		runConfig := setupDeferredRunTest(t, s)
+
+		s.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+			return &api.InitiateRunResult{
+				Deferred:       true,
+				DeferredRunID:  "deferred-123",
+				PlaceholderURL: "https://cloud.rwx.com/mint/rwx/runs/pending/deferred-123",
+				PollingURL:     "https://cloud.rwx.com/mint/api/deferred_runs/deferred-123",
+			}, nil
+		}
+
+		shortBackoff := 1
+		calls := 0
+		var receivedPollingURL string
+		s.mockAPI.MockDeferredRunStatus = func(pollingURL string) (api.DeferredRunStatusResult, error) {
+			receivedPollingURL = pollingURL
+			calls++
+			if calls == 1 {
+				return api.DeferredRunStatusResult{
+					State:   api.DeferredRunStatePending,
+					Polling: api.PollingResult{Completed: false, BackoffMs: &shortBackoff},
+				}, nil
+			}
+			return api.DeferredRunStatusResult{
+				State:   api.DeferredRunStateCreated,
+				RunID:   "run-789",
+				RunURL:  "https://cloud.rwx.com/mint/rwx/runs/run-789",
+				Polling: api.PollingResult{Completed: true},
+			}, nil
+		}
+
+		result, err := s.service.InitiateRun(runConfig)
+		require.NoError(t, err)
+		require.Equal(t, "run-789", result.RunID)
+		require.Equal(t, "https://cloud.rwx.com/mint/rwx/runs/run-789", result.RunURL)
+		require.Contains(t, result.Message, "Run is watchable at https://cloud.rwx.com/mint/rwx/runs/run-789")
+		require.False(t, result.Deferred)
+		require.Equal(t, 2, calls)
+		require.Equal(t, "https://cloud.rwx.com/mint/api/deferred_runs/deferred-123", receivedPollingURL)
+
+		// The placeholder URL is printed up front so a user who Ctrl+Cs can still open the page.
+		require.Contains(t, s.mockStdout.String(), "https://cloud.rwx.com/mint/rwx/runs/pending/deferred-123")
+
+		var deferredEvent bool
+		for _, e := range s.drainEvents() {
+			if e.Event == "run.deferred" {
+				deferredEvent = true
+				require.Equal(t, api.DeferredRunStateCreated, e.Props["state"])
+			}
+		}
+		require.True(t, deferredEvent, "expected a run.deferred telemetry event")
+	})
+
+	t.Run("returns the failure reason when the deferred run expires", func(t *testing.T) {
+		s := setupTest(t)
+		runConfig := setupDeferredRunTest(t, s)
+
+		s.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+			return &api.InitiateRunResult{
+				Deferred:       true,
+				DeferredRunID:  "deferred-123",
+				PlaceholderURL: "https://cloud.rwx.com/mint/rwx/runs/pending/deferred-123",
+				PollingURL:     "https://cloud.rwx.com/mint/api/deferred_runs/deferred-123",
+			}, nil
+		}
+		s.mockAPI.MockDeferredRunStatus = func(pollingURL string) (api.DeferredRunStatusResult, error) {
+			return api.DeferredRunStatusResult{
+				State:         api.DeferredRunStateExpired,
+				FailureReason: "no task server became available",
+				Polling:       api.PollingResult{Completed: true},
+			}, nil
+		}
+
+		result, err := s.service.InitiateRun(runConfig)
+		require.Nil(t, result)
+		require.ErrorContains(t, err, "no task server became available")
+	})
+}

--- a/internal/cli/service_run.go
+++ b/internal/cli/service_run.go
@@ -354,5 +354,9 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 		return nil, errors.Wrap(err, "Failed to initiate run")
 	}
 
+	if runResult.Deferred {
+		return s.awaitDeferredRun(runResult, cfg)
+	}
+
 	return runResult, nil
 }

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -9,6 +9,7 @@ type API struct {
 	MockGetSkillContent                         func() (string, error)
 	MockGetSkillLatestVersion                   func() (string, error)
 	MockInitiateRun                             func(api.InitiateRunConfig) (*api.InitiateRunResult, error)
+	MockDeferredRunStatus                       func(pollingURL string) (api.DeferredRunStatusResult, error)
 	MockGetDebugConnectionInfo                  func(runID string) (api.DebugConnectionInfo, error)
 	MockGetSandboxConnectionInfo                func(runID, scopedToken string) (api.SandboxConnectionInfo, error)
 	MockCreateSandboxToken                      func(api.CreateSandboxTokenConfig) (*api.CreateSandboxTokenResult, error)
@@ -72,6 +73,14 @@ func (c *API) InitiateRun(cfg api.InitiateRunConfig) (*api.InitiateRunResult, er
 	}
 
 	return nil, errors.New("MockInitiateRun was not configured")
+}
+
+func (c *API) DeferredRunStatus(pollingURL string) (api.DeferredRunStatusResult, error) {
+	if c.MockDeferredRunStatus != nil {
+		return c.MockDeferredRunStatus(pollingURL)
+	}
+
+	return api.DeferredRunStatusResult{}, errors.New("MockDeferredRunStatus was not configured")
 }
 
 func (c *API) GetDebugConnectionInfo(runID string) (api.DebugConnectionInfo, error) {


### PR DESCRIPTION
### Background

- Linear: [RWX-1008](https://linear.app/rwx-cloud/issue/RWX-1008/teach-the-cli-to-handle-the-deferred-run-202-response-and-enable-the)
- [RFC 188 — Deferred Runs for Ephemeral Orgs](https://www.notion.so/rwx/RFC-188-Deferred-Runs-for-Ephemeral-Orgs-37bc3a490d9880a8a7ecc33486d28bde)
- Server side: cloud PRs #7703 (deferral infra) and #7714 (polling endpoint).

### Problem

When an ephemeral org's task servers are cold-starting, cloud now returns `202 { status: "deferred", deferredRun: {...} }` instead of creating a run synchronously. The CLI treated any non-201 as a failure, which would misread the 202 and re-run.

### Solution

- Recognize the `202` deferred response and parse the camelCase body.
- New `DeferredRunStatus` client method that polls the server-provided `pollingUrl`.
- Block-poll UX: print the placeholder URL + cold-start message first (Ctrl+C-safe), then poll until `created` (resolve to the real run, resume the normal flow incl. `--wait`) or `expired`. JSON mode stays silent and still emits the real run id.
- No special-casing of the `rwx_cli_version_too_old` error: a CLI carrying this code ships in the same release the version gate keys off, so it can't actually receive that error. If it ever did, the server's upgrade message still surfaces through the normal error path.

The feature stays dark until cloud's `RWX_CLI_DEFERRED_RUN_VERSION_MINIMUM` is lowered to the shipped release — that flip is the on-switch (tracked on RWX-1008).

## Results

### Happy path

```
╰─⠠⠵ RWX_HOST=cloud.local /tmp/rwx-deferred run -f .rwx/ci.yml
Included a git patch for uncommitted changes

Your organization's task servers are starting up. Your run will begin shortly.
Track it here: https://cloud.local/mint/staging/runs/pending/5d7de61b-cba3-421a-b0f4-c6eb3a570a79
Run is watchable at https://cloud.local/mint/staging/runs/fed9e571e0ce4277b4b3bc63369abdb8

Use `rwx results --wait fed9e571e0ce4277b4b3bc63369abdb8` to wait for this run to complete.
```

### Expired

In this case, the `DeferredRun`'s `failure_reason` is set to "oops" (real server errors will be more descriptive)

```
╰─⠠⠵ RWX_HOST=cloud.local /tmp/rwx-deferred run -f .rwx/ci.yml
Included a git patch for uncommitted changes

Your organization's task servers are starting up. Your run will begin shortly.
Track it here: https://cloud.local/mint/staging/runs/pending/ef2305c8-83d2-4fe5-b821-278c4b7ab6fb
Error: oops
```

### Outdated

```
╰─⠠⠵ RWX_HOST=cloud.local /tmp/rwx-deferred run -f .rwx/ci.yml
Included a git patch for uncommitted changes

Error: Failed to initiate run: Please upgrade your CLI to at least v2.0.0.
```


Completes RWX-1006 and RWX-1008