### PR TITLE
Clean up stranded git patch file when deferred run poll is interrupted

### DIFF
--- a/internal/cli/service_run.go
+++ b/internal/cli/service_run.go
@@ -5,8 +5,10 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/rwx-cloud/rwx/internal/api"
@@ -203,6 +205,16 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 	patchDir := filepath.Join(rwxDirectoryPath, ".patches")
 	defer os.RemoveAll(patchDir)
 
+	// Go's default SIGINT/SIGTERM handling terminates the process without
+	// unwinding deferred functions, so the os.RemoveAll cleanup above never runs
+	// on Ctrl+C. The deferred-run poll (awaitDeferredRun, reached from this
+	// function) is explicitly designed for the user to Ctrl+C mid-wait, which
+	// would otherwise strand the patch file written into patchDir. Mirror the
+	// deferred cleanup on signal so the patch (and any temp .rwx dir) is removed
+	// before the process exits.
+	stopSignalCleanup := removePathsOnSignal(tempRwxDir, patchDir)
+	defer stopSignalCleanup()
+
 	// Generate patches if enabled and git is available
 	patchable := cfg.Patchable && gitAvailable
 	if _, ok := os.LookupEnv("RWX_DISABLE_GIT_PATCH"); ok {
@@ -394,4 +406,36 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 	}
 
 	return runResult, nil
+}
+
+// removePathsOnSignal removes the given paths if the process receives SIGINT or
+// SIGTERM, then restores default signal handling and re-raises the signal so the
+// process still exits with its conventional status. It returns a stop function
+// that must be called (deferred) to tear down the handler on the normal,
+// non-signal return path.
+func removePathsOnSignal(paths ...string) func() {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	done := make(chan struct{})
+
+	go func() {
+		select {
+		case sig := <-sigCh:
+			for _, p := range paths {
+				if p != "" {
+					_ = os.RemoveAll(p)
+				}
+			}
+			// Restore default handling and re-send the signal to self so the
+			// process exits as it normally would (e.g. status 130 on SIGINT).
+			signal.Stop(sigCh)
+			if proc, err := os.FindProcess(os.Getpid()); err == nil {
+				_ = proc.Signal(sig)
+			}
+		case <-done:
+			signal.Stop(sigCh)
+		}
+	}()
+
+	return func() { close(done) }
 }


### PR DESCRIPTION
### Background

Follow-up from the deferred-run 202 work in [RWX-1008](https://linear.app/rwx-cloud/issue/RWX-1008/teach-the-cli-to-handle-the-deferred-run-202-response-and-enable-the) (PR #545).

### Problem

`InitiateRun` writes a git patch to `.rwx/.patches/<sha>` and relies on `defer os.RemoveAll(patchDir)` to clean it up. The `awaitDeferredRun` poll loop is explicitly designed for the user to Ctrl+C while waiting. But Go's default SIGINT handler exits without unwinding deferred functions, so the patch file gets stranded in the working tree. Only an interrupted poll leaks it — the normal error/success returns all clean up fine.

### Solution

- New helper `removePathsOnSignal` installs a `SIGINT`/`SIGTERM` handler that `os.RemoveAll`s the given paths, then restores default handling and re-raises the signal so the process still exits with its conventional status.
- Wired into `InitiateRun` after the existing patch-dir defer; since `awaitDeferredRun` runs within `InitiateRun`, the handler stays live through the poll loop and is torn down on normal return (no goroutine leak). Mirrors both the temp `.rwx` dir and patch dir.

#### Further confirmation needed

- [ ] Confirm Ctrl+C during the deferred poll no longer strands `.rwx/.patches/<sha>` (no automated test — `removePathsOnSignal` is unexported and re-raises SIGINT, which would kill a unit-test process). Needs manual verification against a real deferred run.
- [x] Normal error/success paths still clean up as before (existing patch/deferred unit tests pass).
