### PR TITLE
Add repository metadata to initiated runs

### DIFF
--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -32,6 +32,14 @@ func TestAPIClient_InitiateRun(t *testing.T) {
 
 		roundTrip := func(req *http.Request) (*http.Response, error) {
 			require.Equal(t, "/mint/api/runs", req.URL.Path)
+			var requestBody struct {
+				Run api.InitiateRunConfig `json:"run"`
+			}
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&requestBody))
+			require.Equal(t, "cli", requestBody.Run.RepositoryName)
+			require.Equal(t, "rwx-cloud/cli", requestBody.Run.RepositorySlug)
+			require.Equal(t, "https://github.com/rwx-cloud/cli", requestBody.Run.RepositoryURL)
+			require.Equal(t, "github", requestBody.Run.VCSProvider)
 			return &http.Response{
 				Status:     "201 Created",
 				StatusCode: 201,
@@ -48,6 +56,10 @@ func TestAPIClient_InitiateRun(t *testing.T) {
 			},
 			TargetedTaskKeys: []string{},
 			UseCache:         false,
+			RepositoryName:   "cli",
+			RepositorySlug:   "rwx-cloud/cli",
+			RepositoryURL:    "https://github.com/rwx-cloud/cli",
+			VCSProvider:      "github",
 		}
 
 		result, err := c.InitiateRun(initRunConfig)

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -32,6 +32,10 @@ type InitiateRunConfig struct {
 	Title                    string                    `json:"title,omitempty"`
 	UseCache                 bool                      `json:"use_cache"`
 	Git                      GitMetadata               `json:"git"`
+	RepositoryName           string                    `json:"repository_name,omitempty"`
+	RepositorySlug           string                    `json:"repository_slug,omitempty"`
+	RepositoryURL            string                    `json:"repository_url,omitempty"`
+	VCSProvider              string                    `json:"vcs_provider,omitempty"`
 	Patch                    PatchMetadata             `json:"patch"`
 	CliState                 string                    `json:"cli_state,omitempty"`
 }

--- a/internal/cli/service_run.go
+++ b/internal/cli/service_run.go
@@ -135,6 +135,7 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 	gitDirectory := s.GitClient.IsInsideWorkTree()
 	var errorMessage string
 	var sha, branch, originUrl string
+	var repository git.RepositoryMetadata
 
 	// Track whether we can generate patches (requires working git)
 	gitAvailable := gitInstalled && gitDirectory
@@ -148,6 +149,7 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 		} else {
 			branch = s.GitClient.GetBranch()
 			originUrl = s.GitClient.GetOriginUrl()
+			repository = git.RepositoryMetadataFromOriginUrl(originUrl)
 		}
 	} else if !gitInstalled {
 		errorMessage = "Git is not installed"
@@ -331,6 +333,10 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 			Sha:       sha,
 			OriginUrl: originUrl,
 		},
+		RepositoryName: repository.Name,
+		RepositorySlug: repository.Slug,
+		RepositoryURL:  repository.URL,
+		VCSProvider:    repository.VCSProvider,
 		Patch: api.PatchMetadata{
 			Sent:           patchFile.Written,
 			UntrackedFiles: []string{},

--- a/internal/cli/service_run_patch_test.go
+++ b/internal/cli/service_run_patch_test.go
@@ -232,6 +232,10 @@ func TestService_InitiatingRunPatch(t *testing.T) {
 			require.Equal(t, "3e76c8295cd0ce4decbf7b56253c902ce296cb25", cfg.Git.Sha)
 			require.Equal(t, "main", cfg.Git.Branch)
 			require.Equal(t, "git@github.com:example/repo.git", cfg.Git.OriginUrl)
+			require.Equal(t, "repo", cfg.RepositoryName)
+			require.Equal(t, "example/repo", cfg.RepositorySlug)
+			require.Equal(t, "https://github.com/example/repo", cfg.RepositoryURL)
+			require.Equal(t, "github", cfg.VCSProvider)
 			return &api.InitiateRunResult{
 				RunID:  "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
 				RunURL: "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",

--- a/internal/cli/service_run_test.go
+++ b/internal/cli/service_run_test.go
@@ -110,6 +110,10 @@ func TestService_InitiatingRun(t *testing.T) {
 					require.Equal(t, branch, cfg.Git.Branch)
 					require.Equal(t, sha, cfg.Git.Sha)
 					require.Equal(t, originUrl, cfg.Git.OriginUrl)
+					require.Equal(t, "rwx", cfg.RepositoryName)
+					require.Equal(t, "rwx-cloud/rwx", cfg.RepositorySlug)
+					require.Equal(t, "https://github.com/rwx-cloud/rwx", cfg.RepositoryURL)
+					require.Equal(t, "github", cfg.VCSProvider)
 					receivedSpecifiedFileContent = cfg.TaskDefinitions[0].FileContents
 					receivedRwxDir = cfg.RwxDirectory
 					return &api.InitiateRunResult{

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -176,6 +177,13 @@ func (c *Client) GetOriginUrl() string {
 	return c.GetRemoteUrl(getRemote())
 }
 
+type RepositoryMetadata struct {
+	Name        string
+	Slug        string
+	URL         string
+	VCSProvider string
+}
+
 // RepoNameFromOriginUrl extracts the repository name from a git remote URL.
 // For example, "git@github.com:rwx-cloud/rwx.git" returns "rwx".
 func RepoNameFromOriginUrl(originUrl string) string {
@@ -190,6 +198,68 @@ func RepoNameFromOriginUrl(originUrl string) string {
 	}
 
 	return strings.TrimSuffix(originUrl, ".git")
+}
+
+func RepositoryMetadataFromOriginUrl(originUrl string) RepositoryMetadata {
+	host, path := remoteHostAndPath(originUrl)
+	if host == "" || path == "" {
+		return RepositoryMetadata{}
+	}
+
+	slug := strings.TrimSuffix(strings.Trim(path, "/"), ".git")
+	if slug == "" || slug == "." || strings.HasPrefix(slug, "..") {
+		return RepositoryMetadata{}
+	}
+
+	parts := strings.Split(slug, "/")
+	name := parts[len(parts)-1]
+	if name == "" {
+		return RepositoryMetadata{}
+	}
+
+	provider := vcsProviderFromHost(host)
+	return RepositoryMetadata{
+		Name:        name,
+		Slug:        slug,
+		URL:         "https://" + host + "/" + slug,
+		VCSProvider: provider,
+	}
+}
+
+func remoteHostAndPath(originUrl string) (string, string) {
+	originUrl = strings.TrimSpace(originUrl)
+	if originUrl == "" {
+		return "", ""
+	}
+
+	if idx := strings.LastIndex(originUrl, ":"); idx != -1 && !strings.Contains(originUrl[:idx], "://") && strings.Contains(originUrl[:idx], "@") {
+		userAndHost := originUrl[:idx]
+		host := userAndHost[strings.LastIndex(userAndHost, "@")+1:]
+		return normalizeRemoteHost(host), originUrl[idx+1:]
+	}
+
+	parsed, err := url.Parse(originUrl)
+	if err != nil || parsed.Host == "" {
+		return "", ""
+	}
+
+	return normalizeRemoteHost(parsed.Hostname()), parsed.Path
+}
+
+func normalizeRemoteHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return strings.TrimPrefix(host, "www.")
+}
+
+func vcsProviderFromHost(host string) string {
+	switch host {
+	case "github.com":
+		return "github"
+	case "gitlab.com":
+		return "gitlab"
+	default:
+		return ""
+	}
 }
 
 func (c *Client) GetRemoteUrl(remote string) string {

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -709,3 +709,87 @@ func TestRepoNameFromOriginUrl(t *testing.T) {
 		})
 	}
 }
+
+func TestRepositoryMetadataFromOriginUrl(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected git.RepositoryMetadata
+	}{
+		{
+			name:  "GitHub SSH URL",
+			input: "git@github.com:rwx-cloud/cli.git",
+			expected: git.RepositoryMetadata{
+				Name:        "cli",
+				Slug:        "rwx-cloud/cli",
+				URL:         "https://github.com/rwx-cloud/cli",
+				VCSProvider: "github",
+			},
+		},
+		{
+			name:  "GitHub HTTPS URL",
+			input: "https://github.com/rwx-cloud/cli.git",
+			expected: git.RepositoryMetadata{
+				Name:        "cli",
+				Slug:        "rwx-cloud/cli",
+				URL:         "https://github.com/rwx-cloud/cli",
+				VCSProvider: "github",
+			},
+		},
+		{
+			name:  "GitLab nested HTTPS URL",
+			input: "https://gitlab.com/group/subgroup/repo.git",
+			expected: git.RepositoryMetadata{
+				Name:        "repo",
+				Slug:        "group/subgroup/repo",
+				URL:         "https://gitlab.com/group/subgroup/repo",
+				VCSProvider: "gitlab",
+			},
+		},
+		{
+			name:  "GitLab nested SSH URL",
+			input: "git@gitlab.com:group/subgroup/repo.git",
+			expected: git.RepositoryMetadata{
+				Name:        "repo",
+				Slug:        "group/subgroup/repo",
+				URL:         "https://gitlab.com/group/subgroup/repo",
+				VCSProvider: "gitlab",
+			},
+		},
+		{
+			name:  "SSH scheme URL",
+			input: "ssh://git@github.com/rwx-cloud/cli.git",
+			expected: git.RepositoryMetadata{
+				Name:        "cli",
+				Slug:        "rwx-cloud/cli",
+				URL:         "https://github.com/rwx-cloud/cli",
+				VCSProvider: "github",
+			},
+		},
+		{
+			name:  "unknown host",
+			input: "git@git.example.com:some-org/some-repo.git",
+			expected: git.RepositoryMetadata{
+				Name: "some-repo",
+				Slug: "some-org/some-repo",
+				URL:  "https://git.example.com/some-org/some-repo",
+			},
+		},
+		{
+			name:     "local path",
+			input:    "../some-repo",
+			expected: git.RepositoryMetadata{},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: git.RepositoryMetadata{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, git.RepositoryMetadataFromOriginUrl(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Derive repository name, slug, URL, and VCS provider from the git origin URL
- Include the repository metadata in run initiation requests and service plumbing
- Add coverage for GitHub, GitLab, SSH, and invalid/local origin formats

## Testing
- Added unit tests for repository metadata parsing in `internal/git/client_test.go`
- Updated CLI and API tests to assert the new repository fields are propagated correctly