### PR TITLE
Make `rwx runs` a command group with a `start` alias

### DIFF
--- a/.rwx/integration/run-test.yml
+++ b/.rwx/integration/run-test.yml
@@ -150,3 +150,80 @@ tasks:
     env:
       RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
       RUN_DEF: ${{ run.dir }}/integration/run-test/failing-def.yml
+
+  # `rwx runs start` is the noun-verb alias for `rwx run`; it must initiate a
+  # run equivalently. The remaining `rwx run` behaviors share the same RunE, so
+  # one equivalence check here is sufficient.
+  - key: test-runs-start
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      kickoff=$(rwx runs start "$RUN_DEF" --wait --json --no-cache)
+      status=$(echo "$kickoff" | jq -r '.ResultStatus')
+      run_url=$(echo "$kickoff" | jq -r '.RunURL // empty')
+      echo "$run_url" > "$RWX_LINKS/runs start run"
+
+      if [ "$status" != "succeeded" ]; then
+        echo "Expected 'succeeded' from 'rwx runs start', got '$status'"
+        echo "$kickoff"
+        exit 1
+      fi
+
+      if [ -z "$run_url" ]; then
+        echo "Expected 'rwx runs start' to return a RunURL"
+        echo "$kickoff"
+        exit 1
+      fi
+    env:
+      RUN_DEF: ${{ run.dir }}/integration/run-test/simple-def.yml
+      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+
+  # Bare `rwx runs` is a pure parent command: it prints help and must never
+  # initiate a run. No access token is required because help short-circuits
+  # before any API client setup.
+  - key: test-runs-bare-prints-help
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      output=$(rwx runs)
+
+      if ! echo "$output" | grep -q "Available Commands"; then
+        echo "Expected bare 'rwx runs' to print help with available commands"
+        echo "$output"
+        exit 1
+      fi
+
+      if ! echo "$output" | grep -q "start"; then
+        echo "Expected bare 'rwx runs' help to list the 'start' subcommand"
+        echo "$output"
+        exit 1
+      fi
+
+      if echo "$output" | grep -qiE "https?://[^ ]+/runs/"; then
+        echo "Bare 'rwx runs' should not initiate a run"
+        echo "$output"
+        exit 1
+      fi
+
+  # `rwx runs <id>` resolves to the parent group and prints help instead of
+  # looking up a run; it is not a `rwx results` alias.
+  - key: test-runs-bare-id-prints-help
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      output=$(rwx runs some-nonexistent-run-id)
+
+      if ! echo "$output" | grep -q "Available Commands"; then
+        echo "Expected 'rwx runs <id>' to print help"
+        echo "$output"
+        exit 1
+      fi
+
+      if echo "$output" | grep -qi "result status"; then
+        echo "'rwx runs <id>' should not alias 'rwx results'"
+        echo "$output"
+        exit 1
+      fi

--- a/.rwx/release.yml
+++ b/.rwx/release.yml
@@ -349,7 +349,7 @@ tasks:
       LINEAR_ACCESS_KEY: ${{ vaults.rwx_cli_development.secrets.linear-release-access-key }}
 
   - key: rwx-cli
-    call: rwx/install-cli 4.0.4
+    call: rwx/install-cli 4.0.5
 
   - key: homebrew-release
     use: rwx-cli

--- a/cmd/rwx/runs.go
+++ b/cmd/rwx/runs.go
@@ -5,18 +5,28 @@ import "github.com/spf13/cobra"
 var runsCmd *cobra.Command
 
 func init() {
-	aliasShort := "Alias for rwx results"
-
+	// `rwx runs` is a pure parent command. With no RunE and subcommands present,
+	// Cobra prints help for a bare `rwx runs` (or any stray arg, e.g. a run id)
+	// and never initiates a run, so the plural form can't be mistaken for
+	// `rwx run` or for `rwx results`.
 	runsCmd = &cobra.Command{
-		GroupID: "outputs",
-		Use:     "runs [run-id]",
-		Short:   aliasShort,
-		Args:    resultsCmd.Args,
-		PreRunE: resultsCmd.PreRunE,
-		RunE:    resultsCmd.RunE,
-		Hidden:  true,
+		GroupID: "execution",
+		Use:     "runs",
+		Short:   "Create and inspect runs",
 	}
-	runsCmd.Flags().AddFlagSet(resultsCmd.Flags())
+
+	// `rwx runs start` is the noun-verb form of `rwx run`. It reuses runCmd's
+	// validation and execution so the two stay in lockstep.
+	runsStartCmd := &cobra.Command{
+		Use:     "start <file> [flags]",
+		Short:   runCmd.Short,
+		Long:    runCmd.Long,
+		PreRunE: runCmd.PreRunE,
+		RunE:    runCmd.RunE,
+	}
+	runsStartCmd.Flags().AddFlagSet(runCmd.Flags())
+
+	aliasShort := "Alias for rwx results"
 
 	runsGetCmd := &cobra.Command{
 		Use:     "get [run-id]",
@@ -38,6 +48,7 @@ func init() {
 	}
 	runsShowCmd.Flags().AddFlagSet(resultsCmd.Flags())
 
+	runsCmd.AddCommand(runsStartCmd)
 	runsCmd.AddCommand(runsGetCmd)
 	runsCmd.AddCommand(runsShowCmd)
 

--- a/cmd/rwx/runs_test.go
+++ b/cmd/rwx/runs_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func findSubcommand(parent *cobra.Command, name string) *cobra.Command {
+	for _, c := range parent.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func sameFunc(a, b any) bool {
+	return reflect.ValueOf(a).Pointer() == reflect.ValueOf(b).Pointer()
+}
+
+func TestRunsIsPureParent(t *testing.T) {
+	// A pure parent: no Run/RunE means Cobra prints help by default and a bare
+	// `rwx runs` can never initiate a run or alias `rwx results`.
+	require.Nil(t, runsCmd.RunE)
+	require.Nil(t, runsCmd.Run)
+	require.False(t, runsCmd.Runnable())
+	require.True(t, runsCmd.HasSubCommands())
+}
+
+func TestRunsStartMirrorsRun(t *testing.T) {
+	startCmd := findSubcommand(runsCmd, "start")
+	require.NotNil(t, startCmd, "rwx runs start should exist")
+	require.False(t, startCmd.Hidden, "start is a real action and should be visible")
+
+	// start is the noun-verb form of `rwx run`: it reuses runCmd's validation
+	// and execution so the two stay in lockstep.
+	require.True(t, sameFunc(startCmd.RunE, runCmd.RunE), "start should reuse run's RunE")
+	require.True(t, sameFunc(startCmd.PreRunE, runCmd.PreRunE), "start should reuse run's PreRunE")
+
+	// It exposes the same flags as `rwx run`.
+	for _, name := range []string{"init", "target", "file", "no-cache", "dir", "open", "debug", "wait", "fail-fast", "title"} {
+		require.NotNil(t, startCmd.Flags().Lookup(name), "start should expose the --%s flag", name)
+	}
+}
+
+func TestRunsResultAliasesStayHidden(t *testing.T) {
+	for _, name := range []string{"get", "show"} {
+		aliasCmd := findSubcommand(runsCmd, name)
+		require.NotNil(t, aliasCmd, "rwx runs %s should exist", name)
+		require.True(t, aliasCmd.Hidden, "rwx runs %s should remain hidden", name)
+		require.True(t, sameFunc(aliasCmd.RunE, resultsCmd.RunE), "rwx runs %s should alias results", name)
+	}
+}
+
+// executeRoot runs the root command with the given args, capturing combined
+// output. A bare/parent invocation resolves to ErrHelp before PersistentPreRunE,
+// so no network or access token is required.
+func executeRoot(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+func TestRunsBarePrintsHelp(t *testing.T) {
+	out, err := executeRoot(t, "runs")
+	require.NoError(t, err)
+	require.Contains(t, out, "Available Commands")
+	require.Contains(t, out, "start")
+}
+
+func TestRunsBareIdPrintsHelpAndDoesNotAliasResults(t *testing.T) {
+	// The bare-id form resolves to the parent (non-runnable), so Cobra prints
+	// help instead of looking up a run; it is not a `rwx results` alias.
+	out, err := executeRoot(t, "runs", "some-run-id")
+	require.NoError(t, err)
+	require.Contains(t, out, "Available Commands")
+	require.NotContains(t, out, "result status")
+}


### PR DESCRIPTION
### Background

[RWX-1011](https://linear.app/rwx-cloud/issue/RWX-1011/cli-make-rwx-runs-a-command-group-add-rwx-runs-create-alias-for-rwx). Blocks [RWX-1003](https://linear.app/rwx-cloud/issue/RWX-1003/cli-add-rwx-runs-list-command-with-typed-listruns-client-and-shared) (`rwx runs list`); both touch `cmd/rwx/runs.go`.

### Problem

`rwx runs` was a hidden alias for `rwx results`, so the plural `rwx runs` could silently behave like a results lookup — easy to confuse with the singular `rwx run` (execute), especially with `rwx runs list` on the way.

### Solution

`rwx runs` is now a real command group: bare `rwx runs` prints help (never runs or aliases results), and `rwx runs start` is the visible noun-verb form of `rwx run` (reuses its `RunE`/`PreRunE`/flags). `get`/`show` stay hidden results aliases. Adds integration coverage in `run-test.yml` and bumps `rwx/install-cli` `4.0.4 -> 4.0.5`.

```
# BEFORE — rwx runs --help            # AFTER — rwx runs --help
Alias for rwx results                 Create and inspect runs

Usage:                                Usage:
  rwx runs [run-id] [flags]             rwx runs [command]

Flags:                                Available Commands:
  --branch / --commit / --wait          start    Launch a run from a local
  --open / --repo / --task ...                   RWX definitions file
  (results flags; runs <id> -> results)
```

Note: a stray `rwx runs <id>` now prints help (exit 0) rather than an unknown-command error — Cobra only auto-errors for root-level unknowns, and this matches the repo's other groups (`image`, `vaults`). It still no longer aliases results.

#### Further confirmation needed

- [ ] `run-rwx-run-test.integration-tests.run-playwright` — `mint-login.spec.ts` timed out on the `mint login` flow in an earlier loop; appears flaky, unrelated to `rwx runs`. Confirm green on CI.
