### PR TITLE
Add `rwx runs list` command

### DIFF
--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -159,6 +159,11 @@ tasks:
     init:
       ref: ${{ init.commit-sha }}
 
+  - key: run-rwx-runs-list-test
+    call: ${{ run.dir }}/integration/runs-list-test.yml
+    init:
+      ref: ${{ init.commit-sha }}
+
   - key: run-rwx-dispatch-test
     call: ${{ run.dir }}/integration/dispatch-test.yml
     init:

--- a/.rwx/integration/runs-list-test.yml
+++ b/.rwx/integration/runs-list-test.yml
@@ -1,0 +1,139 @@
+on:
+  cli:
+    init:
+      ref: ${{ event.git.sha }}
+
+base:
+  image: ubuntu:24.04
+  config: rwx/base 1.1.1
+
+tasks:
+  - key: code
+    call: git/clone 2.0.7
+    with:
+      repository: https://github.com/rwx-cloud/rwx.git
+      ref: ${{ init.ref }}
+
+  - key: build-def
+    use: code
+    run: cp .rwx/build.yml $RWX_ARTIFACTS/build-yml
+
+  - key: build-rwx-cli
+    call: ${{ tasks.build-def.artifacts.build-yml }}
+    init:
+      ref: ${{ init.ref }}
+
+  - key: rwx-cli
+    run: sudo install "$CLI_BINARY" /usr/local/bin
+    env:
+      CLI_BINARY: ${{ tasks.build-rwx-cli.tasks.build.artifacts.rwx }}
+
+  - key: test-runs-list
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      # Seed a run so the org has at least one to list, then exercise the listing.
+      kickoff=$(rwx run "$RUN_DEF" --json)
+      run_id=$(echo "$kickoff" | jq -r '.RunID')
+      run_url=$(echo "$kickoff" | jq -r '.RunURL // empty')
+      echo "$run_url" > "$RWX_LINKS/Run URL"
+
+      if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+        echo "Failed to get RunID from kickoff"
+        echo "$kickoff"
+        exit 1
+      fi
+
+      # JSON shape: PascalCase Runs array plus a Pagination envelope with the
+      # NextCursor and Limit keys (the convention rwx results --json shares).
+      list=$(rwx runs list --json)
+      if ! echo "$list" | jq -e '.Runs | type == "array"' >/dev/null; then
+        echo "Expected .Runs to be an array"
+        echo "$list"
+        exit 1
+      fi
+      if ! echo "$list" | jq -e '.Pagination | has("NextCursor") and has("Limit")' >/dev/null; then
+        echo "Expected .Pagination to have NextCursor and Limit"
+        echo "$list"
+        exit 1
+      fi
+
+      # The seeded run must show up in the listing.
+      if ! rwx runs list --limit 100 --json | jq -e --arg id "$run_id" '.Runs[].ID | select(. == $id)' >/dev/null; then
+        echo "Seeded run $run_id was not found in the listing"
+        rwx runs list --limit 100 --json
+        exit 1
+      fi
+
+      # --limit caps the page size and is echoed back in the pagination envelope.
+      page=$(rwx runs list --limit 1 --json)
+      count=$(echo "$page" | jq '.Runs | length')
+      limit=$(echo "$page" | jq '.Pagination.Limit')
+      if [ "$count" -gt 1 ]; then
+        echo "Expected at most 1 run with --limit 1, got $count"
+        echo "$page"
+        exit 1
+      fi
+      if [ "$limit" -ne 1 ]; then
+        echo "Expected Pagination.Limit 1, got $limit"
+        echo "$page"
+        exit 1
+      fi
+
+      # Cursor pagination: the next page must not repeat the first page's row.
+      cursor=$(echo "$page" | jq -r '.Pagination.NextCursor // empty')
+      if [ -n "$cursor" ]; then
+        first_id=$(echo "$page" | jq -r '.Runs[0].ID')
+        next_page=$(rwx runs list --limit 1 --cursor "$cursor" --json)
+        second_id=$(echo "$next_page" | jq -r '.Runs[0].ID // empty')
+        if [ -n "$second_id" ] && [ "$second_id" = "$first_id" ]; then
+          echo "Cursor page repeated the first row ($first_id)"
+          echo "$next_page"
+          exit 1
+        fi
+      fi
+
+      # Default (table) output carries the column header.
+      table=$(rwx runs list --limit 1)
+      if ! echo "$table" | grep -q "ID"; then
+        echo "Expected table output to include an ID column header"
+        echo "$table"
+        exit 1
+      fi
+      if ! echo "$table" | grep -q "STATUS"; then
+        echo "Expected table output to include a STATUS column header"
+        echo "$table"
+        exit 1
+      fi
+
+      # A malformed cursor surfaces a clean error and a non-zero exit.
+      exit_code=0
+      out=$(rwx runs list --cursor not-a-real-cursor 2>&1) || exit_code=$?
+      if [ "$exit_code" -eq 0 ]; then
+        echo "Expected a non-zero exit for a malformed cursor"
+        echo "$out"
+        exit 1
+      fi
+      if ! echo "$out" | grep -qi "Invalid cursor"; then
+        echo "Expected the malformed-cursor error to mention 'Invalid cursor'"
+        echo "$out"
+        exit 1
+      fi
+
+      # An invalid status filter is rejected by the server's structured 400.
+      exit_code=0
+      out=$(rwx runs list --result-status definitely-not-a-status 2>&1) || exit_code=$?
+      if [ "$exit_code" -eq 0 ]; then
+        echo "Expected a non-zero exit for an invalid --result-status"
+        echo "$out"
+        exit 1
+      fi
+      if ! echo "$out" | grep -q "result_status"; then
+        echo "Expected the invalid-status error to name the result_status filter"
+        echo "$out"
+        exit 1
+      fi
+    env:
+      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RUN_DEF: ${{ run.dir }}/integration/runs-list-test/passing.yml

--- a/.rwx/integration/runs-list-test/passing.yml
+++ b/.rwx/integration/runs-list-test/passing.yml
@@ -1,0 +1,7 @@
+base:
+  image: ubuntu:24.04
+  config: rwx/base 1.1.1
+
+tasks:
+  - key: hello
+    run: echo "hello from runs list test"

--- a/cmd/rwx/runs.go
+++ b/cmd/rwx/runs.go
@@ -51,6 +51,7 @@ func init() {
 	runsCmd.AddCommand(runsStartCmd)
 	runsCmd.AddCommand(runsGetCmd)
 	runsCmd.AddCommand(runsShowCmd)
+	runsCmd.AddCommand(runsListCmd)
 
 	rootCmd.AddCommand(runsCmd)
 }

--- a/cmd/rwx/runs_list.go
+++ b/cmd/rwx/runs_list.go
@@ -136,8 +136,8 @@ func runStatusLabel(status api.RunStatus) string {
 }
 
 func shortCommitSha(sha string) string {
-	if len(sha) > 8 {
-		return sha[:8]
+	if len(sha) > 7 {
+		return sha[:7]
 	}
 	return sha
 }

--- a/cmd/rwx/runs_list.go
+++ b/cmd/rwx/runs_list.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/cli"
+	"github.com/rwx-cloud/rwx/internal/text"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	RunsListRepositories      []string
+	RunsListBranches          []string
+	RunsListCommits           []string
+	RunsListDefinitions       []string
+	RunsListResultStatuses    []string
+	RunsListExecutionStatuses []string
+	RunsListMine              bool
+	RunsListLimit             int
+	RunsListCursor            string
+
+	runsListCmd = &cobra.Command{
+		Use:     "list [flags]",
+		Aliases: []string{"ls"},
+		Short:   "List runs",
+		Long: `List runs, most recent first.
+
+The default output is a table. Pass --json (or --format json) for the structured
+payload, which includes a NextCursor for deliberate paging.
+
+Results are paginated: the default page shows the most recent runs and --limit
+sets the page size (capped at 100). When more runs remain, pass the reported
+cursor to --cursor to fetch the next page.
+
+For a given run's full payload, run 'rwx results <id> --json'.`,
+		Args: cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return requireAccessToken()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			useJson := useJsonOutput()
+
+			result, err := service.ListRuns(cli.ListRunsConfig{
+				RepositoryNames:   RunsListRepositories,
+				Branches:          RunsListBranches,
+				CommitShas:        RunsListCommits,
+				DefinitionPaths:   RunsListDefinitions,
+				ResultStatuses:    RunsListResultStatuses,
+				ExecutionStatuses: RunsListExecutionStatuses,
+				MyRuns:            RunsListMine,
+				Limit:             RunsListLimit,
+				Cursor:            RunsListCursor,
+			})
+			if err != nil {
+				return err
+			}
+
+			// Open-ended filter near-misses come back on a successful (200)
+			// response, so they are a non-fatal hint on stderr rather than an error.
+			printRunFilterSuggestions(os.Stderr, result.Suggestions)
+
+			if useJson {
+				return printRunsJSON(result)
+			}
+
+			if len(result.Runs) == 0 {
+				fmt.Fprintln(os.Stdout, "No runs found.")
+				return nil
+			}
+
+			renderRunsTable(os.Stdout, result.Runs)
+			if result.Pagination.NextCursor != nil {
+				fmt.Fprintf(os.Stderr, "\nMore runs available. Fetch the next page with --cursor %s\n", *result.Pagination.NextCursor)
+			}
+
+			return nil
+		},
+	}
+)
+
+func init() {
+	// All filters are repeatable. StringSliceVar (not StringArrayVar) accepts both
+	// repeated flags (--branch a --branch b) and a comma-separated value
+	// (--branch a,b); a single value is sent in the scalar query-param form.
+	runsListCmd.Flags().StringSliceVar(&RunsListRepositories, "repository", nil, "filter by repository name, case-insensitive (repeatable)")
+	runsListCmd.Flags().StringSliceVar(&RunsListBranches, "branch", nil, "filter by branch name, case-insensitive (repeatable)")
+	runsListCmd.Flags().StringSliceVar(&RunsListCommits, "commit", nil, "filter by commit SHA (repeatable)")
+	runsListCmd.Flags().StringSliceVar(&RunsListDefinitions, "definition", nil, "filter by definition path (repeatable)")
+	runsListCmd.Flags().StringSliceVar(&RunsListResultStatuses, "result-status", nil, "filter by result status, repeatable: succeeded, debugged, sandboxed, failed, no_result")
+	runsListCmd.Flags().StringSliceVar(&RunsListExecutionStatuses, "execution-status", nil, "filter by execution status, repeatable: waiting, in_progress, finished, aborted")
+	runsListCmd.Flags().BoolVar(&RunsListMine, "mine", false, "only list runs you triggered")
+	runsListCmd.Flags().IntVar(&RunsListLimit, "limit", 0, "page size (max 100; server default applies when unset)")
+	runsListCmd.Flags().StringVar(&RunsListCursor, "cursor", "", "cursor for fetching the next page (from a prior result's NextCursor)")
+}
+
+// Title and branch are the most variable-length columns, so they are capped to
+// keep rows from overflowing the terminal; the rest are naturally short.
+const (
+	maxTitleWidth  = 40
+	maxBranchWidth = 24
+)
+
+func renderRunsTable(w io.Writer, runs []api.RunSummary) {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "TITLE\tID\tSTATUS\tREPO\tBRANCH\tCOMMIT\tDEFINITION\tCREATED")
+	for _, run := range runs {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			text.Truncate(run.Title, maxTitleWidth),
+			run.ID,
+			runStatusLabel(run.Status),
+			run.RepositoryName,
+			text.Truncate(run.Branch, maxBranchWidth),
+			shortCommitSha(run.CommitSha),
+			run.DefinitionPath,
+			derefString(run.CreatedAt),
+		)
+	}
+	tw.Flush()
+}
+
+// runStatusLabel collapses the nested status into one column: while a run is
+// still executing, its execution phase is the meaningful state; once finished,
+// the result is.
+func runStatusLabel(status api.RunStatus) string {
+	if status.Execution != "" && status.Execution != "finished" {
+		return status.Execution
+	}
+	return status.Result
+}
+
+func shortCommitSha(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// printRunsJSON emits the typed result with PascalCase keys, matching the casing
+// used by 'rwx results --output json' (see MergeEnrichedResults) so the two
+// interoperate.
+func printRunsJSON(result *api.ListRunsResult) error {
+	encoded, err := runsJSON(result)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(encoded))
+	return nil
+}
+
+// runsJSON rewrites the snake_case wire keys to PascalCase, matching the casing of
+// 'rwx results --output json'.
+func runsJSON(result *api.ListRunsResult) ([]byte, error) {
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+	var asMap map[string]any
+	if err := json.Unmarshal(encoded, &asMap); err != nil {
+		return nil, err
+	}
+	return json.Marshal(pascalCaseKeys(asMap))
+}
+
+func printRunFilterSuggestions(w io.Writer, suggestions map[string][]api.RunFilterSuggestion) {
+	for kind, entries := range suggestions {
+		for _, entry := range entries {
+			if len(entry.Suggestions) == 0 {
+				continue
+			}
+			fmt.Fprintf(w, "No exact match for %s %q. Did you mean: %s?\n",
+				strings.TrimSuffix(kind, "s"), entry.Value, strings.Join(entry.Suggestions, ", "))
+		}
+	}
+}

--- a/cmd/rwx/runs_list_test.go
+++ b/cmd/rwx/runs_list_test.go
@@ -42,7 +42,7 @@ func TestRenderRunsTable(t *testing.T) {
 	require.Contains(t, out, "CREATED")
 	require.Contains(t, out, "run-1")
 	require.Contains(t, out, "succeeded")
-	require.Contains(t, out, "abcdef12") // commit truncated to 8 chars
+	require.Contains(t, out, "abcdef1") // commit truncated to 7 chars
 	require.NotContains(t, out, "abcdef1234567890")
 	require.Contains(t, out, "2026-06-23T12:00:00Z")
 }

--- a/cmd/rwx/runs_list_test.go
+++ b/cmd/rwx/runs_list_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunsListIsRegistered(t *testing.T) {
+	listCmd := findSubcommand(runsCmd, "list")
+	require.NotNil(t, listCmd, "rwx runs list should exist")
+	require.False(t, listCmd.Hidden, "list is a real action and should be visible")
+	require.Contains(t, listCmd.Aliases, "ls")
+
+	for _, name := range []string{"repository", "branch", "commit", "definition", "result-status", "execution-status", "mine", "limit", "cursor"} {
+		require.NotNil(t, listCmd.Flags().Lookup(name), "list should expose the --%s flag", name)
+	}
+}
+
+func TestRenderRunsTable(t *testing.T) {
+	created := "2026-06-23T12:00:00Z"
+	var buf bytes.Buffer
+	renderRunsTable(&buf, []api.RunSummary{
+		{
+			ID:             "run-1",
+			Status:         api.RunStatus{Result: "succeeded", Execution: "finished"},
+			RepositoryName: "rwx-cloud/cloud",
+			Branch:         "main",
+			CommitSha:      "abcdef1234567890",
+			DefinitionPath: ".rwx/ci.yml",
+			Title:          "CI",
+			CreatedAt:      &created,
+		},
+	})
+
+	out := buf.String()
+	require.Contains(t, out, "ID")
+	require.Contains(t, out, "STATUS")
+	require.Contains(t, out, "CREATED")
+	require.Contains(t, out, "run-1")
+	require.Contains(t, out, "succeeded")
+	require.Contains(t, out, "abcdef12") // commit truncated to 8 chars
+	require.NotContains(t, out, "abcdef1234567890")
+	require.Contains(t, out, "2026-06-23T12:00:00Z")
+}
+
+func TestRenderRunsTableTruncatesTitleAndBranch(t *testing.T) {
+	longTitle := "This is an extremely long run title that should be truncated in the table"
+	longBranch := "feature/some-really-long-branch-name-that-overflows"
+	var buf bytes.Buffer
+	renderRunsTable(&buf, []api.RunSummary{
+		{ID: "run-1", Title: longTitle, Branch: longBranch},
+	})
+
+	out := buf.String()
+	require.NotContains(t, out, longTitle)
+	require.NotContains(t, out, longBranch)
+	require.Contains(t, out, "…")
+	// The truncated cells keep their leading content.
+	require.Contains(t, out, "This is an extremely long run title")
+	require.Contains(t, out, "feature/some-really")
+}
+
+func TestRunStatusLabel(t *testing.T) {
+	// While executing, the execution phase is the meaningful state.
+	require.Equal(t, "in_progress", runStatusLabel(api.RunStatus{Result: "no_result", Execution: "in_progress"}))
+	// Once finished, the result is.
+	require.Equal(t, "succeeded", runStatusLabel(api.RunStatus{Result: "succeeded", Execution: "finished"}))
+}
+
+func TestRunsJSONUsesPascalCaseAndIncludesNextCursor(t *testing.T) {
+	next := "next-cursor"
+	encoded, err := runsJSON(&api.ListRunsResult{
+		Runs: []api.RunSummary{
+			{
+				ID:             "run-1",
+				Status:         api.RunStatus{Result: "succeeded", Execution: "finished"},
+				RepositoryName: "rwx-cloud/cloud",
+				RunURL:         "https://cloud.rwx.com/runs/run-1",
+			},
+		},
+		Pagination: api.ListRunsPagination{NextCursor: &next, Limit: 50},
+	})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+
+	runs, ok := decoded["Runs"].([]any)
+	require.True(t, ok, "expected PascalCase Runs key")
+	run := runs[0].(map[string]any)
+	require.Equal(t, "run-1", run["ID"])
+	require.Equal(t, "rwx-cloud/cloud", run["RepositoryName"])
+	// pascalCaseKeys only treats "id" as an initialism, so run_url -> RunUrl. This
+	// matches the casing 'rwx results --output json' emits via the same helper;
+	// pin it so the shared convention can't drift unnoticed.
+	require.Equal(t, "https://cloud.rwx.com/runs/run-1", run["RunUrl"])
+	status := run["Status"].(map[string]any)
+	require.Equal(t, "succeeded", status["Result"])
+	require.Equal(t, "finished", status["Execution"])
+
+	pagination := decoded["Pagination"].(map[string]any)
+	require.Equal(t, "next-cursor", pagination["NextCursor"])
+}
+
+func TestPrintRunFilterSuggestions(t *testing.T) {
+	var buf bytes.Buffer
+	printRunFilterSuggestions(&buf, map[string][]api.RunFilterSuggestion{
+		"branch_names": {{Value: "develp", Suggestions: []string{"develop"}}},
+	})
+
+	out := buf.String()
+	require.Contains(t, out, "develp")
+	require.Contains(t, out, "develop")
+}

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -975,11 +975,11 @@ func TestAPIClient_RunStatus(t *testing.T) {
 	t.Run("parses the response when run is in progress", func(t *testing.T) {
 		backoffMs := 2000
 		body := struct {
-			Status  *api.RunStatus    `json:"run_status"`
-			RunID   string            `json:"run_id"`
-			Polling api.PollingResult `json:"polling"`
+			Status  *api.PollingRunStatus `json:"run_status"`
+			RunID   string                `json:"run_id"`
+			Polling api.PollingResult     `json:"polling"`
 		}{
-			Status:  &api.RunStatus{Result: ""},
+			Status:  &api.PollingRunStatus{Result: ""},
 			RunID:   "run-123",
 			Polling: api.PollingResult{Completed: false, BackoffMs: &backoffMs},
 		}
@@ -1011,10 +1011,10 @@ func TestAPIClient_RunStatus(t *testing.T) {
 
 	t.Run("sends fail_fast as false by default", func(t *testing.T) {
 		body := struct {
-			Status  *api.RunStatus    `json:"run_status"`
-			Polling api.PollingResult `json:"polling"`
+			Status  *api.PollingRunStatus `json:"run_status"`
+			Polling api.PollingResult     `json:"polling"`
 		}{
-			Status:  &api.RunStatus{Result: "succeeded"},
+			Status:  &api.PollingRunStatus{Result: "succeeded"},
 			Polling: api.PollingResult{Completed: true},
 		}
 		bodyBytes, _ := json.Marshal(body)
@@ -1036,11 +1036,11 @@ func TestAPIClient_RunStatus(t *testing.T) {
 
 	t.Run("parses the response when run is completed", func(t *testing.T) {
 		body := struct {
-			Status  *api.RunStatus    `json:"run_status"`
-			RunID   string            `json:"run_id"`
-			Polling api.PollingResult `json:"polling"`
+			Status  *api.PollingRunStatus `json:"run_status"`
+			RunID   string                `json:"run_id"`
+			Polling api.PollingResult     `json:"polling"`
 		}{
-			Status:  &api.RunStatus{Result: "succeeded"},
+			Status:  &api.PollingRunStatus{Result: "succeeded"},
 			RunID:   "run-456",
 			Polling: api.PollingResult{Completed: true},
 		}
@@ -1070,8 +1070,8 @@ func TestAPIClient_RunStatus(t *testing.T) {
 
 	t.Run("parses the response when run is not found", func(t *testing.T) {
 		body := struct {
-			Status  *api.RunStatus    `json:"run_status"`
-			Polling api.PollingResult `json:"polling"`
+			Status  *api.PollingRunStatus `json:"run_status"`
+			Polling api.PollingResult     `json:"polling"`
 		}{
 			Status:  nil,
 			Polling: api.PollingResult{Completed: true},

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -365,19 +365,24 @@ type RunDetailsConfig struct {
 	TaskKey string
 }
 
-type RunStatus struct {
+// PollingRunStatus is the minimal status object returned by the results
+// status/latest polling endpoint (keyed `run_status`); the CLI reads only the
+// result from it. It is intentionally a separate type from the richer shared
+// RunStatus returned by the runs index and results details, whose status object
+// has a different shape.
+type PollingRunStatus struct {
 	Result string `json:"result"`
 }
 
 type RunStatusResult struct {
-	Status     *RunStatus    `json:"run_status,omitempty"`
-	TaskStatus *TaskStatus   `json:"task_status,omitempty"`
-	RunID      string        `json:"run_id,omitempty"`
-	RunURL     string        `json:"run_url,omitempty"`
-	TaskID     string        `json:"task_id,omitempty"`
-	TaskURL    string        `json:"task_url,omitempty"`
-	Commit     *string       `json:"commit_sha,omitempty"`
-	Polling    PollingResult `json:"polling"`
+	Status     *PollingRunStatus `json:"run_status,omitempty"`
+	TaskStatus *TaskStatus       `json:"task_status,omitempty"`
+	RunID      string            `json:"run_id,omitempty"`
+	RunURL     string            `json:"run_url,omitempty"`
+	TaskID     string            `json:"task_id,omitempty"`
+	TaskURL    string            `json:"task_url,omitempty"`
+	Commit     *string           `json:"commit_sha,omitempty"`
+	Polling    PollingResult     `json:"polling"`
 }
 
 type AmbiguousTaskKeyError struct {
@@ -419,6 +424,78 @@ type SandboxRunSummary struct {
 
 type ListSandboxRunsResult struct {
 	Runs []SandboxRunSummary `json:"runs"`
+}
+
+// RunStatus is the shared status object returned by both the runs index (under
+// `status`) and results details, where the two are kept identical. The CLI
+// prefers this nested object over the legacy flat status fields in the payload.
+type RunStatus struct {
+	Result            string `json:"result"`
+	Execution         string `json:"execution"`
+	WaitingSubStatus  string `json:"waiting_sub_status"`
+	AbortedSubStatus  string `json:"aborted_sub_status"`
+	FinishedSubStatus string `json:"finished_sub_status"`
+}
+
+// RunSummary is one entry of the runs index payload.
+type RunSummary struct {
+	ID                      string    `json:"id"`
+	Status                  RunStatus `json:"status"`
+	StartedAt               *string   `json:"started_at"`
+	CompletedAt             *string   `json:"completed_at"`
+	CreatedAt               *string   `json:"created_at"`
+	CompletedRuntimeSeconds *float64  `json:"completed_runtime_seconds"`
+	RepositoryName          string    `json:"repository_name"`
+	Branch                  string    `json:"branch"`
+	Tag                     *string   `json:"tag"`
+	CommitSha               string    `json:"commit_sha"`
+	DefinitionPath          string    `json:"definition_path"`
+	Trigger                 string    `json:"trigger"`
+	Title                   string    `json:"title"`
+	RunURL                  string    `json:"run_url"`
+	// CliState is only populated for requests made by the RWX CLI, so it is optional.
+	CliState *string `json:"cli_state,omitempty"`
+}
+
+// ListRunsPagination is the keyset-pagination envelope from the index. NextCursor
+// is nil on the final page; Limit echoes the server-applied page size.
+type ListRunsPagination struct {
+	NextCursor *string `json:"next_cursor"`
+	Limit      int     `json:"limit"`
+}
+
+// RunFilterSuggestion is a near-miss hint for an open-ended filter value on a
+// successful (200) response. Distinct from RunFilterValidationEntry (the 400
+// status-filter error leaf): `suggestions` here is a list, and there is no
+// `valid_values` because the filter dictionary is open-ended.
+type RunFilterSuggestion struct {
+	Value       string   `json:"value"`
+	Suggestions []string `json:"suggestions"`
+}
+
+// ListRunsResult is the decoded runs index response. Suggestions is keyed by the
+// plural filter name (e.g. "branch_names") and is omitted when there is no
+// near-miss; it is non-fatal and may appear even when Runs is non-empty.
+type ListRunsResult struct {
+	Runs        []RunSummary                     `json:"runs"`
+	Pagination  ListRunsPagination               `json:"pagination"`
+	Suggestions map[string][]RunFilterSuggestion `json:"suggestions,omitempty"`
+}
+
+// ListRunsConfig holds the runs index filters plus pagination. Status values are
+// intentionally not validated client-side: the server owns the enum and returns a
+// structured 400 (with the valid values and a suggested correction) on a bad
+// value, so the CLI keeps no copy of the set that could drift out of sync.
+type ListRunsConfig struct {
+	RepositoryNames   []string
+	Branches          []string
+	CommitShas        []string
+	DefinitionPaths   []string
+	ResultStatuses    []string
+	ExecutionStatuses []string
+	MyRuns            bool
+	Limit             int
+	Cursor            string
 }
 
 type CreateSandboxTokenConfig struct {

--- a/internal/api/runs.go
+++ b/internal/api/runs.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/rwx-cloud/rwx/internal/errors"
+)
+
+// RunFilterValidationEntry is one leaf of the structured 400 returned when a
+// closed-enum status filter has an unknown value. SuggestedValue is the single
+// best correction (nil for gibberish), distinct from the soft-200
+// RunFilterSuggestion leaf whose `suggestions` is a list.
+type RunFilterValidationEntry struct {
+	Key            string   `json:"key"`
+	ProvidedValue  string   `json:"provided_value"`
+	SuggestedValue *string  `json:"suggested_value"`
+	ValidValues    []string `json:"valid_values"`
+}
+
+// InvalidRunFilterError wraps the structured 400 body so the command can render
+// a "did you mean" hint per entry, falling back to the valid set when the server
+// has no single suggestion.
+type InvalidRunFilterError struct {
+	Entries []RunFilterValidationEntry
+}
+
+func (e *InvalidRunFilterError) Error() string {
+	var b strings.Builder
+	b.WriteString("invalid run filter:")
+	for _, entry := range e.Entries {
+		b.WriteString(fmt.Sprintf("\n  %s %q is not valid", entry.Key, entry.ProvidedValue))
+		if entry.SuggestedValue != nil && *entry.SuggestedValue != "" {
+			b.WriteString(fmt.Sprintf(" (did you mean %q?)", *entry.SuggestedValue))
+		} else if len(entry.ValidValues) > 0 {
+			b.WriteString(fmt.Sprintf(" (valid: %s)", strings.Join(entry.ValidValues, ", ")))
+		}
+	}
+	return b.String()
+}
+
+func (e *InvalidRunFilterError) Unwrap() error {
+	return errors.ErrBadRequest
+}
+
+// RateLimitedError surfaces a 429 from the runs index. The server replies with an
+// empty body, so the CLI synthesizes its own message from the Retry-After window.
+type RateLimitedError struct {
+	RetryAfterSeconds int
+}
+
+func (e *RateLimitedError) Error() string {
+	if e.RetryAfterSeconds > 0 {
+		return fmt.Sprintf("rate limited by RWX (100 requests/min). Retry after %d seconds.", e.RetryAfterSeconds)
+	}
+	return "rate limited by RWX (100 requests/min). Please retry shortly."
+}
+
+// queryParams maps the config onto the index's accepted parameters. Each filter
+// is sent in the scalar form for a lone value and the plural `[]` form once there
+// is more than one.
+func (c ListRunsConfig) queryParams() url.Values {
+	params := url.Values{}
+
+	setFilterParam(params, "repository_name", "repository_names[]", c.RepositoryNames)
+	setFilterParam(params, "branch", "branch_names[]", c.Branches)
+	setFilterParam(params, "commit_sha", "commit_shas[]", c.CommitShas)
+	setFilterParam(params, "definition_path", "definition_paths[]", c.DefinitionPaths)
+	setFilterParam(params, "result_status", "result_statuses[]", c.ResultStatuses)
+	setFilterParam(params, "execution_status", "execution_statuses[]", c.ExecutionStatuses)
+
+	if c.MyRuns {
+		params.Set("my_runs", "true")
+	}
+	if c.Limit > 0 {
+		params.Set("limit", strconv.Itoa(c.Limit))
+	}
+	if c.Cursor != "" {
+		params.Set("cursor", c.Cursor)
+	}
+
+	return params
+}
+
+func setFilterParam(params url.Values, scalarKey, pluralKey string, values []string) {
+	switch len(values) {
+	case 0:
+		return
+	case 1:
+		params.Set(scalarKey, values[0])
+	default:
+		for _, value := range values {
+			params.Add(pluralKey, value)
+		}
+	}
+}
+
+func (c Client) ListRuns(cfg ListRunsConfig) (*ListRunsResult, error) {
+	endpoint := "/mint/api/runs?" + cfg.queryParams().Encode()
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create new HTTP request")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.RoundTrip(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "HTTP request failed")
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		result := ListRunsResult{}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return nil, errors.Wrap(err, "unable to parse API response")
+		}
+		return &result, nil
+	case http.StatusBadRequest:
+		return nil, parseInvalidRunFilterError(resp.Body)
+	case http.StatusTooManyRequests:
+		// The 429 body is empty; Retry-After carries the window in seconds.
+		retryAfter, _ := strconv.Atoi(resp.Header.Get("Retry-After"))
+		return nil, &RateLimitedError{RetryAfterSeconds: retryAfter}
+	default:
+		msg := extractErrorMessage(resp.Body)
+		if msg == "" {
+			msg = fmt.Sprintf("Unable to call RWX API - %s", resp.Status)
+		}
+		return nil, classifyHTTPStatusError(resp.StatusCode, msg)
+	}
+}
+
+// parseInvalidRunFilterError handles both 400 shapes from the index: the
+// structured status-filter body ({"errors": [...]}) and the malformed-cursor body
+// ({"error": "Invalid cursor"}).
+func parseInvalidRunFilterError(body io.Reader) error {
+	bodyBytes, readErr := io.ReadAll(body)
+	if readErr != nil {
+		return errors.Wrap(errors.ErrBadRequest, "Unable to call RWX API - 400 Bad Request")
+	}
+
+	structured := struct {
+		Errors []RunFilterValidationEntry `json:"errors"`
+	}{}
+	if err := json.Unmarshal(bodyBytes, &structured); err == nil && len(structured.Errors) > 0 {
+		return &InvalidRunFilterError{Entries: structured.Errors}
+	}
+
+	msg := extractErrorMessage(strings.NewReader(string(bodyBytes)))
+	if msg == "" {
+		msg = "Unable to call RWX API - 400 Bad Request"
+	}
+	return errors.Wrap(errors.ErrBadRequest, msg)
+}

--- a/internal/api/runs_test.go
+++ b/internal/api/runs_test.go
@@ -1,0 +1,286 @@
+package api_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func jsonBody(t *testing.T, v any) io.ReadCloser {
+	t.Helper()
+	encoded, err := json.Marshal(v)
+	require.NoError(t, err)
+	return io.NopCloser(strings.NewReader(string(encoded)))
+}
+
+func TestAPIClient_ListRuns(t *testing.T) {
+	t.Run("maps single-valued filters onto scalar params", func(t *testing.T) {
+		var captured *http.Request
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			captured = req
+			return &http.Response{
+				StatusCode: 200,
+				Body:       jsonBody(t, api.ListRunsResult{Runs: []api.RunSummary{}}),
+			}, nil
+		})
+
+		_, err := c.ListRuns(api.ListRunsConfig{
+			RepositoryNames: []string{"rwx-cloud/cloud"},
+			Branches:        []string{"main"},
+			CommitShas:      []string{"abc123"},
+			DefinitionPaths: []string{".rwx/ci.yml"},
+			MyRuns:          true,
+			Limit:           25,
+			Cursor:          "cursor-token",
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, "/mint/api/runs", captured.URL.Path)
+		query := captured.URL.Query()
+		require.Equal(t, "rwx-cloud/cloud", query.Get("repository_name"))
+		require.Equal(t, "main", query.Get("branch"))
+		require.Equal(t, "abc123", query.Get("commit_sha"))
+		require.Equal(t, ".rwx/ci.yml", query.Get("definition_path"))
+		require.Equal(t, "true", query.Get("my_runs"))
+		require.Equal(t, "25", query.Get("limit"))
+		require.Equal(t, "cursor-token", query.Get("cursor"))
+	})
+
+	t.Run("uses the scalar param for a lone filter value", func(t *testing.T) {
+		var captured *http.Request
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			captured = req
+			return &http.Response{StatusCode: 200, Body: jsonBody(t, api.ListRunsResult{})}, nil
+		})
+
+		_, err := c.ListRuns(api.ListRunsConfig{
+			Branches:       []string{"main"},
+			ResultStatuses: []string{"succeeded"},
+		})
+		require.NoError(t, err)
+
+		query := captured.URL.Query()
+		require.Equal(t, "main", query.Get("branch"))
+		require.Equal(t, "succeeded", query.Get("result_status"))
+		require.Empty(t, query["branch_names[]"])
+		require.Empty(t, query["result_statuses[]"])
+	})
+
+	t.Run("uses the plural param when a filter has multiple values", func(t *testing.T) {
+		var captured *http.Request
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			captured = req
+			return &http.Response{StatusCode: 200, Body: jsonBody(t, api.ListRunsResult{})}, nil
+		})
+
+		_, err := c.ListRuns(api.ListRunsConfig{
+			Branches:       []string{"main", "develop"},
+			ResultStatuses: []string{"succeeded", "failed"},
+		})
+		require.NoError(t, err)
+
+		query := captured.URL.Query()
+		require.Equal(t, []string{"main", "develop"}, query["branch_names[]"])
+		require.Empty(t, query.Get("branch"))
+		require.Equal(t, []string{"succeeded", "failed"}, query["result_statuses[]"])
+		require.Empty(t, query.Get("result_status"))
+	})
+
+	t.Run("decodes runs, nested status, and pagination", func(t *testing.T) {
+		next := "next-page-cursor"
+		tag := "v1.2.3"
+		body := api.ListRunsResult{
+			Runs: []api.RunSummary{
+				{
+					ID:             "run-1",
+					Status:         api.RunStatus{Result: "succeeded", Execution: "finished", FinishedSubStatus: "not_applicable"},
+					RepositoryName: "rwx-cloud/cloud",
+					Branch:         "main",
+					Tag:            &tag,
+					CommitSha:      "abcdef1234567890",
+					DefinitionPath: ".rwx/ci.yml",
+					Trigger:        "github",
+					Title:          "CI",
+					RunURL:         "https://cloud.rwx.com/runs/run-1",
+				},
+			},
+			Pagination: api.ListRunsPagination{NextCursor: &next, Limit: 50},
+		}
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 200, Body: jsonBody(t, body)}, nil
+		})
+
+		result, err := c.ListRuns(api.ListRunsConfig{})
+		require.NoError(t, err)
+		require.Len(t, result.Runs, 1)
+		require.Equal(t, "run-1", result.Runs[0].ID)
+		require.Equal(t, "succeeded", result.Runs[0].Status.Result)
+		require.Equal(t, "finished", result.Runs[0].Status.Execution)
+		require.NotNil(t, result.Pagination.NextCursor)
+		require.Equal(t, "next-page-cursor", *result.Pagination.NextCursor)
+		require.Equal(t, 50, result.Pagination.Limit)
+	})
+
+	t.Run("represents the final page with a nil next cursor", func(t *testing.T) {
+		raw := `{"runs":[],"pagination":{"next_cursor":null,"limit":50}}`
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(raw))}, nil
+		})
+
+		result, err := c.ListRuns(api.ListRunsConfig{})
+		require.NoError(t, err)
+		require.Nil(t, result.Pagination.NextCursor)
+		require.Equal(t, 50, result.Pagination.Limit)
+	})
+
+	t.Run("surfaces a 200 suggestions envelope without erroring", func(t *testing.T) {
+		raw := `{"runs":[{"id":"run-1","status":{"result":"succeeded"}}],` +
+			`"pagination":{"next_cursor":null,"limit":50},` +
+			`"suggestions":{"branch_names":[{"value":"develp","suggestions":["develop"]}]}}`
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(raw))}, nil
+		})
+
+		result, err := c.ListRuns(api.ListRunsConfig{})
+		require.NoError(t, err)
+		// Suggestions can ride along with a non-empty runs list.
+		require.Len(t, result.Runs, 1)
+		require.Len(t, result.Suggestions["branch_names"], 1)
+		require.Equal(t, "develp", result.Suggestions["branch_names"][0].Value)
+		require.Equal(t, []string{"develop"}, result.Suggestions["branch_names"][0].Suggestions)
+	})
+
+	t.Run("parses the structured 400 invalid-status body into a typed error", func(t *testing.T) {
+		raw := `{"errors":[{"key":"result_status","provided_value":"succeded",` +
+			`"suggested_value":"succeeded","valid_values":["succeeded","debugged","sandboxed","failed","no_result"]}]}`
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{Status: "400 Bad Request", StatusCode: 400, Body: io.NopCloser(strings.NewReader(raw))}, nil
+		})
+
+		_, err := c.ListRuns(api.ListRunsConfig{ResultStatuses: []string{"succeded"}})
+		require.Error(t, err)
+
+		var filterErr *api.InvalidRunFilterError
+		require.True(t, errors.As(err, &filterErr))
+		require.Len(t, filterErr.Entries, 1)
+		require.Equal(t, "result_status", filterErr.Entries[0].Key)
+		require.Equal(t, "succeded", filterErr.Entries[0].ProvidedValue)
+		require.NotNil(t, filterErr.Entries[0].SuggestedValue)
+		require.Equal(t, "succeeded", *filterErr.Entries[0].SuggestedValue)
+		require.Contains(t, err.Error(), "did you mean")
+		require.True(t, errors.Is(err, errors.ErrBadRequest))
+	})
+
+	t.Run("falls back to valid_values when the 400 suggestion is null", func(t *testing.T) {
+		raw := `{"errors":[{"key":"execution_status","provided_value":"zzz",` +
+			`"suggested_value":null,"valid_values":["waiting","in_progress","finished","aborted"]}]}`
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{Status: "400 Bad Request", StatusCode: 400, Body: io.NopCloser(strings.NewReader(raw))}, nil
+		})
+
+		_, err := c.ListRuns(api.ListRunsConfig{})
+		require.Error(t, err)
+		var filterErr *api.InvalidRunFilterError
+		require.True(t, errors.As(err, &filterErr))
+		require.Nil(t, filterErr.Entries[0].SuggestedValue)
+		require.Contains(t, err.Error(), "valid:")
+		require.Contains(t, err.Error(), "waiting")
+	})
+
+	t.Run("handles the malformed-cursor 400 body", func(t *testing.T) {
+		raw := `{"error":"Invalid cursor"}`
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{Status: "400 Bad Request", StatusCode: 400, Body: io.NopCloser(strings.NewReader(raw))}, nil
+		})
+
+		_, err := c.ListRuns(api.ListRunsConfig{Cursor: "bogus"})
+		require.Error(t, err)
+		var filterErr *api.InvalidRunFilterError
+		require.False(t, errors.As(err, &filterErr), "a bad cursor is not a filter validation error")
+		require.True(t, errors.Is(err, errors.ErrBadRequest))
+		require.Contains(t, err.Error(), "Invalid cursor")
+	})
+
+	t.Run("sends status filters as-is, leaving enum validation to the server", func(t *testing.T) {
+		var captured *http.Request
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			captured = req
+			return &http.Response{StatusCode: 200, Body: jsonBody(t, api.ListRunsResult{})}, nil
+		})
+
+		// An unknown value is not rejected client-side; it reaches the server, which
+		// owns the enum and answers with a structured 400 (exercised above).
+		_, err := c.ListRuns(api.ListRunsConfig{ResultStatuses: []string{"succeded"}})
+		require.NoError(t, err)
+		require.Equal(t, "succeded", captured.URL.Query().Get("result_status"))
+	})
+
+	t.Run("synthesizes an actionable message from a 429 with Retry-After", func(t *testing.T) {
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			header := http.Header{}
+			header.Set("Retry-After", "60")
+			return &http.Response{
+				Status:     "429 Too Many Requests",
+				StatusCode: 429,
+				Header:     header,
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		})
+
+		_, err := c.ListRuns(api.ListRunsConfig{})
+		require.Error(t, err)
+		var rateErr *api.RateLimitedError
+		require.True(t, errors.As(err, &rateErr))
+		require.Equal(t, 60, rateErr.RetryAfterSeconds)
+		require.Contains(t, err.Error(), "60 seconds")
+	})
+}
+
+// TestRunStatus_StatusHashShape pins the shared RunStatus to the status_hash shape
+// emitted by both the runs index `status` and results details, and guards against
+// regressing onto the divergent `runs#show` `run_status` shape.
+func TestRunStatus_StatusHashShape(t *testing.T) {
+	t.Run("deserializes the status_hash keys", func(t *testing.T) {
+		raw := `{
+			"result": "succeeded",
+			"execution": "finished",
+			"waiting_sub_status": "not_applicable",
+			"aborted_sub_status": "not_applicable",
+			"finished_sub_status": "not_applicable"
+		}`
+		var status api.RunStatus
+		require.NoError(t, json.Unmarshal([]byte(raw), &status))
+		require.Equal(t, "succeeded", status.Result)
+		require.Equal(t, "finished", status.Execution)
+		require.Equal(t, "not_applicable", status.WaitingSubStatus)
+		require.Equal(t, "not_applicable", status.AbortedSubStatus)
+		require.Equal(t, "not_applicable", status.FinishedSubStatus)
+	})
+
+	t.Run("does not absorb the divergent runs#show run_status keys", func(t *testing.T) {
+		// `runs#show` uses *_status (not *_sub_status) plus extra fields; none of
+		// those should populate the shared status_hash type.
+		raw := `{
+			"result": "succeeded",
+			"execution": "finished",
+			"predicted_result": "succeeded",
+			"waiting_status": "leaked",
+			"aborted_status": "leaked",
+			"finished_status": "leaked",
+			"cancelation_requested?": false
+		}`
+		var status api.RunStatus
+		require.NoError(t, json.Unmarshal([]byte(raw), &status))
+		require.Equal(t, "succeeded", status.Result)
+		require.Equal(t, "finished", status.Execution)
+		require.Empty(t, status.WaitingSubStatus)
+		require.Empty(t, status.AbortedSubStatus)
+		require.Empty(t, status.FinishedSubStatus)
+	})
+}

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -41,6 +41,7 @@ type APIClient interface {
 	TaskIDStatus(api.TaskIDStatusConfig) (api.TaskStatusResult, error)
 	RunStatus(api.RunStatusConfig) (api.RunStatusResult, error)
 	GetRunDetails(api.RunDetailsConfig) (map[string]any, error)
+	ListRuns(api.ListRunsConfig) (*api.ListRunsResult, error)
 	GetLogDownloadRequest(taskId string) (api.LogDownloadRequestResult, error)
 	GetLogDownloadRequestByTaskKey(runID, taskKey string) (api.LogDownloadRequestResult, error)
 	DownloadLogs(api.LogDownloadRequestResult, ...int) ([]byte, error)

--- a/internal/cli/service_runs.go
+++ b/internal/cli/service_runs.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"github.com/rwx-cloud/rwx/internal/api"
+)
+
+type ListRunsConfig struct {
+	RepositoryNames   []string
+	Branches          []string
+	CommitShas        []string
+	DefinitionPaths   []string
+	ResultStatuses    []string
+	ExecutionStatuses []string
+	MyRuns            bool
+	Limit             int
+	Cursor            string
+}
+
+func (s Service) ListRuns(cfg ListRunsConfig) (*api.ListRunsResult, error) {
+	return s.APIClient.ListRuns(api.ListRunsConfig{
+		RepositoryNames:   cfg.RepositoryNames,
+		Branches:          cfg.Branches,
+		CommitShas:        cfg.CommitShas,
+		DefinitionPaths:   cfg.DefinitionPaths,
+		ResultStatuses:    cfg.ResultStatuses,
+		ExecutionStatuses: cfg.ExecutionStatuses,
+		MyRuns:            cfg.MyRuns,
+		Limit:             cfg.Limit,
+		Cursor:            cfg.Cursor,
+	})
+}

--- a/internal/cli/service_runs_test.go
+++ b/internal/cli/service_runs_test.go
@@ -1,0 +1,57 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/cli"
+	"github.com/rwx-cloud/rwx/internal/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_ListRuns(t *testing.T) {
+	t.Run("passes filters through to the API and returns the result", func(t *testing.T) {
+		setup := setupTest(t)
+
+		next := "cursor-2"
+		setup.mockAPI.MockListRuns = func(cfg api.ListRunsConfig) (*api.ListRunsResult, error) {
+			require.Equal(t, []string{"rwx-cloud/cloud"}, cfg.RepositoryNames)
+			require.Equal(t, []string{"main", "develop"}, cfg.Branches)
+			require.Equal(t, []string{"succeeded", "failed"}, cfg.ResultStatuses)
+			require.True(t, cfg.MyRuns)
+			require.Equal(t, 10, cfg.Limit)
+			require.Equal(t, "cursor-1", cfg.Cursor)
+			return &api.ListRunsResult{
+				Runs:       []api.RunSummary{{ID: "run-1"}},
+				Pagination: api.ListRunsPagination{NextCursor: &next, Limit: 10},
+			}, nil
+		}
+
+		result, err := setup.service.ListRuns(cli.ListRunsConfig{
+			RepositoryNames: []string{"rwx-cloud/cloud"},
+			Branches:        []string{"main", "develop"},
+			ResultStatuses:  []string{"succeeded", "failed"},
+			MyRuns:          true,
+			Limit:           10,
+			Cursor:          "cursor-1",
+		})
+
+		require.NoError(t, err)
+		require.Len(t, result.Runs, 1)
+		require.Equal(t, "run-1", result.Runs[0].ID)
+		require.Equal(t, "cursor-2", *result.Pagination.NextCursor)
+	})
+
+	t.Run("propagates an API error", func(t *testing.T) {
+		setup := setupTest(t)
+
+		setup.mockAPI.MockListRuns = func(cfg api.ListRunsConfig) (*api.ListRunsResult, error) {
+			return nil, errors.New("boom")
+		}
+
+		result, err := setup.service.ListRuns(cli.ListRunsConfig{})
+
+		require.Nil(t, result)
+		require.Error(t, err)
+	})
+}

--- a/internal/cli/service_telemetry_test.go
+++ b/internal/cli/service_telemetry_test.go
@@ -1060,7 +1060,7 @@ func TestTelemetry_RunComplete(t *testing.T) {
 			return api.RunStatusResult{
 				RunID:  "run-complete-123",
 				RunURL: "https://cloud.rwx.com/runs/run-complete-123",
-				Status: &api.RunStatus{Result: "succeeded"},
+				Status: &api.PollingRunStatus{Result: "succeeded"},
 				Polling: api.PollingResult{
 					Completed: true,
 				},
@@ -1092,7 +1092,7 @@ func TestTelemetry_RunComplete(t *testing.T) {
 			return api.RunStatusResult{
 				RunID:  "run-pending-123",
 				RunURL: "https://cloud.rwx.com/runs/run-pending-123",
-				Status: &api.RunStatus{Result: "running"},
+				Status: &api.PollingRunStatus{Result: "running"},
 				Polling: api.PollingResult{
 					Completed: false,
 				},

--- a/internal/cli/service_wait_test.go
+++ b/internal/cli/service_wait_test.go
@@ -15,7 +15,7 @@ func TestService_GetRunStatus(t *testing.T) {
 		setup.mockAPI.MockRunStatus = func(cfg api.RunStatusConfig) (api.RunStatusResult, error) {
 			require.Equal(t, "run-123", cfg.RunID)
 			return api.RunStatusResult{
-				Status:  &api.RunStatus{Result: "succeeded"},
+				Status:  &api.PollingRunStatus{Result: "succeeded"},
 				RunID:   "run-123",
 				Polling: api.PollingResult{Completed: true},
 			}, nil
@@ -39,7 +39,7 @@ func TestService_GetRunStatus(t *testing.T) {
 		setup.mockAPI.MockRunStatus = func(cfg api.RunStatusConfig) (api.RunStatusResult, error) {
 			require.True(t, cfg.FailFast)
 			return api.RunStatusResult{
-				Status:  &api.RunStatus{Result: "failed"},
+				Status:  &api.PollingRunStatus{Result: "failed"},
 				RunID:   "run-123",
 				Polling: api.PollingResult{Completed: true},
 			}, nil
@@ -65,13 +65,13 @@ func TestService_GetRunStatus(t *testing.T) {
 			callCount++
 			if callCount < 3 {
 				return api.RunStatusResult{
-					Status:  &api.RunStatus{Result: "in_progress"},
+					Status:  &api.PollingRunStatus{Result: "in_progress"},
 					RunID:   "run-456",
 					Polling: api.PollingResult{Completed: false, BackoffMs: &backoffMs},
 				}, nil
 			}
 			return api.RunStatusResult{
-				Status:  &api.RunStatus{Result: "failed"},
+				Status:  &api.PollingRunStatus{Result: "failed"},
 				RunID:   "run-456",
 				Polling: api.PollingResult{Completed: true},
 			}, nil
@@ -99,13 +99,13 @@ func TestService_GetRunStatus(t *testing.T) {
 			callCount++
 			if callCount < 2 {
 				return api.RunStatusResult{
-					Status:  &api.RunStatus{Result: "in_progress"},
+					Status:  &api.PollingRunStatus{Result: "in_progress"},
 					RunID:   "run-789",
 					Polling: api.PollingResult{Completed: false, BackoffMs: &backoffMs},
 				}, nil
 			}
 			return api.RunStatusResult{
-				Status:  &api.RunStatus{Result: "succeeded"},
+				Status:  &api.PollingRunStatus{Result: "succeeded"},
 				RunID:   "run-789",
 				Polling: api.PollingResult{Completed: true},
 			}, nil
@@ -129,7 +129,7 @@ func TestService_GetRunStatus(t *testing.T) {
 
 		setup.mockAPI.MockRunStatus = func(cfg api.RunStatusConfig) (api.RunStatusResult, error) {
 			return api.RunStatusResult{
-				Status:  &api.RunStatus{Result: "in_progress"},
+				Status:  &api.PollingRunStatus{Result: "in_progress"},
 				RunID:   "run-789",
 				Polling: api.PollingResult{Completed: false, BackoffMs: nil},
 			}, nil
@@ -191,7 +191,7 @@ func TestService_GetRunStatus(t *testing.T) {
 			require.Equal(t, "main", cfg.BranchName)
 			require.Equal(t, "cli", cfg.RepositoryName)
 			return api.RunStatusResult{
-				Status:  &api.RunStatus{Result: "succeeded"},
+				Status:  &api.PollingRunStatus{Result: "succeeded"},
 				RunID:   "resolved-run-id",
 				RunURL:  "https://cloud.rwx.com/mint/org/runs/resolved-run-id",
 				Polling: api.PollingResult{Completed: true},
@@ -263,13 +263,13 @@ func TestService_GetRunStatus(t *testing.T) {
 			callCount++
 			if callCount < 2 {
 				return api.RunStatusResult{
-					Status:  &api.RunStatus{Result: "no_result"},
+					Status:  &api.PollingRunStatus{Result: "no_result"},
 					RunID:   "resolved-run-id",
 					Polling: api.PollingResult{Completed: false, BackoffMs: &backoffMs},
 				}, nil
 			}
 			return api.RunStatusResult{
-				Status:  &api.RunStatus{Result: "succeeded"},
+				Status:  &api.PollingRunStatus{Result: "succeeded"},
 				RunID:   "resolved-run-id",
 				Polling: api.PollingResult{Completed: true},
 			}, nil
@@ -295,7 +295,7 @@ func TestService_GetRunStatus(t *testing.T) {
 		commitSHA := "abc123def456"
 		setup.mockAPI.MockRunStatus = func(cfg api.RunStatusConfig) (api.RunStatusResult, error) {
 			return api.RunStatusResult{
-				Status:  &api.RunStatus{Result: "succeeded"},
+				Status:  &api.PollingRunStatus{Result: "succeeded"},
 				RunID:   "run-123",
 				Commit:  &commitSHA,
 				Polling: api.PollingResult{Completed: true},
@@ -317,7 +317,7 @@ func TestService_GetRunStatus(t *testing.T) {
 
 		setup.mockAPI.MockRunStatus = func(cfg api.RunStatusConfig) (api.RunStatusResult, error) {
 			return api.RunStatusResult{
-				Status:  &api.RunStatus{Result: "succeeded"},
+				Status:  &api.PollingRunStatus{Result: "succeeded"},
 				RunID:   "run-123",
 				Commit:  nil,
 				Polling: api.PollingResult{Completed: true},
@@ -339,7 +339,7 @@ func TestService_GetRunStatus(t *testing.T) {
 
 		setup.mockAPI.MockRunStatus = func(cfg api.RunStatusConfig) (api.RunStatusResult, error) {
 			return api.RunStatusResult{
-				Status:  &api.RunStatus{Result: "succeeded"},
+				Status:  &api.PollingRunStatus{Result: "succeeded"},
 				RunID:   "run-123",
 				RunURL:  "https://cloud.rwx.com/mint/org/runs/run-123",
 				TaskID:  "task-456",
@@ -368,7 +368,7 @@ func TestService_GetRunStatus(t *testing.T) {
 		setup.mockAPI.MockRunStatus = func(cfg api.RunStatusConfig) (api.RunStatusResult, error) {
 			callCount++
 			return api.RunStatusResult{
-				Status:  &api.RunStatus{Result: "in_progress"},
+				Status:  &api.PollingRunStatus{Result: "in_progress"},
 				RunID:   "run-123",
 				Polling: api.PollingResult{Completed: false},
 			}, nil

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -36,6 +36,7 @@ type API struct {
 	MockTaskIDStatus                            func(api.TaskIDStatusConfig) (api.TaskStatusResult, error)
 	MockRunStatus                               func(api.RunStatusConfig) (api.RunStatusResult, error)
 	MockGetRunDetails                           func(api.RunDetailsConfig) (map[string]any, error)
+	MockListRuns                                func(api.ListRunsConfig) (*api.ListRunsResult, error)
 	MockGetLogDownloadRequest                   func(string) (api.LogDownloadRequestResult, error)
 	MockGetLogDownloadRequestByTaskKey          func(string, string) (api.LogDownloadRequestResult, error)
 	MockDownloadLogs                            func(api.LogDownloadRequestResult) ([]byte, error)
@@ -289,6 +290,14 @@ func (c *API) GetRunDetails(cfg api.RunDetailsConfig) (map[string]any, error) {
 	}
 
 	return nil, errors.New("MockGetRunDetails was not configured")
+}
+
+func (c *API) ListRuns(cfg api.ListRunsConfig) (*api.ListRunsResult, error) {
+	if c.MockListRuns != nil {
+		return c.MockListRuns(cfg)
+	}
+
+	return nil, errors.New("MockListRuns was not configured")
 }
 
 func (c *API) GetLogDownloadRequest(taskId string) (api.LogDownloadRequestResult, error) {

--- a/internal/text/wrap.go
+++ b/internal/text/wrap.go
@@ -2,6 +2,23 @@ package text
 
 import "strings"
 
+// Truncate shortens s to at most max characters (counting runes), replacing the
+// trailing overflow with a single-rune ellipsis so the result still fits within
+// max. A non-positive max returns s unchanged.
+func Truncate(s string, max int) string {
+	if max <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max == 1 {
+		return "…"
+	}
+	return string(runes[:max-1]) + "…"
+}
+
 // WrapText breaks s into lines of at most width characters, splitting at word
 // boundaries when possible. If width is zero or negative, or the string fits
 // within the width, the original string is returned as a single-element slice.

--- a/internal/text/wrap_test.go
+++ b/internal/text/wrap_test.go
@@ -1,0 +1,32 @@
+package text_test
+
+import (
+	"testing"
+
+	"github.com/rwx-cloud/rwx/internal/text"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncate(t *testing.T) {
+	t.Run("returns the string unchanged when it fits", func(t *testing.T) {
+		require.Equal(t, "main", text.Truncate("main", 24))
+		require.Equal(t, "main", text.Truncate("main", 4))
+	})
+
+	t.Run("truncates with a trailing ellipsis, staying within max", func(t *testing.T) {
+		out := text.Truncate("a-very-long-branch-name", 10)
+		require.Equal(t, "a-very-lo…", out)
+		require.Equal(t, 10, len([]rune(out)))
+	})
+
+	t.Run("counts runes, not bytes", func(t *testing.T) {
+		// Five 2-byte runes; a width of 5 fits, a width of 4 truncates to 4 runes.
+		require.Equal(t, "héllo", text.Truncate("héllo", 5))
+		require.Equal(t, "hél…", text.Truncate("héllo", 4))
+	})
+
+	t.Run("returns the string unchanged for a non-positive max", func(t *testing.T) {
+		require.Equal(t, "anything", text.Truncate("anything", 0))
+		require.Equal(t, "anything", text.Truncate("anything", -1))
+	})
+}


### PR DESCRIPTION
### Background

- Linear: [RWX-1003](https://linear.app/rwx-cloud/issue/RWX-1003/cli-add-rwx-runs-list-command-with-typed-listruns-client-and-shared) · RFC 189: [`rwx runs list`](https://www.notion.so/rwx/RFC-189-rwx-runs-list-37bc3a490d9880c397e1c667315a2a98)
- Built against the paginated `#index` (rwx-cloud/cloud#7799), with the aligned payload (#7733), structured `400` (#7779), and soft-`200` suggestions (#7780).

### Problem

The rebuilt `#index` (aligned `RunSummary`, cursor pagination, structured filter validation, rate limiting) had no CLI consumer. This adds `rwx runs list` and the typed client behind it.

### Design notes

Decisions the examples below don't surface:

- Extracted a shared `RunStatus` (the status object the index and results details share); the old polling-only status became `PollingRunStatus` (different shape).
- No client-side enum validation — the server owns the status enum and returns a structured `400`, so the CLI keeps no copy that could drift.
- No `--all` flag (unbounded sweep); callers page deliberately with `--cursor`.
- The `429` is surfaced with a synthesized message, not auto-retried (60s window).
- `GetRunDetails` stays `map[string]any` this pass.

### Examples

All scoped with `--repository rwx`; captured against production.

**Default table** — title and branch are truncated to keep rows aligned:

<details><summary><code>rwx runs list --repository rwx --limit 5</code></summary>

```
TITLE                                     ID                                STATUS     REPO  BRANCH  COMMIT    DEFINITION                                   CREATED
Sandbox: mint-workspace (detached cf0a2…  722a7c3d5d8e4a75b95977dc96178f38  sandboxed  rwx                     test/integration/definitions/sandbox.yml     2026-06-23T20:30:30.472Z
Sandbox: mint-workspace (detached cf0a2…  467199bd1c4b45e8b26b6975d83bbb8a  sandboxed  rwx                     test/integration/definitions/sandbox.yml     2026-06-23T20:30:26.853Z
Dispatched run of dispatch-failure-test…  a77e60cfdc21437fb94e60a5afcf6694  failed     rwx           cf0a2a9d  .rwx/integration/dispatch-test/dispatch.yml  2026-06-23T20:29:55.590Z
Dispatched run of dispatch-failure-test…  52f81cbd821644d8b8025b2f62873f7e  failed     rwx           cf0a2a9d  .rwx/integration/dispatch-test/dispatch.yml  2026-06-23T20:29:55.530Z
Dispatched run of dispatch-success-test…  075d1688f69a4c06894cbb99e1178872  succeeded  rwx           cf0a2a9d  .rwx/integration/dispatch-test/dispatch.yml  2026-06-23T20:29:55.421Z
```
</details>

**JSON** — full (untruncated) values, plus `Pagination.NextCursor`:

<details><summary><code>rwx runs list --repository rwx --limit 2 --json | jq</code></summary>

```json
{
  "Pagination": {
    "Limit": 2,
    "NextCursor": "eyJjcmVhdGVkX2F0IjoiMjAyNi0wNi0yM1QyMDozMDoyNi44NTM2NjVaIiwiaWQiOiI0NjcxOTliZC0xYzRiLTQ1ZTgtYjI2Yi02OTc1ZDgzYmJiOGEifQ"
  },
  "Runs": [
    {
      "Branch": "",
      "CliState": "eyJicmFuY2giOiJkZXRhY2hlZEBjZjBhMmE5IiwiY29uZmlnRmlsZSI6Ii92YXIvbWludC13b3Jrc3BhY2UvdGVzdC9pbnRlZ3JhdGlvbi9kZWZpbml0aW9ucy9zYW5kYm94LnltbCJ9",
      "CommitSha": "",
      "CompletedAt": "2026-06-23T20:30:42.489Z",
      "CompletedRuntimeSeconds": 12,
      "CreatedAt": "2026-06-23T20:30:30.472Z",
      "DefinitionPath": "test/integration/definitions/sandbox.yml",
      "ID": "722a7c3d5d8e4a75b95977dc96178f38",
      "RepositoryName": "rwx",
      "RunUrl": "https://cloud.rwx.com/mint/rwx/runs/722a7c3d5d8e4a75b95977dc96178f38",
      "StartedAt": "2026-06-23T20:30:30.307Z",
      "Status": {
        "AbortedSubStatus": "not_applicable",
        "Execution": "finished",
        "FinishedSubStatus": "not_applicable",
        "Result": "sandboxed",
        "WaitingSubStatus": "not_applicable"
      },
      "Tag": null,
      "Title": "Sandbox: mint-workspace (detached cf0a2a9) [/var/mint-workspace/test/integration/definitions/sandbox.yml]",
      "Trigger": "cli"
    },
    {
      "Branch": "",
      "CliState": "eyJicmFuY2giOiJkZXRhY2hlZEBjZjBhMmE5IiwiY29uZmlnRmlsZSI6Ii92YXIvbWludC13b3Jrc3BhY2UvdGVzdC9pbnRlZ3JhdGlvbi9kZWZpbml0aW9ucy9zYW5kYm94LnltbCJ9",
      "CommitSha": "",
      "CompletedAt": "2026-06-23T20:30:36.146Z",
      "CompletedRuntimeSeconds": 9,
      "CreatedAt": "2026-06-23T20:30:26.853Z",
      "DefinitionPath": "test/integration/definitions/sandbox.yml",
      "ID": "467199bd1c4b45e8b26b6975d83bbb8a",
      "RepositoryName": "rwx",
      "RunUrl": "https://cloud.rwx.com/mint/rwx/runs/467199bd1c4b45e8b26b6975d83bbb8a",
      "StartedAt": "2026-06-23T20:30:26.582Z",
      "Status": {
        "AbortedSubStatus": "not_applicable",
        "Execution": "finished",
        "FinishedSubStatus": "not_applicable",
        "Result": "sandboxed",
        "WaitingSubStatus": "not_applicable"
      },
      "Tag": null,
      "Title": "Sandbox: mint-workspace (detached cf0a2a9) [/var/mint-workspace/test/integration/definitions/sandbox.yml]",
      "Trigger": "cli"
    }
  ]
}
```
</details>

**Filter by result status:**

<details><summary><code>rwx runs list --repository rwx --result-status failed --limit 5</code></summary>

```
TITLE                                     ID                                STATUS  REPO  BRANCH  COMMIT    DEFINITION                                              CREATED
Dispatched run of dispatch-failure-test…  a77e60cfdc21437fb94e60a5afcf6694  failed  rwx           cf0a2a9d  .rwx/integration/dispatch-test/dispatch.yml             2026-06-23T20:29:55.590Z
Dispatched run of dispatch-failure-test…  52f81cbd821644d8b8025b2f62873f7e  failed  rwx           cf0a2a9d  .rwx/integration/dispatch-test/dispatch.yml             2026-06-23T20:29:55.530Z
Sandbox: mint-workspace (detached cf0a2…  abc06d0565274c96b95621289955c9b5  failed  rwx                     test/integration/definitions/sandbox-setup-failure.yml  2026-06-23T20:29:51.378Z
Dispatched run of dispatch-failure-test…  73e14ca164a84909b7ba3e3aa7091e8e  failed  rwx           3fb93ea1  .rwx/integration/dispatch-test/dispatch.yml             2026-06-23T20:10:47.474Z
Dispatched run of dispatch-failure-test…  fafbfba166e746b4aef3772035e732d4  failed  rwx           3fb93ea1  .rwx/integration/dispatch-test/dispatch.yml             2026-06-23T20:10:44.646Z
```
</details>

**Pagination** — `--limit` sets the page size; the "more pages" hint (with the cursor) prints to stderr, then `--cursor` fetches the next page:

<details><summary><code>rwx runs list --repository rwx --limit 2</code> → <code>--cursor …</code></summary>

```
$ rwx runs list --repository rwx --limit 2
TITLE                                     ID                                STATUS     REPO  BRANCH  COMMIT  DEFINITION                                CREATED
Sandbox: mint-workspace (detached cf0a2…  722a7c3d5d8e4a75b95977dc96178f38  sandboxed  rwx                   test/integration/definitions/sandbox.yml  2026-06-23T20:30:30.472Z
Sandbox: mint-workspace (detached cf0a2…  467199bd1c4b45e8b26b6975d83bbb8a  sandboxed  rwx                   test/integration/definitions/sandbox.yml  2026-06-23T20:30:26.853Z

More runs available. Fetch the next page with --cursor eyJjcmVhdGVkX2F0IjoiMjAyNi0wNi0yM1QyMDozMDoyNi44NTM2NjVaIiwiaWQiOiI0NjcxOTliZC0xYzRiLTQ1ZTgtYjI2Yi02OTc1ZDgzYmJiOGEifQ

$ rwx runs list --repository rwx --limit 2 --cursor eyJjcmVhdGVkX2F0IjoiMjAyNi0wNi0yM1QyMDozMDoyNi44NTM2NjVaIiwiaWQiOiI0NjcxOTliZC0xYzRiLTQ1ZTgtYjI2Yi02OTc1ZDgzYmJiOGEifQ
TITLE                                     ID                                STATUS  REPO  BRANCH  COMMIT    DEFINITION                                   CREATED
Dispatched run of dispatch-failure-test…  a77e60cfdc21437fb94e60a5afcf6694  failed  rwx           cf0a2a9d  .rwx/integration/dispatch-test/dispatch.yml  2026-06-23T20:29:55.590Z
Dispatched run of dispatch-failure-test…  52f81cbd821644d8b8025b2f62873f7e  failed  rwx           cf0a2a9d  .rwx/integration/dispatch-test/dispatch.yml  2026-06-23T20:29:55.530Z

More runs available. Fetch the next page with --cursor eyJjcmVhdGVkX2F0IjoiMjAyNi0wNi0yM1QyMDoyOTo1NS41MzA2NzNaIiwiaWQiOiI1MmY4MWNiZC04MjE2LTQ0ZDgtYjgwMi01YjJmNjI4NzNmN2UifQ
```
</details>

**Soft suggestion** — open-ended filters aren't a closed enum, so a near-miss returns a `200` with a non-fatal "did you mean" hint on stderr and exits `0`:

```
$ rwx runs list --repository rwx --branch mian
No exact match for branch_name "mian". Did you mean: main?
No runs found.
```

**Invalid status** — closed enum, so the server's structured `400` drives the message; exit `1`:

```
$ rwx runs list --repository rwx --result-status bogus
Error: invalid run filter:
  result_status "bogus" is not valid (valid: succeeded, debugged, sandboxed, failed, no_result)
exit=1
```

**Malformed cursor** — exit `1`:

```
$ rwx runs list --repository rwx --cursor not-a-real-cursor
Error: Invalid cursor: bad request
```

**Rate limit** — the index allows 100 requests/min per identity; beyond that the CLI synthesizes a message from the `Retry-After` window (exit `1`):

```
$ rwx runs list --repository rwx --limit 1    # ~100th call within a minute
Error: rate limited by RWX (100 requests/min). Retry after 60 seconds.
```

<details><summary><code>rwx runs list --help</code></summary>

```
List runs, most recent first.

The default output is a table. Pass --json (or --format json) for the structured
payload, which includes a NextCursor for deliberate paging.

Results are paginated: the default page shows the most recent runs and --limit
sets the page size (capped at 100). When more runs remain, pass the reported
cursor to --cursor to fetch the next page.

For a given run's full payload, run 'rwx results <id> --json'.

Usage:
  rwx runs list [flags]

Aliases:
  list, ls

Flags:
      --branch strings             filter by branch name, case-insensitive (repeatable)
      --commit strings             filter by commit SHA (repeatable)
      --cursor string              cursor for fetching the next page (from a prior result's NextCursor)
      --definition strings         filter by definition path (repeatable)
      --execution-status strings   filter by execution status, repeatable: waiting, in_progress, finished, aborted
  -h, --help                       help for list
      --limit int                  page size (max 100; server default applies when unset)
      --mine                       only list runs you triggered
      --repository strings         filter by repository name, case-insensitive (repeatable)
      --result-status strings      filter by result status, repeatable: succeeded, debugged, sandboxed, failed, no_result

Global Flags:
      --access-token string   the access token for RWX (default "$RWX_ACCESS_TOKEN")
      --format string         output format: text or json (default "text")
      --json                  output json data to stdout
```
</details>
