### PR TITLE
Migrate ListSandboxRuns onto the typed ListRuns client method

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1620,26 +1620,16 @@ func (c Client) CancelRun(runID, scopedToken string) error {
 }
 
 func (c Client) ListSandboxRuns() (*ListSandboxRunsResult, error) {
-	endpoint := "/mint/api/runs?result_status=sandboxed&execution_status=in_progress&my_runs=true"
-
-	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	result, err := c.ListRuns(ListRunsConfig{
+		ResultStatuses:    []string{"sandboxed"},
+		ExecutionStatuses: []string{"in_progress"},
+		MyRuns:            true,
+	})
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to create new HTTP request")
-	}
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := c.RoundTrip(req)
-	if err != nil {
-		return nil, errors.Wrap(err, "HTTP request failed")
-	}
-	defer resp.Body.Close()
-
-	result := ListSandboxRunsResult{}
-	if err = decodeResponseJSON(resp, &result); err != nil {
 		return nil, err
 	}
 
-	return &result, nil
+	return &ListSandboxRunsResult{Runs: result.Runs}, nil
 }
 
 func (c Client) GetSandboxInitTemplate() (SandboxInitTemplateResult, error) {

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -415,15 +415,8 @@ type SandboxInitTemplateResult struct {
 	Template string `json:"template"`
 }
 
-type SandboxRunSummary struct {
-	ID       string `json:"id"`
-	RunURL   string `json:"run_url"`
-	Title    string `json:"title"`
-	CliState string `json:"cli_state"`
-}
-
 type ListSandboxRunsResult struct {
-	Runs []SandboxRunSummary `json:"runs"`
+	Runs []RunSummary `json:"runs"`
 }
 
 // RunStatus is the shared status object returned by both the runs index (under

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -582,10 +582,10 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 			listResult, listErr := s.APIClient.ListSandboxRuns()
 			if listErr == nil {
 				for _, run := range listResult.Runs {
-					if run.CliState == "" {
+					if run.CliState == nil || *run.CliState == "" {
 						continue
 					}
-					state, decErr := DecodeCliState(run.CliState)
+					state, decErr := DecodeCliState(*run.CliState)
 					if decErr != nil {
 						continue
 					}
@@ -904,7 +904,7 @@ func (s Service) ListSandboxes(cfg ListSandboxesConfig) (*ListSandboxesResult, e
 	}
 
 	// Build set of active run IDs from API response
-	activeRuns := make(map[string]api.SandboxRunSummary, len(listResult.Runs))
+	activeRuns := make(map[string]api.RunSummary, len(listResult.Runs))
 	for _, run := range listResult.Runs {
 		activeRuns[run.ID] = run
 	}
@@ -912,10 +912,10 @@ func (s Service) ListSandboxes(cfg ListSandboxesConfig) (*ListSandboxesResult, e
 	// Merge remotely-discovered runs into local storage
 	storageChanged := false
 	for _, run := range listResult.Runs {
-		if run.CliState == "" {
+		if run.CliState == nil || *run.CliState == "" {
 			continue
 		}
-		state, err := DecodeCliState(run.CliState)
+		state, err := DecodeCliState(*run.CliState)
 		if err != nil {
 			continue
 		}

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -50,7 +50,7 @@ func TestService_ListSandboxes(t *testing.T) {
 		setup := setupTest(t)
 
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
 		}
 
 		result, err := setup.service.ListSandboxes(cli.ListSandboxesConfig{
@@ -113,7 +113,7 @@ func TestService_LockWaitOutput(t *testing.T) {
 		setup := setupTest(t)
 
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
 		}
 
 		_, err := setup.service.ListSandboxes(cli.ListSandboxesConfig{Json: false})
@@ -125,7 +125,7 @@ func TestService_LockWaitOutput(t *testing.T) {
 		setup := setupTest(t)
 
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
 		}
 
 		// Hold the lock to force contention
@@ -162,7 +162,7 @@ func TestService_LockWaitOutput(t *testing.T) {
 		setup := setupTest(t)
 
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
 		}
 
 		// Hold the lock to force contention
@@ -202,7 +202,7 @@ func TestService_ListSandboxes_BulkAPI(t *testing.T) {
 
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
 			return &api.ListSandboxRunsResult{
-				Runs: []api.SandboxRunSummary{
+				Runs: []api.RunSummary{
 					{ID: "run-active", RunURL: "https://cloud.rwx.com/runs/run-active"},
 				},
 			}, nil
@@ -244,9 +244,9 @@ func TestService_ListSandboxes_BulkAPI(t *testing.T) {
 		remoteCliState := cli.EncodeCliState("develop", setup.absConfig(".rwx/sandbox.yml"))
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
 			return &api.ListSandboxRunsResult{
-				Runs: []api.SandboxRunSummary{
+				Runs: []api.RunSummary{
 					{ID: "run-local", RunURL: "https://cloud.rwx.com/runs/run-local"},
-					{ID: "run-remote", RunURL: "https://cloud.rwx.com/runs/run-remote", CliState: remoteCliState},
+					{ID: "run-remote", RunURL: "https://cloud.rwx.com/runs/run-remote", CliState: &remoteCliState},
 				},
 			}, nil
 		}
@@ -278,7 +278,7 @@ func TestService_ListSandboxes_BulkAPI(t *testing.T) {
 
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
 			return &api.ListSandboxRunsResult{
-				Runs: []api.SandboxRunSummary{
+				Runs: []api.RunSummary{
 					{ID: "run-no-state", RunURL: "https://cloud.rwx.com/runs/run-no-state"},
 				},
 			}, nil
@@ -304,9 +304,9 @@ func TestService_ListSandboxes_BulkAPI(t *testing.T) {
 		remoteCliState := cli.EncodeCliState("main", setup.absConfig(".rwx/sandbox.yml"))
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
 			return &api.ListSandboxRunsResult{
-				Runs: []api.SandboxRunSummary{
+				Runs: []api.RunSummary{
 					{ID: "run-local", RunURL: "https://cloud.rwx.com/runs/run-local"},
-					{ID: "run-remote-new", RunURL: "https://cloud.rwx.com/runs/run-remote-new", CliState: remoteCliState},
+					{ID: "run-remote-new", RunURL: "https://cloud.rwx.com/runs/run-remote-new", CliState: &remoteCliState},
 				},
 			}, nil
 		}
@@ -347,7 +347,7 @@ func TestService_ListSandboxes_PrunesExpired(t *testing.T) {
 		// Bulk API only returns the active run
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
 			return &api.ListSandboxRunsResult{
-				Runs: []api.SandboxRunSummary{
+				Runs: []api.RunSummary{
 					{ID: "run-active", RunURL: "https://cloud.rwx.com/runs/run-active"},
 				},
 			}, nil
@@ -401,7 +401,7 @@ func TestService_ListSandboxes_PrunesExpired(t *testing.T) {
 		// Only run-active is returned by the API
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
 			return &api.ListSandboxRunsResult{
-				Runs: []api.SandboxRunSummary{
+				Runs: []api.RunSummary{
 					{ID: "run-active", RunURL: "https://cloud.rwx.com/runs/run-active"},
 				},
 			}, nil
@@ -443,7 +443,7 @@ func TestService_ListSandboxes_PrunesExpired(t *testing.T) {
 
 		// Bulk API does not return the initializing run
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
 		}
 
 		// Fallback check shows the run is still alive
@@ -477,7 +477,7 @@ func TestService_ListSandboxes_PrunesExpired(t *testing.T) {
 		})
 
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
 		}
 
 		// Fallback returns an error (e.g. 400 "run has been cancelled")
@@ -507,7 +507,7 @@ func TestService_ListSandboxes_PrunesExpired(t *testing.T) {
 
 		// Bulk API hasn't picked up the run yet, forcing the fallback path
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
 		}
 
 		// Ready sandbox: Sandboxable=true, Polling.Completed=true
@@ -1816,7 +1816,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		}
 
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
 		}
 		setup.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
 			return &api.InitiateRunResult{
@@ -2000,7 +2000,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		}
 
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
 		}
 		setup.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
 			return &api.InitiateRunResult{
@@ -3247,7 +3247,7 @@ func TestService_ExecSandbox_ConcurrentAutoCreate(t *testing.T) {
 			return &api.CreateSandboxTokenResult{Token: "test-token"}, nil
 		}
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
 		}
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
 			return api.SandboxConnectionInfo{
@@ -3340,11 +3340,11 @@ func TestService_ExecSandbox_RecoverFromAPI(t *testing.T) {
 		// No local session — ListSandboxRuns returns a matching run
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
 			return &api.ListSandboxRunsResult{
-				Runs: []api.SandboxRunSummary{
+				Runs: []api.RunSummary{
 					{
 						ID:       "run-recovered",
 						RunURL:   "https://cloud.rwx.com/runs/run-recovered",
-						CliState: encodedState,
+						CliState: &encodedState,
 					},
 				},
 			}, nil
@@ -3411,7 +3411,7 @@ func TestService_ExecSandbox_RecoverFromAPI(t *testing.T) {
 
 		// ListSandboxRuns returns no matching runs
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
 		}
 
 		// Mock the full auto-create path
@@ -3602,7 +3602,7 @@ func TestService_ExecSandbox_SessionReuse(t *testing.T) {
 			return &api.PackageVersionsResult{LatestMajor: map[string]string{}, LatestMinor: map[string]map[string]string{}}, nil
 		}
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
 		}
 		setup.mockAPI.MockInitiateRun = func(api.InitiateRunConfig) (*api.InitiateRunResult, error) {
 			return &api.InitiateRunResult{RunID: "run-fresh", RunURL: "https://cloud.rwx.com/mint/runs/run-fresh"}, nil
@@ -4960,7 +4960,7 @@ func TestService_ExecSandbox_Reset(t *testing.T) {
 
 		// No session in storage — ListSandboxRuns is called during remote recovery
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
 		}
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
 			return api.SandboxConnectionInfo{
@@ -5102,7 +5102,7 @@ func TestService_ExecSandbox_ReconnectionHint(t *testing.T) {
 		setup.mockGit.MockGetOriginUrl = "git@github.com:example/repo.git"
 		setup.mockGit.MockGeneratePatchFile = git.PatchFile{}
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
-			return &api.ListSandboxRunsResult{Runs: []api.SandboxRunSummary{}}, nil
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
 		}
 		setup.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
 			return &api.InitiateRunResult{RunID: "run-brand-new", RunURL: "https://cloud.rwx.com/runs/run-brand-new"}, nil

--- a/internal/cli/service_telemetry_test.go
+++ b/internal/cli/service_telemetry_test.go
@@ -976,7 +976,7 @@ func TestTelemetry_SandboxList(t *testing.T) {
 
 		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
 			return &api.ListSandboxRunsResult{
-				Runs: []api.SandboxRunSummary{
+				Runs: []api.RunSummary{
 					{ID: "run-list-active", RunURL: "url"},
 				},
 			}, nil


### PR DESCRIPTION
### Background

[RWX-1004](https://linear.app/rwx-cloud/issue/RWX-1004/cli-migrate-listsandboxruns-onto-the-new-listruns-client-method) — a post-v1 cleanup deferred from the `rwx runs list` work (RFC 189).

### Problem

`ListSandboxRuns` hand-built its own request and decoded into a bespoke `SandboxRunSummary` struct, duplicating logic now in the typed `ListRuns` method (RWX-1003).

### Solution

- Re-express `ListSandboxRuns` in terms of `ListRuns`, passing the sandbox filters (`result_status=sandboxed`, `execution_status=in_progress`, `my_runs=true`) via `ListRunsConfig`.
- Remove `SandboxRunSummary`; `ListSandboxRunsResult.Runs` is now `[]RunSummary`.
- Update callers/tests for the type shift (`RunSummary.CliState` is `*string`).

Caveat: the new path adds structured 400/429 handling the old method lacked — strictly additive for sandbox's fixed filters, so no happy-path behavior change.

#### Further confirmation needed

- [ ] `rwx sandbox list` and sandbox auto-recovery behave identically against a live API.
