### PR TITLE
Enrich run --wait and dispatch --wait results JSON

### DIFF
--- a/.rwx/build.yml
+++ b/.rwx/build.yml
@@ -9,7 +9,7 @@ base:
 
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       preserve-git-dir: true
       repository: https://github.com/rwx-cloud/rwx.git
@@ -28,7 +28,7 @@ tasks:
       - language-server-ref
 
   - key: lsp-code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/language-server.git
       ref: ${{ tasks.tool-versions.values.language-server-ref }}

--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -20,7 +20,7 @@ base:
 
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       preserve-git-dir: true
       repository: https://github.com/rwx-cloud/rwx.git
@@ -76,7 +76,7 @@ tasks:
       git lfs install --skip-repo
 
   - key: lsp-code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/language-server.git
       ref: ${{ tasks.tool-versions.values.language-server-ref }}

--- a/.rwx/integration/artifacts-test.yml
+++ b/.rwx/integration/artifacts-test.yml
@@ -9,7 +9,7 @@ base:
 
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/dispatch-test.yml
+++ b/.rwx/integration/dispatch-test.yml
@@ -9,7 +9,7 @@ base:
 
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/image-test.yml
+++ b/.rwx/integration/image-test.yml
@@ -15,7 +15,7 @@ tasks:
     call: aws/install-cli 1.0.11
 
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/lint-test.yml
+++ b/.rwx/integration/lint-test.yml
@@ -11,7 +11,7 @@ base:
 
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}
@@ -52,7 +52,7 @@ tasks:
       node-version: 17.0.0
 
   - key: lsp-code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/language-server.git
       ref: ${{ tasks.tool-versions.values.language-server-ref }}

--- a/.rwx/integration/logs-test.yml
+++ b/.rwx/integration/logs-test.yml
@@ -9,7 +9,7 @@ base:
 
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/resolve-update-test.yml
+++ b/.rwx/integration/resolve-update-test.yml
@@ -11,7 +11,7 @@ base:
 
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/results-test.yml
+++ b/.rwx/integration/results-test.yml
@@ -9,7 +9,7 @@ base:
 
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/run-test.yml
+++ b/.rwx/integration/run-test.yml
@@ -9,7 +9,7 @@ base:
 
 tasks:
   - key: rwx-testing-code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/rwx-testing.git
       ref: main
@@ -28,7 +28,7 @@ tasks:
       cli: ${{ init.cli }}
 
   - key: rwx-cli-code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.cli }}

--- a/.rwx/integration/runs-list-test.yml
+++ b/.rwx/integration/runs-list-test.yml
@@ -9,7 +9,7 @@ base:
 
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/skill-test.yml
+++ b/.rwx/integration/skill-test.yml
@@ -9,7 +9,7 @@ base:
 
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/whoami-test.yml
+++ b/.rwx/integration/whoami-test.yml
@@ -9,7 +9,7 @@ base:
 
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/language-server-update.yml
+++ b/.rwx/language-server-update.yml
@@ -8,7 +8,7 @@ base:
 
 tasks:
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: main

--- a/.rwx/release.yml
+++ b/.rwx/release.yml
@@ -82,7 +82,7 @@ tasks:
       printf "$aliasedVersion" > "$RWX_VALUES/aliased-version"
 
   - key: code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     after: verify-inputs
     with:
       preserve-git-dir: true
@@ -139,7 +139,7 @@ tasks:
       GH_TOKEN: ${{ github-apps.rwx-cloud-bot.token }}
 
   - key: lsp-code
-    call: git/clone 2.0.7
+    call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/language-server.git
       ref: ${{ tasks.tool-versions.values.language-server-ref }}

--- a/cmd/rwx/dispatch.go
+++ b/cmd/rwx/dispatch.go
@@ -121,7 +121,30 @@ var (
 					if promptErr == nil {
 						jsonOutput.ResultPrompt = promptResult.Prompt
 					}
-					waitResultJson, err := json.Marshal(jsonOutput)
+
+					baseJson, err := json.Marshal(jsonOutput)
+					if err != nil {
+						return err
+					}
+					var base map[string]any
+					if err := json.Unmarshal(baseJson, &base); err != nil {
+						return err
+					}
+
+					// Fold the enriched /details payload into the base output,
+					// mirroring `rwx results --json`. An empty object means
+					// enrichment is not enabled for the org, so the merge is a no-op.
+					details, err := service.GetRunDetails(cli.GetRunDetailsConfig{
+						RunID: runs[0].RunID,
+					})
+					if err != nil {
+						return err
+					}
+					if len(details) > 0 {
+						base = MergeEnrichedResults(base, details)
+					}
+
+					waitResultJson, err := json.Marshal(base)
 					if err != nil {
 						return err
 					}

--- a/cmd/rwx/run.go
+++ b/cmd/rwx/run.go
@@ -139,7 +139,30 @@ var (
 					if err == nil {
 						jsonOutput.ResultPrompt = promptResult.Prompt
 					}
-					waitResultJson, err := json.Marshal(jsonOutput)
+
+					baseJson, err := json.Marshal(jsonOutput)
+					if err != nil {
+						return err
+					}
+					var base map[string]any
+					if err := json.Unmarshal(baseJson, &base); err != nil {
+						return err
+					}
+
+					// Fold the enriched /details payload into the base output,
+					// mirroring `rwx results --json`. An empty object means
+					// enrichment is not enabled for the org, so the merge is a no-op.
+					details, err := service.GetRunDetails(cli.GetRunDetailsConfig{
+						RunID: runResult.RunID,
+					})
+					if err != nil {
+						return err
+					}
+					if len(details) > 0 {
+						base = MergeEnrichedResults(base, details)
+					}
+
+					waitResultJson, err := json.Marshal(base)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
### Background

- Linear: https://linear.app/rwx-cloud/issue/RWX-987/apply-enriched-results-json-to-run-wait-and-dispatch-wait
- Follow-up to RWX-962 / rwx-cloud/rwx#534, which enriched `rwx results --json`.

### Problem

`rwx run --wait` and `rwx dispatch --wait` printed a plain results struct, omitting the enriched `/mint/api/results/details` payload that `rwx results --json` already includes for the same run.

### Solution

- Both `--wait` JSON branches now fetch `GetRunDetails` and merge via the existing `MergeEnrichedResults` helper (no merge logic duplicated). Empty payload = no-op; a fetch error surfaces, matching `rwx results --json`.

#### Further confirmation needed

- [ ] Verify enriched JSON shape from `rwx run --wait --output json` / `rwx dispatch --wait --output json` against a real run in an enrichment-enabled org.
