### PR TITLE
Surface `rwx runs show` for discoverability

### DIFF
--- a/cmd/rwx/runs.go
+++ b/cmd/rwx/runs.go
@@ -26,30 +26,22 @@ func init() {
 	}
 	runsStartCmd.Flags().AddFlagSet(runCmd.Flags())
 
-	aliasShort := "Alias for rwx results"
-
-	runsGetCmd := &cobra.Command{
-		Use:     "get [run-id]",
-		Short:   aliasShort,
-		Args:    resultsCmd.Args,
-		PreRunE: resultsCmd.PreRunE,
-		RunE:    resultsCmd.RunE,
-		Hidden:  true,
-	}
-	runsGetCmd.Flags().AddFlagSet(resultsCmd.Flags())
-
+	// `rwx runs show` is the noun-verb form of `rwx results`: the single-run
+	// inspection path, reusing results' execution so the two stay in lockstep.
+	// `get` is an alias so coding-agent guesses (`rwx runs get`) resolve to the
+	// same command without surfacing a second line under `rwx runs -h`.
 	runsShowCmd := &cobra.Command{
 		Use:     "show [run-id]",
-		Short:   aliasShort,
+		Aliases: []string{"get"},
+		Short:   resultsCmd.Short,
+		Long:    resultsCmd.Long,
 		Args:    resultsCmd.Args,
 		PreRunE: resultsCmd.PreRunE,
 		RunE:    resultsCmd.RunE,
-		Hidden:  true,
 	}
 	runsShowCmd.Flags().AddFlagSet(resultsCmd.Flags())
 
 	runsCmd.AddCommand(runsStartCmd)
-	runsCmd.AddCommand(runsGetCmd)
 	runsCmd.AddCommand(runsShowCmd)
 	runsCmd.AddCommand(runsListCmd)
 

--- a/cmd/rwx/runs_test.go
+++ b/cmd/rwx/runs_test.go
@@ -47,13 +47,23 @@ func TestRunsStartMirrorsRun(t *testing.T) {
 	}
 }
 
-func TestRunsResultAliasesStayHidden(t *testing.T) {
-	for _, name := range []string{"get", "show"} {
-		aliasCmd := findSubcommand(runsCmd, name)
-		require.NotNil(t, aliasCmd, "rwx runs %s should exist", name)
-		require.True(t, aliasCmd.Hidden, "rwx runs %s should remain hidden", name)
-		require.True(t, sameFunc(aliasCmd.RunE, resultsCmd.RunE), "rwx runs %s should alias results", name)
-	}
+func TestRunsShowIsVisibleAndAliasesResults(t *testing.T) {
+	// show is the visible single-run inspection command and reuses results'
+	// execution so the two stay in lockstep.
+	showCmd := findSubcommand(runsCmd, "show")
+	require.NotNil(t, showCmd, "rwx runs show should exist")
+	require.False(t, showCmd.Hidden, "rwx runs show should be visible for discoverability")
+	require.True(t, sameFunc(showCmd.RunE, resultsCmd.RunE), "rwx runs show should alias results")
+	require.Equal(t, resultsCmd.Short, showCmd.Short)
+}
+
+func TestRunsGetIsAnAliasOfShow(t *testing.T) {
+	// `get` resolves to show via a Cobra alias rather than its own command, so
+	// `rwx runs get` works without a second line under `rwx runs -h`.
+	require.Nil(t, findSubcommand(runsCmd, "get"), "rwx runs get should not be its own command")
+	showCmd := findSubcommand(runsCmd, "show")
+	require.NotNil(t, showCmd)
+	require.Contains(t, showCmd.Aliases, "get", "show should expose get as an alias")
 }
 
 // executeRoot runs the root command with the given args, capturing combined


### PR DESCRIPTION
### Background

[RWX-1135](https://linear.app/rwx-cloud/issue/RWX-1135/cli-surface-rwx-runs-show-in-rwx-runs-h-for-discoverability)

### Problem

Inspecting a single run — "what's the latest run / status for this branch+repo" — is already encapsulated by `rwx results`, which had `rwx runs show`/`rwx runs get` aliases. But those aliases were **hidden** from `rwx runs -h`, so the path wasn't discoverable. Without knowing it exists, the natural fallback is composing `rwx runs list --branch X --repository Y --limit 1`, which is more verbose and less obvious than a first-class `show`.

The aliases were originally hidden ([RWX-155](https://linear.app/rwx-cloud/issue/RWX-155/rwx-results-misses)) to silently absorb coding-agent guesses (`rwx runs get`/`show`/`<run-id>`) without a non-zero exit triggering retry loops — i.e. the goal was forgiving *input*, not hiding the command from humans browsing help.

### Solution

- Expose `rwx runs show` as a visible subcommand under `rwx runs`, alongside `list` and `start`. It reuses `rwx results`' `RunE`/`PreRunE`/`Args`/flags/long help so the two stay in lockstep.
- Keep `get` reachable as a Cobra alias of `show` (rather than its own hidden command), so `rwx runs get` still resolves gracefully without adding a redundant second line to `rwx runs -h`.
- This preserves the RWX-155 intent: guessed invocations still resolve without a non-zero exit, and the bare-id form (`rwx runs <id>`) still prints help via the non-runnable parent.

#### Further confirmation needed

- [ ] None — covered by automated tests (`TestRunsShowIsVisibleAndAliasesResults`, `TestRunsGetIsAnAliasOfShow`, plus the existing bare-parent/bare-id tests). Unit suite, `gofmt`, and `golangci-lint` all pass locally.