### PR TITLE
Retry rate-limited and transient runs-index fetches

### DIFF
--- a/cmd/rwx/runs_list.go
+++ b/cmd/rwx/runs_list.go
@@ -47,6 +47,14 @@ For a given run's full payload, run 'rwx results <id> --json'.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			useJson := useJsonOutput()
 
+			// Keep retry chatter off stdout under --json so the structured
+			// payload stays clean and parseable; in plain mode it rides along
+			// with the regular output.
+			retryProgress := io.Writer(os.Stdout)
+			if useJson {
+				retryProgress = os.Stderr
+			}
+
 			result, err := service.ListRuns(cli.ListRunsConfig{
 				RepositoryNames:   RunsListRepositories,
 				Branches:          RunsListBranches,
@@ -57,6 +65,7 @@ For a given run's full payload, run 'rwx results <id> --json'.`,
 				MyRuns:            RunsListMine,
 				Limit:             RunsListLimit,
 				Cursor:            RunsListCursor,
+				RetryProgress:     retryProgress,
 			})
 			if err != nil {
 				return err

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1619,11 +1619,12 @@ func (c Client) CancelRun(runID, scopedToken string) error {
 	return nil
 }
 
-func (c Client) ListSandboxRuns() (*ListSandboxRunsResult, error) {
+func (c Client) ListSandboxRuns(retryProgress io.Writer) (*ListSandboxRunsResult, error) {
 	result, err := c.ListRuns(ListRunsConfig{
 		ResultStatuses:    []string{"sandboxed"},
 		ExecutionStatuses: []string{"in_progress"},
 		MyRuns:            true,
+		RetryProgress:     retryProgress,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 
 	"github.com/rwx-cloud/rwx/internal/accesstoken"
 	"github.com/rwx-cloud/rwx/internal/errors"
@@ -489,6 +490,12 @@ type ListRunsConfig struct {
 	MyRuns            bool
 	Limit             int
 	Cursor            string
+
+	// RetryProgress, when non-nil, receives a one-line notice before each
+	// backoff sleep so a caller paging many pages can show that a rate-limited
+	// or transient retry is underway rather than appearing hung. It is not part
+	// of the request and is ignored by queryParams.
+	RetryProgress io.Writer
 }
 
 type CreateSandboxTokenConfig struct {

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -1,0 +1,12 @@
+package api
+
+import "time"
+
+// StubListRunsRetrySleep replaces the ListRuns retry backoff sleep so external
+// (api_test) tests can exercise retry paths without real delays. It returns a
+// function that restores the original sleep.
+func StubListRunsRetrySleep(fn func(time.Duration)) func() {
+	original := listRunsRetrySleep
+	listRunsRetrySleep = fn
+	return func() { listRunsRetrySleep = original }
+}

--- a/internal/api/runs.go
+++ b/internal/api/runs.go
@@ -8,9 +8,15 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/rwx-cloud/rwx/internal/errors"
+	"github.com/rwx-cloud/rwx/internal/retry"
 )
+
+// listRunsRetrySleep is indirected so tests can exercise the backoff loop
+// without real delays.
+var listRunsRetrySleep = time.Sleep
 
 // RunFilterValidationEntry is one leaf of the structured 400 returned when a
 // closed-enum status filter has an unknown value. SuggestedValue is the single
@@ -56,9 +62,9 @@ type RateLimitedError struct {
 
 func (e *RateLimitedError) Error() string {
 	if e.RetryAfterSeconds > 0 {
-		return fmt.Sprintf("rate limited by RWX (100 requests/min). Retry after %d seconds.", e.RetryAfterSeconds)
+		return fmt.Sprintf("rate limited by RWX. Retry after %d seconds.", e.RetryAfterSeconds)
 	}
-	return "rate limited by RWX (100 requests/min). Please retry shortly."
+	return "rate limited by RWX. Please retry shortly."
 }
 
 // queryParams maps the config onto the index's accepted parameters. Each filter
@@ -100,41 +106,103 @@ func setFilterParam(params url.Values, scalarKey, pluralKey string, values []str
 	}
 }
 
+// ListRuns fetches one page of the runs index. The index is rate limited
+// (100 req/min), so a 429 — along with transient 5xx, network, and empty /
+// non-JSON responses — is retried with bounded backoff (honoring Retry-After
+// when present) rather than failing the caller mid-page. Retries are announced
+// on cfg.RetryProgress when set so a multi-page paging loop does not look hung.
 func (c Client) ListRuns(cfg ListRunsConfig) (*ListRunsResult, error) {
 	endpoint := "/mint/api/runs?" + cfg.queryParams().Encode()
 
+	backoff := retry.NewBackoff()
+
+	for {
+		result, retryAfter, retryable, err := c.listRunsOnce(endpoint)
+		if err == nil {
+			return result, nil
+		}
+
+		// 4xx other than 429 (bad filter, bad cursor, auth) are caller errors;
+		// surface them immediately rather than burning retries.
+		if !retryable {
+			return nil, err
+		}
+
+		// Record the transient failure; once the bounded attempt cap is hit,
+		// surface the underlying error rather than retrying forever.
+		delay, capErr := backoff.Record()
+		if capErr != nil {
+			return nil, err
+		}
+
+		// Honor the server's Retry-After window when it gives one; otherwise
+		// fall back to the exponential backoff schedule.
+		if retryAfter > 0 {
+			delay = time.Duration(retryAfter) * time.Second
+		}
+
+		reportListRunsRetry(cfg.RetryProgress, err, delay, backoff)
+		listRunsRetrySleep(delay)
+	}
+}
+
+// listRunsOnce performs a single runs-index request. The retryable flag tells
+// ListRuns whether the error is worth backing off and retrying; retryAfter
+// carries the 429 Retry-After window (in seconds) when present.
+func (c Client) listRunsOnce(endpoint string) (result *ListRunsResult, retryAfter int, retryable bool, err error) {
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to create new HTTP request")
+		return nil, 0, false, errors.Wrap(err, "unable to create new HTTP request")
 	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.RoundTrip(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "HTTP request failed")
+		// Only transient transport failures (resets, timeouts, EOF) are worth a
+		// retry; a fatal transport error (bad cert, etc.) surfaces immediately.
+		return nil, 0, retry.IsTransient(err), errors.Wrap(err, "HTTP request failed")
 	}
 	defer resp.Body.Close()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		result := ListRunsResult{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return nil, errors.Wrap(err, "unable to parse API response")
+		decoded := ListRunsResult{}
+		if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+			// An empty or truncated body on a 200 is transient; retry it.
+			return nil, 0, true, errors.Wrap(err, "unable to parse API response")
 		}
-		return &result, nil
+		return &decoded, 0, false, nil
 	case http.StatusBadRequest:
-		return nil, parseInvalidRunFilterError(resp.Body)
+		return nil, 0, false, parseInvalidRunFilterError(resp.Body)
 	case http.StatusTooManyRequests:
 		// The 429 body is empty; Retry-After carries the window in seconds.
 		retryAfter, _ := strconv.Atoi(resp.Header.Get("Retry-After"))
-		return nil, &RateLimitedError{RetryAfterSeconds: retryAfter}
+		return nil, retryAfter, true, &RateLimitedError{RetryAfterSeconds: retryAfter}
 	default:
 		msg := extractErrorMessage(resp.Body)
 		if msg == "" {
 			msg = fmt.Sprintf("Unable to call RWX API - %s", resp.Status)
 		}
-		return nil, classifyHTTPStatusError(resp.StatusCode, msg)
+		isTransient := resp.StatusCode >= 500 && resp.StatusCode < 600
+		return nil, 0, isTransient, classifyHTTPStatusError(resp.StatusCode, msg)
 	}
+}
+
+// reportListRunsRetry writes a one-line retry notice to w (when non-nil). The
+// attempt just failed; the displayed number is the upcoming attempt.
+func reportListRunsRetry(w io.Writer, err error, delay time.Duration, backoff *retry.Backoff) {
+	if w == nil {
+		return
+	}
+
+	reason := "RWX API request failed"
+	var rateErr *RateLimitedError
+	if errors.As(err, &rateErr) {
+		reason = "rate limited by RWX (100 requests/min)"
+	}
+
+	seconds := int(delay.Round(time.Second).Seconds())
+	fmt.Fprintf(w, "%s, retrying in %ds (attempt %d/%d)\n", reason, seconds, backoff.ConsecutiveFailures+1, backoff.MaxFailures)
 }
 
 // parseInvalidRunFilterError handles both 400 shapes from the index: the

--- a/internal/api/runs.go
+++ b/internal/api/runs.go
@@ -198,7 +198,7 @@ func reportListRunsRetry(w io.Writer, err error, delay time.Duration, backoff *r
 	reason := "RWX API request failed"
 	var rateErr *RateLimitedError
 	if errors.As(err, &rateErr) {
-		reason = "rate limited by RWX (100 requests/min)"
+		reason = "rate limited by RWX"
 	}
 
 	seconds := int(delay.Round(time.Second).Seconds())

--- a/internal/api/runs_retry_test.go
+++ b/internal/api/runs_retry_test.go
@@ -1,0 +1,167 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rwx-cloud/rwx/internal/errors"
+	"github.com/rwx-cloud/rwx/internal/retry"
+	"github.com/stretchr/testify/require"
+)
+
+// stubRetrySleep replaces the package-level sleep for the duration of a test,
+// recording the delays it was asked to wait instead of actually sleeping.
+func stubRetrySleep(t *testing.T) *[]time.Duration {
+	t.Helper()
+	original := listRunsRetrySleep
+	var slept []time.Duration
+	listRunsRetrySleep = func(d time.Duration) { slept = append(slept, d) }
+	t.Cleanup(func() { listRunsRetrySleep = original })
+	return &slept
+}
+
+func okRunsResponse() *http.Response {
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(`{"runs":[],"pagination":{"next_cursor":null,"limit":50}}`)),
+	}
+}
+
+func rateLimitedResponse(retryAfter string) *http.Response {
+	header := http.Header{}
+	if retryAfter != "" {
+		header.Set("Retry-After", retryAfter)
+	}
+	return &http.Response{
+		Status:     "429 Too Many Requests",
+		StatusCode: 429,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+}
+
+func TestListRuns_Retry(t *testing.T) {
+	t.Run("retries a 429 honoring Retry-After, then succeeds", func(t *testing.T) {
+		slept := stubRetrySleep(t)
+
+		attempts := 0
+		c := NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts == 1 {
+				return rateLimitedResponse("60"), nil
+			}
+			return okRunsResponse(), nil
+		})
+
+		var progress bytes.Buffer
+		result, err := c.ListRuns(ListRunsConfig{RetryProgress: &progress})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, 2, attempts)
+		require.Equal(t, []time.Duration{60 * time.Second}, *slept)
+		require.Contains(t, progress.String(), "rate limited by RWX")
+		require.Contains(t, progress.String(), "retrying in 60s")
+		require.Contains(t, progress.String(), "attempt 2/5")
+	})
+
+	t.Run("retries transient 5xx with exponential backoff", func(t *testing.T) {
+		slept := stubRetrySleep(t)
+
+		attempts := 0
+		c := NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts < 3 {
+				return &http.Response{
+					Status:     "503 Service Unavailable",
+					StatusCode: 503,
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, nil
+			}
+			return okRunsResponse(), nil
+		})
+
+		result, err := c.ListRuns(ListRunsConfig{})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, 3, attempts)
+		// No Retry-After, so backoff doubles: 1s then 2s.
+		require.Equal(t, []time.Duration{1 * time.Second, 2 * time.Second}, *slept)
+	})
+
+	t.Run("retries an empty / non-JSON 200 body", func(t *testing.T) {
+		stubRetrySleep(t)
+
+		attempts := 0
+		c := NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts == 1 {
+				return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(""))}, nil
+			}
+			return okRunsResponse(), nil
+		})
+
+		result, err := c.ListRuns(ListRunsConfig{})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, 2, attempts)
+	})
+
+	t.Run("gives up after the max attempts and surfaces the last error", func(t *testing.T) {
+		slept := stubRetrySleep(t)
+
+		attempts := 0
+		c := NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			return rateLimitedResponse("5"), nil
+		})
+
+		maxAttempts := retry.NewBackoff().MaxFailures
+		_, err := c.ListRuns(ListRunsConfig{})
+		require.Error(t, err)
+		var rateErr *RateLimitedError
+		require.True(t, errors.As(err, &rateErr))
+		require.Equal(t, maxAttempts, attempts)
+		// One fewer sleep than attempts: the final failure is not followed by a sleep.
+		require.Len(t, *slept, maxAttempts-1)
+	})
+
+	t.Run("does not retry a non-retryable 4xx", func(t *testing.T) {
+		slept := stubRetrySleep(t)
+
+		attempts := 0
+		c := NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			raw := `{"errors":[{"key":"result_status","provided_value":"nope","suggested_value":"failed","valid_values":["failed"]}]}`
+			return &http.Response{Status: "400 Bad Request", StatusCode: 400, Body: io.NopCloser(strings.NewReader(raw))}, nil
+		})
+
+		_, err := c.ListRuns(ListRunsConfig{})
+		require.Error(t, err)
+		var filterErr *InvalidRunFilterError
+		require.True(t, errors.As(err, &filterErr))
+		require.Equal(t, 1, attempts)
+		require.Empty(t, *slept)
+	})
+
+	t.Run("stays silent when no RetryProgress writer is set", func(t *testing.T) {
+		stubRetrySleep(t)
+
+		attempts := 0
+		c := NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts == 1 {
+				return rateLimitedResponse("1"), nil
+			}
+			return okRunsResponse(), nil
+		})
+
+		// A nil RetryProgress must not panic; the retry still happens.
+		_, err := c.ListRuns(ListRunsConfig{})
+		require.NoError(t, err)
+		require.Equal(t, 2, attempts)
+	})
+}

--- a/internal/api/runs_retry_test.go
+++ b/internal/api/runs_retry_test.go
@@ -147,6 +147,26 @@ func TestListRuns_Retry(t *testing.T) {
 		require.Empty(t, *slept)
 	})
 
+	t.Run("ListSandboxRuns forwards the retry-progress writer", func(t *testing.T) {
+		stubRetrySleep(t)
+
+		attempts := 0
+		c := NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts == 1 {
+				return rateLimitedResponse("1"), nil
+			}
+			return okRunsResponse(), nil
+		})
+
+		var progress bytes.Buffer
+		result, err := c.ListSandboxRuns(&progress)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, 2, attempts)
+		require.Contains(t, progress.String(), "rate limited by RWX")
+	})
+
 	t.Run("stays silent when no RetryProgress writer is set", func(t *testing.T) {
 		stubRetrySleep(t)
 

--- a/internal/api/runs_test.go
+++ b/internal/api/runs_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rwx-cloud/rwx/internal/api"
 	"github.com/rwx-cloud/rwx/internal/errors"
@@ -222,6 +223,9 @@ func TestAPIClient_ListRuns(t *testing.T) {
 	})
 
 	t.Run("synthesizes an actionable message from a 429 with Retry-After", func(t *testing.T) {
+		// Persistent 429s exhaust the retries; stub the backoff so the test is fast.
+		defer api.StubListRunsRetrySleep(func(time.Duration) {})()
+
 		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
 			header := http.Header{}
 			header.Set("Retry-After", "60")

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -53,7 +53,7 @@ type APIClient interface {
 	GetRunPrompt(runID string) (string, error)
 	GetRunPromptByTaskKey(runID, taskKey string) (string, error)
 	GetSandboxInitTemplate() (api.SandboxInitTemplateResult, error)
-	ListSandboxRuns() (*api.ListSandboxRunsResult, error)
+	ListSandboxRuns(retryProgress io.Writer) (*api.ListSandboxRunsResult, error)
 	CancelRun(runID, scopedToken string) error
 }
 

--- a/internal/cli/service_runs.go
+++ b/internal/cli/service_runs.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"io"
+
 	"github.com/rwx-cloud/rwx/internal/api"
 )
 
@@ -14,6 +16,11 @@ type ListRunsConfig struct {
 	MyRuns            bool
 	Limit             int
 	Cursor            string
+
+	// RetryProgress, when non-nil, receives a notice each time a rate-limited
+	// or transient request is retried. The command routes it to stderr under
+	// --json so structured stdout stays clean.
+	RetryProgress io.Writer
 }
 
 func (s Service) ListRuns(cfg ListRunsConfig) (*api.ListRunsResult, error) {
@@ -27,5 +34,6 @@ func (s Service) ListRuns(cfg ListRunsConfig) (*api.ListRunsResult, error) {
 		MyRuns:            cfg.MyRuns,
 		Limit:             cfg.Limit,
 		Cursor:            cfg.Cursor,
+		RetryProgress:     cfg.RetryProgress,
 	})
 }

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -579,7 +579,7 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 
 		if !found {
 			// Check if a matching sandbox already exists remotely
-			listResult, listErr := s.APIClient.ListSandboxRuns()
+			listResult, listErr := s.APIClient.ListSandboxRuns(s.Stderr)
 			if listErr == nil {
 				for _, run := range listResult.Runs {
 					if run.CliState == nil || *run.CliState == "" {
@@ -898,7 +898,7 @@ func (s Service) ListSandboxes(cfg ListSandboxesConfig) (*ListSandboxesResult, e
 		return nil, errors.Wrap(err, "unable to load sandbox sessions")
 	}
 
-	listResult, err := s.APIClient.ListSandboxRuns()
+	listResult, err := s.APIClient.ListSandboxRuns(s.Stderr)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to list sandbox runs")
 	}

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -1,6 +1,8 @@
 package mocks
 
 import (
+	"io"
+
 	"github.com/rwx-cloud/rwx/internal/api"
 	"github.com/rwx-cloud/rwx/internal/errors"
 )
@@ -377,7 +379,9 @@ func (c *API) GetRunPromptByTaskKey(runID, taskKey string) (string, error) {
 	return "", errors.New("MockGetRunPromptByTaskKey was not configured")
 }
 
-func (c *API) ListSandboxRuns() (*api.ListSandboxRunsResult, error) {
+// retryProgress is part of the production signature for surfacing retry chatter;
+// the mock ignores it since tests don't exercise the live backoff loop.
+func (c *API) ListSandboxRuns(_ io.Writer) (*api.ListSandboxRunsResult, error) {
 	if c.MockListSandboxRuns != nil {
 		return c.MockListSandboxRuns()
 	}


### PR DESCRIPTION
### Background

- [RWX-1133](https://linear.app/rwx-cloud/issue/RWX-1133/cli-rwx-runs-list-automatic-retries-on-rate-limit-transient-errors)
- Paired server-side change that retunes the limit: [rwx-cloud/cloud#7834](https://github.com/rwx-cloud/cloud/pull/7834)

### Problem

The runs index is rate limited, so paging a large result set with `rwx runs list` died mid-run on a 429 (or a transient 5xx / empty body), forcing callers to hand-roll their own backoff.

### Solution

- Retry in `api.ListRuns`, so every paged `list` and the internal `ListSandboxRuns` get it consistently.
- Retries `429` (honoring `Retry-After`), transient `5xx`, transient transport errors, and empty/non-JSON `200`s; non-retryable `4xx` surface immediately. Bounded backoff reuses the existing `retry.Backoff`.
- Retries are visible (`rate limited by RWX, retrying in 60s (attempt 2/5)`), routed to stderr under `--json` so stdout stays parseable. Sandbox run lookups (`ListSandboxRuns`) surface the same progress.
- Client-facing messages intentionally do **not** restate the server's limit (e.g. "100 requests/min"): the limit is server-owned and being retuned in the paired PR, so the CLI relies on the `Retry-After` header rather than echoing a number that would drift.

#### Further confirmation needed

- [ ] End-to-end behavior against a live 429 (unit tests use a stubbed transport).
