### PR TITLE
Rename RWX_HIDE_SKILL_HINT to RWX_HIDE_LATEST_SKILL_VERSION

### DIFF
--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -85,7 +85,7 @@ func (s Service) outputLatestVersionMessage() {
 }
 
 func (s Service) outputOutdatedSkillMessage() {
-	if os.Getenv("RWX_HIDE_SKILL_HINT") != "" {
+	if os.Getenv("RWX_HIDE_LATEST_SKILL_VERSION") != "" {
 		return
 	}
 

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -85,7 +85,7 @@ func (s Service) outputLatestVersionMessage() {
 }
 
 func (s Service) outputOutdatedSkillMessage() {
-	if os.Getenv("RWX_HIDE_LATEST_SKILL_VERSION") != "" {
+	if os.Getenv("RWX_HIDE_LATEST_SKILL_VERSION") != "" || os.Getenv("RWX_HIDE_SKILL_HINT") != "" {
 		return
 	}
 

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -128,7 +128,7 @@ func TestOutputOutdatedSkillMessage(t *testing.T) {
 		s := setupSkillTest(t)
 		seedSkillFile(t, s.tmp, "1.0.0")
 		_ = versions.SetSkillLatestVersion("2.0.0")
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -163,7 +163,7 @@ func TestSkillStatus(t *testing.T) {
 		}
 
 		// Suppress the nag from NewService so it does not interfere.
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -189,7 +189,7 @@ func TestSkillStatus(t *testing.T) {
 			return "", nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -213,7 +213,7 @@ func TestSkillStatus(t *testing.T) {
 			return "2.0.0", nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -232,7 +232,7 @@ func TestSkillStatus(t *testing.T) {
 			return "", fmt.Errorf("network error")
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -251,7 +251,7 @@ func TestSkillStatus(t *testing.T) {
 			return "2.0.0", nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -271,7 +271,7 @@ func TestSkillUpdate(t *testing.T) {
 		_ = backend.Set("2.0.0")
 		s.config.SkillVersionsBackend = backend
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -290,7 +290,7 @@ func TestSkillUpdate(t *testing.T) {
 		_ = backend.Set("2.0.0")
 		s.config.SkillVersionsBackend = backend
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -314,7 +314,7 @@ func TestSkillUpdate(t *testing.T) {
 			return newContent, nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -344,7 +344,7 @@ func TestSkillUpdate(t *testing.T) {
 			return "2.0.0", nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -365,7 +365,7 @@ func TestSkillUpdate(t *testing.T) {
 			return "dev", nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -386,7 +386,7 @@ func TestSkillInstall(t *testing.T) {
 			return skillContent, nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -410,7 +410,7 @@ func TestSkillInstall(t *testing.T) {
 			return "---\nmetadata:\n  version: 2.0.0\n---\nSkill content\n", nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -432,7 +432,7 @@ func TestSkillInstall(t *testing.T) {
 			return "---\nmetadata:\n  version: 2.0.0\n---\nSkill content\n", nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -455,7 +455,7 @@ func TestSkillInstall(t *testing.T) {
 			return "---\nmetadata:\n  version: 2.0.0\n---\nSkill content\n", nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -480,7 +480,7 @@ func TestSkillInstall(t *testing.T) {
 			return "---\nmetadata:\n  version: 2.0.0\n---\nSkill content\n", nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -502,7 +502,7 @@ func TestSkillInstall(t *testing.T) {
 			return "", nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -530,7 +530,7 @@ func TestSkillInstall(t *testing.T) {
 			return "---\nmetadata:\n  version: 2.0.0\n---\nSkill content\n", nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -552,7 +552,7 @@ func TestSkillInstall(t *testing.T) {
 			return "", nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -572,7 +572,7 @@ func TestSkillInstall(t *testing.T) {
 			return "---\nmetadata:\n  version: 2.0.0\n---\nSkill content\n", nil
 		}
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)
@@ -594,7 +594,7 @@ func TestSkillInstall(t *testing.T) {
 		s.mockStdin = bytes.NewBufferString("nope\n")
 		s.config.Stdin = s.mockStdin
 
-		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+		t.Setenv("RWX_HIDE_LATEST_SKILL_VERSION", "1")
 
 		var err error
 		s.service, err = cli.NewService(s.config)

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -136,6 +136,18 @@ func TestOutputOutdatedSkillMessage(t *testing.T) {
 		require.Empty(t, s.mockStderr.String())
 	})
 
+	t.Run("suppressed by legacy env var", func(t *testing.T) {
+		s := setupSkillTest(t)
+		seedSkillFile(t, s.tmp, "1.0.0")
+		_ = versions.SetSkillLatestVersion("2.0.0")
+		t.Setenv("RWX_HIDE_SKILL_HINT", "1")
+
+		var err error
+		s.service, err = cli.NewService(s.config)
+		require.NoError(t, err)
+		require.Empty(t, s.mockStderr.String())
+	})
+
 	t.Run("prints upgrade instructions including installations with no version", func(t *testing.T) {
 		s := setupSkillTest(t)
 		seedSkillFile(t, s.tmp, "")


### PR DESCRIPTION
Renames the `RWX_HIDE_SKILL_HINT` environment variable to `RWX_HIDE_LATEST_SKILL_VERSION` for consistency with the existing `RWX_HIDE_LATEST_VERSION` variable.

Confined to the env var check in `internal/cli/service.go` and its test setups in `internal/cli/service_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)