### PR TITLE
Require non-empty value for RWX_DISABLE_GIT_PATCH

### DIFF
--- a/internal/cli/service_run.go
+++ b/internal/cli/service_run.go
@@ -217,7 +217,7 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 
 	// Generate patches if enabled and git is available
 	patchable := cfg.Patchable && gitAvailable
-	if _, ok := os.LookupEnv("RWX_DISABLE_GIT_PATCH"); ok {
+	if os.Getenv("RWX_DISABLE_GIT_PATCH") != "" {
 		patchable = false
 	}
 


### PR DESCRIPTION
## Summary

`RWX_DISABLE_GIT_PATCH` used `os.LookupEnv` (presence-based), so setting it to an empty string would still disable git patching. The other feature-flag env vars (`RWX_HIDE_LATEST_VERSION`, `MINT_HIDE_LATEST_VERSION`, `RWX_HIDE_SKILL_HINT`) use `Getenv() != ""` and require a non-empty value.

This aligns `RWX_DISABLE_GIT_PATCH` on the non-empty idiom for consistency, and to avoid the footgun where an empty value (which reads as "off") still triggers the behavior.

## Behavior change

Relying on `RWX_DISABLE_GIT_PATCH=` (empty) to disable the patch no longer works — a non-empty value (e.g. `1`) is now required.

## Testing

Existing patch tests pass (they set the var to `"1"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)