### PR TITLE
Suppress version hints when stderr is not a TTY

### DIFF
--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -70,7 +70,7 @@ func (s Service) outputLatestVersionMessage() {
 
 	showLatestVersion := os.Getenv("MINT_HIDE_LATEST_VERSION") == "" && os.Getenv("RWX_HIDE_LATEST_VERSION") == ""
 
-	if !showLatestVersion {
+	if !showLatestVersion || !s.StderrIsTTY {
 		return
 	}
 
@@ -85,7 +85,7 @@ func (s Service) outputLatestVersionMessage() {
 }
 
 func (s Service) outputOutdatedSkillMessage() {
-	if os.Getenv("RWX_HIDE_SKILL_HINT") != "" {
+	if os.Getenv("RWX_HIDE_SKILL_HINT") != "" || !s.StderrIsTTY {
 		return
 	}
 

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -136,11 +136,24 @@ func TestOutputOutdatedSkillMessage(t *testing.T) {
 		require.Empty(t, s.mockStderr.String())
 	})
 
+	t.Run("suppressed when stderr is not a tty", func(t *testing.T) {
+		s := setupSkillTest(t)
+		seedSkillFile(t, s.tmp, "1.0.0")
+		_ = versions.SetSkillLatestVersion("2.0.0")
+		s.config.StderrIsTTY = false
+
+		var err error
+		s.service, err = cli.NewService(s.config)
+		require.NoError(t, err)
+		require.Empty(t, s.mockStderr.String())
+	})
+
 	t.Run("prints upgrade instructions including installations with no version", func(t *testing.T) {
 		s := setupSkillTest(t)
 		seedSkillFile(t, s.tmp, "")
 		seedMarketplaceSkillFile(t, s.tmp, "1.1.0")
 		_ = versions.SetSkillLatestVersion("2.0.0")
+		s.config.StderrIsTTY = true
 
 		var err error
 		s.service, err = cli.NewService(s.config)


### PR DESCRIPTION
## What

Automatically suppress the two stderr "nag" hints — the CLI upgrade hint ("A new release of rwx is available…") and the agent-skill hint ("A new version of the RWX agent skill is available…") — when stderr is not a terminal.

## Why

When `rwx` runs inside a script, pipeline, or CI job, these hints add noise to captured output. Previously the only way to silence them was to set an env var explicitly. Now scripts get clean output by default.

## How

Both hints write to `s.Stderr`, and the CLI already detects whether stderr is a terminal via `Config.StderrIsTTY` (set in `cmd/rwx/root.go` using `term.IsTerminal`). The change adds a `!s.StderrIsTTY` guard to each hint function in `internal/cli/service.go` — no new plumbing, env vars, or fields.

The existing env-var opt-outs (`RWX_HIDE_LATEST_VERSION` / legacy `MINT_HIDE_LATEST_VERSION`, and `RWX_HIDE_SKILL_HINT`) remain as explicit overrides for users who want to suppress hints even in an interactive terminal.

## Behavior change to note

Most CI runners present stderr as a non-TTY, so upgrade/skill hints will no longer appear in CI logs. This is the intended outcome of "disable hints in scripts."

## Tests

- Added a negative subtest covering non-TTY suppression of the skill hint.
- Updated the existing positive skill-hint test to set `StderrIsTTY: true` (it previously relied on the default `false`).
- `go build ./cmd/rwx` and `go test ./internal/cli/... ./cmd/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)