### PR TITLE
Switch rwx results to canonical /mint/api/results/:id route

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1161,14 +1161,12 @@ func (c Client) RunStatus(cfg RunStatusConfig) (RunStatusResult, error) {
 }
 
 func (c Client) GetRunDetails(cfg RunDetailsConfig) (map[string]any, error) {
-	params := url.Values{}
+	endpoint := "/mint/api/results/" + url.PathEscape(cfg.RunID)
 	if cfg.TaskKey != "" {
-		params.Set("run_id", cfg.RunID)
+		params := url.Values{}
 		params.Set("task_key", cfg.TaskKey)
-	} else {
-		params.Set("id", cfg.RunID)
+		endpoint += "?" + params.Encode()
 	}
-	endpoint := "/mint/api/results/details?" + params.Encode()
 
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1532,6 +1532,45 @@ func TestAPIClient_CreateSandboxToken(t *testing.T) {
 	})
 }
 
+func TestAPIClient_GetRunDetails(t *testing.T) {
+	t.Run("requests the RESTful results path with the id in the path", func(t *testing.T) {
+		roundTrip := func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "/mint/api/results/run-123", req.URL.Path)
+			require.Empty(t, req.URL.RawQuery)
+			require.Equal(t, http.MethodGet, req.Method)
+			return &http.Response{
+				Status:     "200 OK",
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"run":{}}`))),
+			}, nil
+		}
+
+		c := api.NewClientWithRoundTrip(roundTrip)
+
+		_, err := c.GetRunDetails(api.RunDetailsConfig{RunID: "run-123"})
+		require.NoError(t, err)
+	})
+
+	t.Run("scopes to a task via the task_key query param on the run path", func(t *testing.T) {
+		roundTrip := func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "/mint/api/results/run-123", req.URL.Path)
+			require.Equal(t, "build", req.URL.Query().Get("task_key"))
+			require.Empty(t, req.URL.Query().Get("run_id"))
+			require.Empty(t, req.URL.Query().Get("id"))
+			return &http.Response{
+				Status:     "200 OK",
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"run":{}}`))),
+			}, nil
+		}
+
+		c := api.NewClientWithRoundTrip(roundTrip)
+
+		_, err := c.GetRunDetails(api.RunDetailsConfig{RunID: "run-123", TaskKey: "build"})
+		require.NoError(t, err)
+	})
+}
+
 func TestAPIClient_GetRunPrompt(t *testing.T) {
 	t.Run("builds the request and returns the prompt text", func(t *testing.T) {
 		roundTrip := func(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
### Background

[RWX-1151](https://linear.app/rwx-cloud/issue/RWX-1151/switch-rwx-results-cli-to-read-from-get-mintapiresultsid), following RWX-1150, which moved the enriched run/task drill-in to a RESTful `GET /mint/api/results/:id`.

### Problem

`rwx results` still reads the enriched payload from the legacy `/mint/api/results/details` route, passing the id as a query param. That route is now a non-canonical alias. Moving clients onto the canonical path lets us retire `details` later.

### Solution

- Run-scoped: `GET /mint/api/results/{id}`.
- Task-scoped: `GET /mint/api/results/{runID}?task_key=...`.

Both routes dispatch to the same action, so auth and the response payload don't change. The edit is isolated to `GetRunDetails` in `internal/api/client.go`. The service layer, config, and callers stay as they are because the `RunID`/`TaskKey` contract is unchanged. Added client tests covering the new path for both cases.

#### Further confirmation needed

- [ ] Confirm `rwx results <run-id>` and `rwx results <run-id> --task-key=<key>` return enriched output against the deployed endpoint.
