### PR TITLE
Fix sandbox/run git patch sync for file renames

### DIFF
--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1304,7 +1304,7 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 
 	// Get patch from sandbox (stdout only to avoid output capture issues after sync markers).
 	// Binary diffs need full indexes so local git apply can recreate new binary files.
-	exitCode, patch, err := s.SSHClient.ExecuteCommandWithOutput(sandboxWorktreeRootCommand("/usr/bin/git diff --binary --full-index refs/rwx-sync"))
+	exitCode, patch, err := s.SSHClient.ExecuteCommandWithOutput(sandboxWorktreeRootCommand("/usr/bin/git diff --binary --full-index --no-renames refs/rwx-sync"))
 	patchBytes := len(patch)
 
 	// Reset the intent-to-add for untracked files

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -2570,7 +2570,7 @@ func TestService_ExecSandbox_Pull(t *testing.T) {
 			}
 			if isSandboxPullDiffCommand(cmd) {
 				foundDiffRef = true
-				requireSandboxWorktreeRootCommand(t, cmd, "/usr/bin/git diff --binary --full-index refs/rwx-sync")
+				requireSandboxWorktreeRootCommand(t, cmd, "/usr/bin/git diff --binary --full-index --no-renames refs/rwx-sync")
 			}
 			if strings.Contains(cmd, "git reset HEAD") {
 				foundReset = true

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -527,11 +527,11 @@ func (c *Client) GenerateDirtyPatches() (DirtyPatches, error) {
 		}, nil
 	}
 
-	staged, err := c.diffBytes("diff", "--cached", "-p", "--binary")
+	staged, err := c.diffBytes("diff", "--cached", "-p", "--binary", "--no-renames")
 	if err != nil {
 		return DirtyPatches{}, err
 	}
-	unstaged, err := c.diffBytes("diff", "-p", "--binary")
+	unstaged, err := c.diffBytes("diff", "-p", "--binary", "--no-renames")
 	if err != nil {
 		return DirtyPatches{}, err
 	}
@@ -544,8 +544,8 @@ func (c *Client) changedFilesForDirtyPatch() ([]string, error) {
 	var files []string
 
 	for _, args := range [][]string{
-		{"diff", "--cached", "-z", "--name-only"},
-		{"diff", "-z", "--name-only"},
+		{"diff", "--cached", "-z", "--name-only", "--no-renames"},
+		{"diff", "-z", "--name-only", "--no-renames"},
 	} {
 		cmd := exec.Command(c.Binary, args...)
 		cmd.Dir = c.Dir
@@ -571,8 +571,8 @@ func (c *Client) newFilesForDirtyPatch() ([]string, error) {
 	var files []string
 
 	for _, args := range [][]string{
-		{"diff", "--cached", "-z", "--name-only", "--diff-filter=A"},
-		{"diff", "-z", "--name-only", "--diff-filter=A"},
+		{"diff", "--cached", "-z", "--name-only", "--diff-filter=A", "--no-renames"},
+		{"diff", "-z", "--name-only", "--diff-filter=A", "--no-renames"},
 	} {
 		cmd := exec.Command(c.Binary, args...)
 		cmd.Dir = c.Dir

--- a/test/integration/sandbox-rename-sync.sh
+++ b/test/integration/sandbox-rename-sync.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/sandbox-helpers.sh"
+
+SANDBOX_CONFIG="${SCRIPT_DIR}/definitions/sandbox-setup-sync.yml"
+
+PUSH_OLD="CONTRIBUTING.md"
+PUSH_NEW="CONTRIBUTING-renamed.md"
+PULL_OLD="LICENSE"
+PULL_NEW="LICENSE-renamed"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+cleanup() {
+  rm -f "${PUSH_NEW}" "${PULL_NEW}"
+  git restore "${PUSH_OLD}" "${PULL_OLD}" 2>/dev/null || true
+  rm -f setup-artifact.txt
+  "${RWX_CLI}" sandbox stop 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Scenario: a local file rename syncs into a fresh sandbox"
+mv "${PUSH_OLD}" "${PUSH_NEW}"
+"${RWX_CLI}" sandbox exec "${SANDBOX_CONFIG}" --init "ref=${COMMIT_SHA}" \
+  -- sh -c "test ! -e '${PUSH_OLD}' && test -e '${PUSH_NEW}'"
+git restore "${PUSH_OLD}"
+rm -f "${PUSH_NEW}"
+echo "PASS: local rename synced into the sandbox"
+
+echo "Scenario: a rename performed inside the sandbox is pulled back locally"
+"${RWX_CLI}" sandbox exec "${SANDBOX_CONFIG}" --init "ref=${COMMIT_SHA}" \
+  -- sh -c "git mv '${PULL_OLD}' '${PULL_NEW}'"
+[ ! -e "${PULL_OLD}" ] || fail "${PULL_OLD} should have been removed locally after the sandbox rename"
+[ -e "${PULL_NEW}" ] || fail "${PULL_NEW} was not pulled back from the sandbox"
+echo "PASS: sandbox-side rename pulled back locally"


### PR DESCRIPTION
### Background

- Slack: rwx sandbox exec failing on a renamed file (https://rwxhq.slack.com/archives/C044VB13K6G/p1782756645945809)
- Linear: https://linear.app/rwx-cloud/issue/RWX-1166/sandboxrun-git-patch-sync-fails-on-file-renames

### Problem

Rename a file before a sandbox sync and it dies with `git apply failed with exit code 1`. The dirty-patch sync runs `git diff` with rename detection on (the default), and that breaks two things:

- The rename destination shows up as `R`, not `A`, so `removePreAppliedNewFilesFromSandbox` never cleans it. It survives the `git reset --hard` as an orphaned untracked file, and re-apply then fails with `already exists in working directory`.
- The changed-files list drops the deleted source, so the `refs/rwx-sync` baseline no longer matches the worktree and pull-back fails trying to delete a file that is already gone locally.

### Solution

[Red](https://cloud.rwx.com/mint/rwx/runs/1ea8e03f648943b4abd4ddb288b2374e) | [Green](https://cloud.rwx.com/mint/rwx/runs/e082aa4bb9874abaa685119833173aea)

- Pass `--no-renames` to the dirty-patch diffs (patch generation, changed-files list, new-files list). A rename then syncs as delete-source plus add-destination, which is just the primitives we already handle.
- Pass `--no-renames` to the pull-back diff too, so a rename made inside the sandbox comes back as delete + add. This one isn't a crash I could reproduce — local always matches the baseline at pull time, so the rename applies — but it keeps both directions consistent and guards against a divergent worktree.
- Add an `rwx run` integration test (`test/integration/sandbox-rename-sync.sh`) covering both directions: a local rename synced into a fresh sandbox (red without the fix, green with it), and a sandbox-side rename pulled back locally.

#### Further confirmation needed

- [ ] None outstanding. Sanity-check the integration test on a real run if you want a second look.
