### PR TITLE
Send a non-thin pack when pushing git commits to the sandbox

### DIFF
--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -666,7 +666,10 @@ func (c *Client) PushRef(opts PushRefOptions) error {
 		return fmt.Errorf("no refspec provided")
 	}
 
-	cmd := exec.Command(c.Binary, "push", opts.Remote, opts.Refspec)
+	// --no-thin sends a self-contained pack: the sandbox repo is a shallow/partial
+	// clone that lacks the delta base objects a thin pack would reference, which
+	// otherwise fails with "unresolved deltas left after unpacking".
+	cmd := exec.Command(c.Binary, "push", "--no-thin", opts.Remote, opts.Refspec)
 	cmd.Dir = c.Dir
 	if len(opts.Env) > 0 {
 		cmd.Env = append(os.Environ(), opts.Env...)

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -450,6 +450,27 @@ func TestPushRef(t *testing.T) {
 	require.Equal(t, head, pushed)
 }
 
+// TestPushRefUsesNoThin guards the fix for RWX-1195: the sandbox repo is a
+// shallow/partial clone that lacks the delta bases a thin pack references, so
+// the push must be self-contained (--no-thin) or the remote fails with
+// "unresolved deltas left after unpacking".
+func TestPushRefUsesNoThin(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args")
+	fakeGit := filepath.Join(dir, "git")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argsFile + "\nexit 0\n"
+	require.NoError(t, os.WriteFile(fakeGit, []byte(script), 0o755))
+
+	client := &git.Client{Binary: fakeGit, Dir: dir}
+	err := client.PushRef(git.PushRefOptions{Remote: "sandbox", Refspec: "abc:refs/rwx/sync-push"})
+	require.NoError(t, err)
+
+	recorded, err := os.ReadFile(argsFile)
+	require.NoError(t, err)
+	args := strings.Fields(string(recorded))
+	require.Equal(t, []string{"push", "--no-thin", "sandbox", "abc:refs/rwx/sync-push"}, args)
+}
+
 func TestGeneratePatchFile(t *testing.T) {
 	t.Run("does not write a patch file", func(t *testing.T) {
 		t.Run("when git is not installed", func(t *testing.T) {


### PR DESCRIPTION
### Background

Linear: https://linear.app/rwx-cloud/issue/RWX-1195

Surfaced while investigating a report of sandbox changes not syncing back mid-rebase. That specific incident is **not** confirmed to be this bug (see caveats) — this PR is standalone hardening.

### Problem

`pushLocalHeadToSandbox` pushes a local commit into the sandbox when the sandbox doesn't already have it (e.g. a commit made mid-rebase, absent from `origin`). It used a plain `git push`, which builds a **thin pack**: deltas against objects the sender assumes the receiver has. The sandbox is a shallow/partial `git/clone`, so depending on the local repo's pack layout the pack can reference base objects the sandbox lacks, failing with:

```
remote: fatal: unresolved deltas left after unpacking
```

This is intermittent and depends on the local object store — I could reproduce it from a heavily-used working checkout (multiple packs) against a real shallow-clone sandbox, but **not** from a fresh clone, and CI's `sandbox-unpushed-commits.sh` doesn't hit it because CI itself checks out shallow (so the sender never picks a deep delta base).

### Solution

Push with `--no-thin` so the pack is self-contained — robustness no longer depends on the local repo's delta layout. Contained: `PushRef` is only used for the sandbox push.

### Caveats

- **Not a proven fix for the original report.** No client-side error logs from that session exist (sync runs over SSH, bracketed by markers Mint filters from task logs; `sandbox.sync_push` telemetry records only `success`, no error text). The one visible failure logged `patch_bytes=40752`, which by code order is a post-dirty-patch (`applyDirtyPatches`/snapshot) failure, not this push path.
- **No integration test.** The failure isn't deterministically reproducible (pack-layout-dependent), and CI's shallow checkout can't trigger it, so any added integration test would pass regardless. Covered by a unit test asserting the flag (`TestPushRefUsesNoThin`); manual repro: push a local-only commit into a shallow-cloned sandbox from a full working checkout.

#### Further confirmation needed

- [ ] The original mid-rebase incident is still open — the 13:36 empty pull looks like correct-empty behavior, and the 13:31 apply/snapshot failure (`patch_bytes=40752`) is unexplained. Investigating separately against the docs repo.
