### PR TITLE
Fix newlines around "Successfully set the following secrets" message

### DIFF
--- a/internal/cli/service_secrets.go
+++ b/internal/cli/service_secrets.go
@@ -156,8 +156,7 @@ func (s Service) SetSecretsInVault(cfg SetSecretsInVaultConfig) (*api.SetSecrets
 			return nil, errors.Wrap(err, "unable to encode JSON output")
 		}
 	} else if result != nil && len(result.SetSecrets) > 0 {
-		fmt.Fprintln(s.Stdout)
-		fmt.Fprintf(s.Stdout, "Successfully set the following secrets: %s", strings.Join(result.SetSecrets, ", "))
+		fmt.Fprintf(s.Stdout, "Successfully set the following secrets: %s\n", strings.Join(result.SetSecrets, ", "))
 	}
 
 	return result, nil

--- a/internal/cli/service_secrets_test.go
+++ b/internal/cli/service_secrets_test.go
@@ -54,7 +54,7 @@ func TestService_SettingSecrets(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, []string{"ABC", "DEF"}, result.SetSecrets)
-		require.Equal(t, "\nSuccessfully set the following secrets: ABC, DEF", s.mockStdout.String())
+		require.Equal(t, "Successfully set the following secrets: ABC, DEF\n", s.mockStdout.String())
 	})
 
 	t.Run("when reading secrets from a file", func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestService_SettingSecrets(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, []string{"A", "B", "C", "D"}, result.SetSecrets)
-		require.Equal(t, "\nSuccessfully set the following secrets: A, B, C, D", s.mockStdout.String())
+		require.Equal(t, "Successfully set the following secrets: A, B, C, D\n", s.mockStdout.String())
 	})
 }
 


### PR DESCRIPTION
## Summary

The `rwx secrets set` success message printed a leading blank line and was missing a trailing newline:

```go
fmt.Fprintln(s.Stdout)
fmt.Fprintf(s.Stdout, "Successfully set the following secrets: %s", ...)
```

This makes it match the sibling `DeleteSecret` message in the same file, which has no leading blank line and a trailing newline:

```go
fmt.Fprintf(s.Stdout, "Deleted secret %q from vault %q.\n", ...)
```

I checked the rest of `internal/cli` — the other leading-blank-line and no-trailing-newline occurrences are all intentional (section separators between newline-terminated blocks, or input prompts). This was the only inconsistent case.

## Changes
- `internal/cli/service_secrets.go` — remove the leading blank-line print, add a trailing `\n` to the message.
- `internal/cli/service_secrets_test.go` — update both assertions to match.

## Test plan
- `go test -run TestService_SettingSecrets ./internal/cli/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)