### PR TITLE
Skip fetching the package index when every reference is already pinned

### DIFF
--- a/internal/cli/service_packages.go
+++ b/internal/cli/service_packages.go
@@ -194,6 +194,54 @@ func (s Service) parsePackageVersion(str string) PackageVersion {
 	}
 }
 
+// packageReferenceNeedsResolution reports whether a package reference could be
+// rewritten by updatePackageReferenceAtPath: expressions and (outside of update
+// mode) already-versioned references never need the package index.
+func (s Service) packageReferenceNeedsResolution(original string, update bool) bool {
+	// Expressions can't be statically resolved, so skip them
+	if strings.Contains(original, "${{") {
+		return false
+	}
+
+	packageVersion := s.parsePackageVersion(original)
+	if packageVersion.Name == "" {
+		return false
+	} else if !update && packageVersion.MajorVersion != "" {
+		return false
+	}
+
+	return true
+}
+
+// forEachPackageReference visits every node in the file that may hold a package
+// reference: each task's `call`, plus `base.config` in run definitions.
+func forEachPackageReference(file *MintYAMLFile, fn func(yamlPath string, original string) error) error {
+	var nodePath string
+	if file.Doc.IsRunDefinition() {
+		nodePath = "$.tasks[*].call"
+	} else if file.Doc.IsListOfTasks() {
+		nodePath = "$[*].call"
+	} else {
+		return nil
+	}
+
+	err := file.Doc.ForEachNode(nodePath, func(node ast.Node) error {
+		return fn(node.GetPath(), node.String())
+	})
+	if err != nil {
+		return err
+	}
+
+	if file.Doc.IsRunDefinition() {
+		baseConfig := file.Doc.TryReadStringAtPath("$.base.config")
+		if baseConfig != "" && baseConfig != "none" {
+			return fn("$.base.config", baseConfig)
+		}
+	}
+
+	return nil
+}
+
 func (s Service) updatePackageReferenceAtPath(
 	doc *YAMLDoc,
 	yamlPath string,
@@ -203,17 +251,11 @@ func (s Service) updatePackageReferenceAtPath(
 	versionPicker func(versions api.PackageVersionsResult, rwxPackage string, major string) (string, error),
 	replacements map[string]string,
 ) (bool, error) {
-	// Expressions can't be statically resolved, so skip them
-	if strings.Contains(original, "${{") {
+	if !s.packageReferenceNeedsResolution(original, update) {
 		return false, nil
 	}
 
 	packageVersion := s.parsePackageVersion(original)
-	if packageVersion.Name == "" {
-		return false, nil
-	} else if !update && packageVersion.MajorVersion != "" {
-		return false, nil
-	}
 
 	newName := packageVersions.Renames[packageVersion.Name]
 	if newName == "" {
@@ -245,6 +287,27 @@ func (s Service) updatePackageReferenceAtPath(
 }
 
 func (s Service) resolveOrUpdatePackagesForFiles(mintFiles []*MintYAMLFile, update bool, versionPicker func(versions api.PackageVersionsResult, rwxPackage string, major string) (string, error)) (map[string]string, error) {
+	// Skip fetching the package index entirely when every reference is already
+	// pinned (the common case after the first run resolves them).
+	needsResolution := false
+	for _, file := range mintFiles {
+		err := forEachPackageReference(file, func(_ string, original string) error {
+			if s.packageReferenceNeedsResolution(original, update) {
+				needsResolution = true
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to scan package references")
+		}
+		if needsResolution {
+			break
+		}
+	}
+	if !needsResolution {
+		return map[string]string{}, nil
+	}
+
 	packageVersions, err := s.APIClient.GetPackageVersions()
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to fetch package versions")
@@ -256,17 +319,8 @@ func (s Service) resolveOrUpdatePackagesForFiles(mintFiles []*MintYAMLFile, upda
 	for _, file := range mintFiles {
 		hasChange := false
 
-		var nodePath string
-		if file.Doc.IsRunDefinition() {
-			nodePath = "$.tasks[*].call"
-		} else if file.Doc.IsListOfTasks() {
-			nodePath = "$[*].call"
-		} else {
-			continue
-		}
-
-		err = file.Doc.ForEachNode(nodePath, func(node ast.Node) error {
-			changed, err := s.updatePackageReferenceAtPath(file.Doc, node.GetPath(), node.String(), update, packageVersions, versionPicker, replacements)
+		err = forEachPackageReference(file, func(yamlPath string, original string) error {
+			changed, err := s.updatePackageReferenceAtPath(file.Doc, yamlPath, original, update, packageVersions, versionPicker, replacements)
 			if err != nil {
 				return err
 			}
@@ -277,19 +331,6 @@ func (s Service) resolveOrUpdatePackagesForFiles(mintFiles []*MintYAMLFile, upda
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to replace package references")
-		}
-
-		if file.Doc.IsRunDefinition() {
-			baseConfig := file.Doc.TryReadStringAtPath("$.base.config")
-			if baseConfig != "" && baseConfig != "none" {
-				changed, err := s.updatePackageReferenceAtPath(file.Doc, "$.base.config", baseConfig, update, packageVersions, versionPicker, replacements)
-				if err != nil {
-					return nil, errors.Wrap(err, "unable to replace base.config package reference")
-				}
-				if changed {
-					hasChange = true
-				}
-			}
 		}
 
 		if hasChange {

--- a/internal/cli/service_resolve_packages_test.go
+++ b/internal/cli/service_resolve_packages_test.go
@@ -24,8 +24,7 @@ func TestService_ResolvingPackages(t *testing.T) {
 
 		originalContents := `
 base:
-  os: ubuntu 24.04
-  tag: 1.1
+  image: ubuntu:24.04
   config: rwx/base 1.2.3
 tasks:
   - key: embedded

--- a/internal/cli/service_resolve_packages_test.go
+++ b/internal/cli/service_resolve_packages_test.go
@@ -13,6 +13,76 @@ import (
 )
 
 func TestService_ResolvingPackages(t *testing.T) {
+	t.Run("does not fetch package versions when every reference is already pinned", func(t *testing.T) {
+		s := setupTest(t)
+
+		called := false
+		s.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+			called = true
+			return nil, errors.New("package versions should not be fetched")
+		}
+
+		originalContents := `
+base:
+  os: ubuntu 24.04
+  tag: 1.1
+  config: rwx/base 1.2.3
+tasks:
+  - key: embedded
+    call: ${{ run.dir }}/integration/run-test.yml
+  - key: dynamic
+    call: ${{ tasks.export.values.package-name }}
+  - key: package
+    call: nodejs/install 1.2.3
+  - key: script
+    run: echo hello
+`
+		err := os.WriteFile(filepath.Join(s.tmp, "foo.yaml"), []byte(originalContents), 0o644)
+		require.NoError(t, err)
+
+		_, err = s.service.ResolvePackages(cli.ResolvePackagesConfig{
+			RwxDirectory:        s.tmp,
+			LatestVersionPicker: cli.PickLatestMajorVersion,
+		})
+		require.NoError(t, err)
+		require.False(t, called)
+
+		contents, err := os.ReadFile(filepath.Join(s.tmp, "foo.yaml"))
+		require.NoError(t, err)
+		require.Equal(t, originalContents, string(contents))
+	})
+
+	t.Run("fetches package versions when base.config is unversioned", func(t *testing.T) {
+		s := setupTest(t)
+
+		s.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+			return &api.PackageVersionsResult{
+				LatestMajor: map[string]string{"rwx/base": "2.0.1"},
+			}, nil
+		}
+
+		err := os.WriteFile(filepath.Join(s.tmp, "foo.yaml"), []byte(`
+base:
+  os: ubuntu 24.04
+  tag: 1.1
+  config: rwx/base
+tasks:
+  - key: script
+    run: echo hello
+`), 0o644)
+		require.NoError(t, err)
+
+		_, err = s.service.ResolvePackages(cli.ResolvePackagesConfig{
+			RwxDirectory:        s.tmp,
+			LatestVersionPicker: cli.PickLatestMajorVersion,
+		})
+		require.NoError(t, err)
+
+		contents, err := os.ReadFile(filepath.Join(s.tmp, "foo.yaml"))
+		require.NoError(t, err)
+		require.Contains(t, string(contents), "config: rwx/base 2.0.1")
+	})
+
 	t.Run("skips call values containing expressions", func(t *testing.T) {
 		s := setupTest(t)
 
@@ -140,7 +210,11 @@ tasks:
 				return nil, errors.New("cannot get package versions")
 			}
 
-			err := os.WriteFile(filepath.Join(s.tmp, "foo.yaml"), []byte(""), 0o644)
+			err := os.WriteFile(filepath.Join(s.tmp, "foo.yaml"), []byte(`
+tasks:
+  - key: foo
+    call: nodejs/install
+`), 0o644)
 			require.NoError(t, err)
 
 			_, err = s.service.ResolvePackages(cli.ResolvePackagesConfig{

--- a/internal/cli/service_update_packages_test.go
+++ b/internal/cli/service_update_packages_test.go
@@ -142,7 +142,11 @@ tasks:
 				return nil, errors.New("cannot get package versions")
 			}
 
-			err := os.WriteFile(filepath.Join(s.tmp, "foo.yaml"), []byte(""), 0o644)
+			err := os.WriteFile(filepath.Join(s.tmp, "foo.yaml"), []byte(`
+tasks:
+  - key: foo
+    call: nodejs/install 1.0.0
+`), 0o644)
 			require.NoError(t, err)
 
 			_, err = s.service.UpdatePackages(cli.UpdatePackagesConfig{


### PR DESCRIPTION
## Why

`rwx run` makes exactly three sequential API requests, and one of them is avoidable in the common case. Instrumented against a local stack:

```
GET  /mint/api/leaves    65–103ms   ← this PR
POST /mint/api/runs      602–936ms
POST /api/telemetry      65–87ms
```

`resolveOrUpdatePackagesForFiles` fetched the full package index **before** scanning the run definition for package references. In the run path (`update=false`), only unversioned, non-expression `call`/`base.config` references can ever be rewritten — and since the CLI pins versions into the file the first time it resolves them, every subsequent run of a normal repo (and any run with no packages at all) paid the round-trip for nothing.

## What

- Scan the parsed YAML for a reference needing resolution first (local, free), and only call `GetPackageVersions` when one exists.
- The pre-scan and the rewrite loop share the same traversal (`forEachPackageReference`, covering `tasks[*].call` / `$[*].call` / `base.config`) and the same skip predicate (`packageReferenceNeedsResolution`, which is the exact early-exit logic previously inlined in `updatePackageReferenceAtPath`), so the two passes can't drift.
- `rwx packages update` (`update=true`) still always fetches for files containing package references, since pinned references are updatable there.

Two existing tests asserted fetch-error propagation using **empty** YAML files — they were incidentally pinning the fetch-always behavior. Updated them to use files that actually contain a package reference, preserving their intent.

## Behavior notes

- Runs/`packages update` over files with no package references no longer error when the package index endpoint is unavailable (there was nothing to resolve anyway).
- Verified end-to-end against a local stack: a run with pinned/no packages makes no `GET /mint/api/leaves` request; a run with an unversioned `call` still fetches and resolves as before.

## Testing

- New tests: fully-pinned file skips the fetch entirely (mock asserts no call, file byte-identical); unversioned `base.config` still triggers fetch + rewrite
- `go test ./internal/... ./cmd/...` and `go test ./test/...` pass
- `go fmt` / `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)