### PR TITLE
Update to Go 1.26

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+version: "2"
+
+linters:
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - -ST1*
+        - -QF1*
+  exclusions:
+    presets:
+      - std-error-handling

--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -39,7 +39,7 @@ tasks:
   - key: golangci-lint
     use: go
     run: |
-      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${{ tasks.tool-versions.values.golangci-lint }}
+      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh | sudo sh -s -- -b /usr/local/bin v${{ tasks.tool-versions.values.golangci-lint }}
 
   - key: go-deps
     use: [go, code]

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.24.1
-golangci-lint 1.64.6
+golang 1.26.4
+golangci-lint 2.12.2
 ginkgo 2.23.4
 nodejs 24.14.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/rwx-cloud/rwx
 
-go 1.24.0
+go 1.26.0
 
-toolchain go1.24.1
+toolchain go1.26.4
 
 require (
 	al.essio.dev/pkg/shellescape v1.6.0


### PR DESCRIPTION
Updates the project to the latest Go release (**1.26.4**).

## Changes

- **`go.mod`** — `go 1.26.0`, `toolchain go1.26.4`
- **`.tool-versions`** — `golang 1.26.4`
- **`.tool-versions`** — `golangci-lint 1.64.6` → `2.12.2`. golangci-lint v1 (built with go1.24, and now EOL) refuses to lint code targeting Go 1.26 (`the Go language version used to build golangci-lint is lower than the targeted Go version`), so the linter must move to v2.
- **`.golangci.yml`** (new) — restores the prior lint policy under golangci-lint v2, which otherwise surfaces 59 pre-existing findings that v1 excluded by default. It disables the newly-defaulted staticcheck `ST*` (stylecheck) and `QF*` (quickfix) categories and re-applies the standard error-handling exclusions. Result: **no code churn**.
- **`.rwx/ci.yml`** — golangci-lint install URL `master` → `main`. golangci-lint's default branch is now `main`; the frozen `master` install script mis-verifies the v2 tarball checksum and fails the install task.

## Verification

- Local: `go build`, `go vet`, unit tests all pass on go1.26.4; `golangci-lint 2.12.2 run ./...` → 0 issues.
- Cloud: `rwx run .rwx/ci.yml --wait --target lint --target unit-tests` → **succeeded**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)