### PR TITLE
Split integration tests into a separate workflow

### DIFF
--- a/.rwx/integration-sandbox.yml
+++ b/.rwx/integration-sandbox.yml
@@ -36,21 +36,12 @@ tasks:
     use: go-installation
     run: echo "$(go env GOPATH)/bin" > "${MINT_ENV}/PATH"
 
-  - key: golangci-lint
-    use: go
-    run: |
-      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${{ tasks.tool-versions.values.golangci-lint }}
-
   - key: go-deps
     use: [go, code]
     call: golang/mod-download 1.0.2
     filter: [go.mod, go.sum]
     with:
       tool-cache: cli-go-deps
-
-  - key: gotestsum
-    use: go
-    run: go install gotest.tools/gotestsum@latest
 
   - key: git
     run: |
@@ -84,46 +75,30 @@ tasks:
     use: code
     run: cp ${{ tasks.lsp-build.tasks.build.artifacts.bundle }} internal/lsp/bundle/server.js
 
-  - key: unit-tests
-    use: [go-deps, rwx-cli, gotestsum, git]
-    run: |
-      gotestsum \
-        --jsonfile tmp/go-test.json \
-        -- \
-        -ldflags "-w -s -X github.com/rwx-cloud/rwx/cmd/rwx/config.Version=testing-${{ init.commit-sha }}" \
-        -parallel 4 \
-        ./internal/... ./cmd/... ./test/...
-    outputs:
-      test-results:
-        - path: tmp/go-test.json
-
   - key: rwx-cli
     use: [go-deps, lsp-server]
     run: |
       go build -a -ldflags "-w -s -X github.com/rwx-cloud/rwx/cmd/rwx/config.Version=testing-${{ init.commit-sha }}" ./cmd/rwx
 
-  - key: lint
-    use: [golangci-lint, go-deps, lsp-server]
-    run: golangci-lint run ./...
-
-  - key: go-mod-tidy
-    use: go-deps
+  - key: generate-sandbox-tests
+    use: code
     run: |
-      before=$(git diff)
-      go mod tidy
-      after=$(git diff)
-      if [ "$before" != "$after" ]; then
-        echo "go mod tidy produced changes"
-        exit 1
-      fi
-
-  - key: go-fmt
-    use: go-deps
-    run: |
-      before=$(git diff)
-      go fmt ./...
-      after=$(git diff)
-      if [ "$before" != "$after" ]; then
-        echo "go fmt produced changes"
-        exit 1
-      fi
+      for script in test/integration/sandbox-*.sh; do
+        key=$(basename "$script" .sh)
+        if [ "$key" = "sandbox-helpers" ]; then
+          continue
+        fi
+        printf '%s\n' \
+          "- key: ${key}" \
+          "  use: [rwx-cli, git]" \
+          "  run: ./${script}" \
+          "  env:" \
+          "    RWX_ACCESS_TOKEN: ${RWX_ACCESS_TOKEN}" \
+          "    COMMIT_SHA: ${COMMIT_SHA}" \
+          >> "$RWX_DYNAMIC_TASKS/sandbox-tests.yml"
+      done
+    env:
+      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      COMMIT_SHA: ${{ init.commit-sha }}
+    filter:
+      - test/integration/sandbox-*.sh

--- a/.rwx/integration.yml
+++ b/.rwx/integration.yml
@@ -2,90 +2,12 @@ on:
   cli:
     init:
       commit-sha: ${{ event.git.sha }}
-      ref: ${{ event.git.sha }}
-
-concurrency-pools:
-  - id: rwx-cloud/rwx:integration-${{ init.ref }}
-    capacity: 1
-    on-overflow: cancel-running
 
 base:
   image: ubuntu:24.04
   config: rwx/base 1.1.1
 
 tasks:
-  - key: code
-    call: git/clone 2.0.8
-    with:
-      preserve-git-dir: true
-      repository: https://github.com/rwx-cloud/rwx.git
-      ref: ${{ init.commit-sha }}
-      github-token: ${{ github['rwx-cloud'].token }}
-
-  - key: tool-versions
-    use: code
-    run: |
-      while read -r tool version _; do
-        printf "%s" "$version" > "$RWX_VALUES/$tool"
-      done < .tool-versions
-      cp language-server-ref $RWX_VALUES
-    filter:
-      - .tool-versions
-      - language-server-ref
-
-  - key: go-installation
-    call: golang/install 1.2.1
-    with:
-      go-version: ${{ tasks.tool-versions.values.golang }}
-
-  - key: go
-    use: go-installation
-    run: echo "$(go env GOPATH)/bin" > "${MINT_ENV}/PATH"
-
-  - key: go-deps
-    use: [go, code]
-    call: golang/mod-download 1.0.2
-    filter: [go.mod, go.sum]
-    with:
-      tool-cache: cli-go-deps
-
-  - key: git
-    run: |
-      sudo apt-get update
-      sudo apt-get install git git-lfs
-      sudo apt-get clean
-
-      git config --global user.name "Testing"
-      git config --global user.email "git@example.com"
-      git config --global init.defaultBranch main
-
-      git lfs install --skip-repo
-
-  - key: lsp-code
-    call: git/clone 2.0.8
-    with:
-      repository: https://github.com/rwx-cloud/language-server.git
-      ref: ${{ tasks.tool-versions.values.language-server-ref }}
-      path: language-server
-
-  - key: lsp-build-def
-    use: lsp-code
-    run: cp language-server/.rwx/build.yml $RWX_ARTIFACTS/build-run-def
-
-  - key: lsp-build
-    call: ${{ tasks.lsp-build-def.artifacts.build-run-def }}
-    init:
-      ref: ${{ tasks.tool-versions.values.language-server-ref }}
-
-  - key: lsp-server
-    use: code
-    run: cp ${{ tasks.lsp-build.tasks.build.artifacts.bundle }} internal/lsp/bundle/server.js
-
-  - key: rwx-cli
-    use: [go-deps, lsp-server]
-    run: |
-      go build -a -ldflags "-w -s -X github.com/rwx-cloud/rwx/cmd/rwx/config.Version=testing-${{ init.commit-sha }}" ./cmd/rwx
-
   - key: run-rwx-run-test
     call: ${{ run.dir }}/integration/run-test.yml
     init:
@@ -140,26 +62,3 @@ tasks:
     call: ${{ run.dir }}/integration/whoami-test.yml
     init:
       ref: ${{ init.commit-sha }}
-
-  - key: generate-sandbox-tests
-    use: code
-    run: |
-      for script in test/integration/sandbox-*.sh; do
-        key=$(basename "$script" .sh)
-        if [ "$key" = "sandbox-helpers" ]; then
-          continue
-        fi
-        printf '%s\n' \
-          "- key: ${key}" \
-          "  use: [rwx-cli, git]" \
-          "  run: ./${script}" \
-          "  env:" \
-          "    RWX_ACCESS_TOKEN: ${RWX_ACCESS_TOKEN}" \
-          "    COMMIT_SHA: ${COMMIT_SHA}" \
-          >> "$RWX_DYNAMIC_TASKS/sandbox-tests.yml"
-      done
-    env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
-      COMMIT_SHA: ${{ init.commit-sha }}
-    filter:
-      - test/integration/sandbox-*.sh

--- a/.rwx/integration.yml
+++ b/.rwx/integration.yml
@@ -5,7 +5,7 @@ on:
       ref: ${{ event.git.sha }}
 
 concurrency-pools:
-  - id: rwx-cloud/rwx:ci-${{ init.ref }}
+  - id: rwx-cloud/rwx:integration-${{ init.ref }}
     capacity: 1
     on-overflow: cancel-running
 
@@ -42,21 +42,12 @@ tasks:
     use: go-installation
     run: echo "$(go env GOPATH)/bin" > "${MINT_ENV}/PATH"
 
-  - key: golangci-lint
-    use: go
-    run: |
-      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v${{ tasks.tool-versions.values.golangci-lint }}
-
   - key: go-deps
     use: [go, code]
     call: golang/mod-download 1.0.2
     filter: [go.mod, go.sum]
     with:
       tool-cache: cli-go-deps
-
-  - key: gotestsum
-    use: go
-    run: go install gotest.tools/gotestsum@latest
 
   - key: git
     run: |
@@ -90,51 +81,85 @@ tasks:
     use: code
     run: cp ${{ tasks.lsp-build.tasks.build.artifacts.bundle }} internal/lsp/bundle/server.js
 
-  - key: unit-tests
-    use: [go-deps, rwx-cli, gotestsum, git]
-    run: |
-      gotestsum \
-        --jsonfile tmp/go-test.json \
-        -- \
-        -ldflags "-w -s -X github.com/rwx-cloud/rwx/cmd/rwx/config.Version=testing-${{ init.commit-sha }}" \
-        -parallel 4 \
-        ./internal/... ./cmd/... ./test/...
-    outputs:
-      test-results:
-        - path: tmp/go-test.json
-
   - key: rwx-cli
     use: [go-deps, lsp-server]
     run: |
       go build -a -ldflags "-w -s -X github.com/rwx-cloud/rwx/cmd/rwx/config.Version=testing-${{ init.commit-sha }}" ./cmd/rwx
 
-  - key: lint
-    use: [golangci-lint, go-deps, lsp-server]
-    run: golangci-lint run ./...
+  - key: run-rwx-run-test
+    call: ${{ run.dir }}/integration/run-test.yml
+    init:
+      cli: ${{ init.commit-sha }}
 
-  - key: go-mod-tidy
-    use: go-deps
-    run: |
-      before=$(git diff)
-      go mod tidy
-      after=$(git diff)
-      if [ "$before" != "$after" ]; then
-        echo "go mod tidy produced changes"
-        exit 1
-      fi
-
-  - key: go-fmt
-    use: go-deps
-    run: |
-      before=$(git diff)
-      go fmt ./...
-      after=$(git diff)
-      if [ "$before" != "$after" ]; then
-        echo "go fmt produced changes"
-        exit 1
-      fi
-
-  - key: test-build
-    call: ${{ run.dir }}/build.yml
+  - key: run-rwx-image-test
+    call: ${{ run.dir }}/integration/image-test.yml
     init:
       ref: ${{ init.commit-sha }}
+
+  - key: run-rwx-results-test
+    call: ${{ run.dir }}/integration/results-test.yml
+    init:
+      ref: ${{ init.commit-sha }}
+
+  - key: run-rwx-runs-list-test
+    call: ${{ run.dir }}/integration/runs-list-test.yml
+    init:
+      ref: ${{ init.commit-sha }}
+
+  - key: run-rwx-dispatch-test
+    call: ${{ run.dir }}/integration/dispatch-test.yml
+    init:
+      ref: ${{ init.commit-sha }}
+
+  - key: run-rwx-logs-test
+    call: ${{ run.dir }}/integration/logs-test.yml
+    init:
+      ref: ${{ init.commit-sha }}
+
+  - key: run-rwx-artifacts-test
+    call: ${{ run.dir }}/integration/artifacts-test.yml
+    init:
+      ref: ${{ init.commit-sha }}
+
+  - key: run-rwx-lint-test
+    call: ${{ run.dir }}/integration/lint-test.yml
+    init:
+      ref: ${{ init.commit-sha }}
+
+  - key: run-rwx-resolve-update-test
+    call: ${{ run.dir }}/integration/resolve-update-test.yml
+    init:
+      ref: ${{ init.commit-sha }}
+
+  - key: run-rwx-skill-test
+    call: ${{ run.dir }}/integration/skill-test.yml
+    init:
+      ref: ${{ init.commit-sha }}
+
+  - key: run-rwx-whoami-test
+    call: ${{ run.dir }}/integration/whoami-test.yml
+    init:
+      ref: ${{ init.commit-sha }}
+
+  - key: generate-sandbox-tests
+    use: code
+    run: |
+      for script in test/integration/sandbox-*.sh; do
+        key=$(basename "$script" .sh)
+        if [ "$key" = "sandbox-helpers" ]; then
+          continue
+        fi
+        printf '%s\n' \
+          "- key: ${key}" \
+          "  use: [rwx-cli, git]" \
+          "  run: ./${script}" \
+          "  env:" \
+          "    RWX_ACCESS_TOKEN: ${RWX_ACCESS_TOKEN}" \
+          "    COMMIT_SHA: ${COMMIT_SHA}" \
+          >> "$RWX_DYNAMIC_TASKS/sandbox-tests.yml"
+      done
+    env:
+      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      COMMIT_SHA: ${{ init.commit-sha }}
+    filter:
+      - test/integration/sandbox-*.sh

--- a/.rwx/main.yml
+++ b/.rwx/main.yml
@@ -4,11 +4,9 @@ on:
       if: ${{event.git.branch == 'main' }}
       init:
         commit-sha: ${{ event.git.sha }}
-        ref: ${{ event.git.ref }}
   cli:
     init:
       commit-sha: ${{ event.git.sha }}
-      ref: ${{ event.git.sha }}
 
 concurrency-pools:
   - id: rwx-cloud/rwx:main
@@ -20,16 +18,19 @@ tasks:
     call: ${{ run.dir }}/ci.yml
     init:
       commit-sha: ${{ init.commit-sha }}
-      ref: ${{ init.ref }}
 
   - key: integration
     call: ${{ run.dir }}/integration.yml
     init:
       commit-sha: ${{ init.commit-sha }}
-      ref: ${{ init.ref }}
+
+  - key: integration-sandbox
+    call: ${{ run.dir }}/integration-sandbox.yml
+    init:
+      commit-sha: ${{ init.commit-sha }}
 
   - key: release-unstable
-    after: [ci, integration]
+    after: [ci, integration, integration-sandbox]
     call: ${{ run.dir }}/release.yml
     init:
       kind: unstable

--- a/.rwx/pull-request.yml
+++ b/.rwx/pull-request.yml
@@ -1,7 +1,6 @@
 on:
   github:
-    push:
-      if: ${{event.git.branch == 'main' }}
+    pull_request:
       init:
         commit-sha: ${{ event.git.sha }}
         ref: ${{ event.git.ref }}
@@ -11,9 +10,9 @@ on:
       ref: ${{ event.git.sha }}
 
 concurrency-pools:
-  - id: rwx-cloud/rwx:main
+  - id: rwx-cloud/rwx:pull-request-${{ init.ref }}
     capacity: 1
-    on-overflow: cancel-waiting
+    on-overflow: cancel-running
 
 tasks:
   - key: ci
@@ -27,11 +26,3 @@ tasks:
     init:
       commit-sha: ${{ init.commit-sha }}
       ref: ${{ init.ref }}
-
-  - key: release-unstable
-    after: [ci, integration]
-    call: ${{ run.dir }}/release.yml
-    init:
-      kind: unstable
-      commit: ${{ init.commit-sha }}
-      version: UNSTABLE

--- a/.rwx/pull-request.yml
+++ b/.rwx/pull-request.yml
@@ -3,26 +3,34 @@ on:
     pull_request:
       init:
         commit-sha: ${{ event.git.sha }}
-        ref: ${{ event.git.ref }}
+        pr-number: ${{ event.github.pull_request.number }}
   cli:
     init:
       commit-sha: ${{ event.git.sha }}
-      ref: ${{ event.git.sha }}
+      pr-number: 0
 
 concurrency-pools:
-  - id: rwx-cloud/rwx:pull-request-${{ init.ref }}
+  - id: rwx-cloud/rwx:pull-request-${{ init.pr-number }}
     capacity: 1
     on-overflow: cancel-running
 
 tasks:
+  - key: test-build
+    call: ${{ run.dir }}/build.yml
+    init:
+      ref: ${{ init.commit-sha }}
+
   - key: ci
     call: ${{ run.dir }}/ci.yml
     init:
       commit-sha: ${{ init.commit-sha }}
-      ref: ${{ init.ref }}
 
   - key: integration
     call: ${{ run.dir }}/integration.yml
     init:
       commit-sha: ${{ init.commit-sha }}
-      ref: ${{ init.ref }}
+
+  - key: integration-sandbox
+    call: ${{ run.dir }}/integration-sandbox.yml
+    init:
+      commit-sha: ${{ init.commit-sha }}


### PR DESCRIPTION
## Summary

Makes `rwx run .rwx/ci.yml` fast by pulling the slow, platform-hitting integration tests into their own workflow, and adds a `pull-request.yml` entrypoint that runs both in parallel.

## Changes

- **`.rwx/ci.yml`** — now the fast path only. Removed the `github.pull_request` trigger (moved to `pull-request.yml`) and the 11 `run-rwx-*-test` embedded runs + the `generate-sandbox-tests` dynamic task. Kept the `cli` trigger, build chain, `unit-tests`, `lint`, `go-mod-tidy`, `go-fmt`, and `test-build`.
- **`.rwx/integration.yml`** (new) — the moved integration tests. Reproduces the build chain (`code` → … → `rwx-cli`, plus `git`) that the sandbox tests depend on, since embedded runs have isolated filesystems. Runnable standalone via a `cli` trigger with its own concurrency pool.
- **`.rwx/pull-request.yml`** (new) — the `github.pull_request` entrypoint. Embeds `ci.yml` and `integration.yml` in parallel, with a `pull-request-${ref}` concurrency pool (`cancel-running`).
- **`.rwx/main.yml`** — also embeds `integration.yml` so pushes to `main` keep integration coverage; `release-unstable` now runs `after: [ci, integration]`.

## Notes / decisions

- The Go `./test/...` tests stay in `ci.yml`'s `unit-tests` task — they run with `--access-token fake-for-test` and only exercise local flag parsing/error messages (fast, no network), so moving them buys nothing.
- `test-build` stays in `ci.yml` — it verifies `build.yml` compiles; it doesn't exercise the CLI against the platform.
- Nested concurrency pools (`pull-request-*` embedding `ci-*` / `integration-*`) mirror the existing `main.yml` → `ci.yml` pattern.

## Testing

- `rwx lint` passes on all four files.
- Ran `rwx run .rwx/pull-request.yml --wait` locally: embedding worked end-to-end (ci + integration fanned out, nested `run-rwx-image-test` ran, sandbox tests generated). The two failures observed were environmental — a locked `rwx_cli_development` vault (pre-existing, unrelated) and `sandbox-git-state-sync` rejecting the dirty tree from the uncommitted local git patch (won't occur on a committed PR run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)