### PR TITLE
Fix config initialization for directory users

### DIFF
--- a/internal/config/file_backend.go
+++ b/internal/config/file_backend.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -121,16 +120,18 @@ func (f FileBackend) Set(filename, value string) error {
 var tildeSlash = fmt.Sprintf("~%v", string(os.PathSeparator))
 
 func expandTilde(dir string) (string, error) {
-	user, err := user.Current()
+	if dir != "~" && !strings.HasPrefix(dir, tildeSlash) {
+		return dir, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
 
-	if strings.HasPrefix(dir, tildeSlash) {
-		return filepath.Join(user.HomeDir, strings.TrimPrefix(dir, tildeSlash)), nil
-	} else if dir == "~" {
-		return user.HomeDir, nil
-	} else {
-		return dir, nil
+	if dir == "~" {
+		return homeDir, nil
 	}
+
+	return filepath.Join(homeDir, strings.TrimPrefix(dir, tildeSlash)), nil
 }

--- a/test/config_backend_linux_test.go
+++ b/test/config_backend_linux_test.go
@@ -1,0 +1,53 @@
+//go:build linux && cgo
+
+package integration_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigBackendInitializesForUnknownUser(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to execute the CLI as an unknown user")
+	}
+
+	homeDir, err := os.MkdirTemp("", "rwx-unknown-user-home-")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(homeDir)) })
+	require.NoError(t, os.Chmod(homeDir, 0o755))
+
+	uid := findUnknownUID(t)
+	cmd := mintCmd(t, input{args: []string{"completion", "bash"}})
+	cmd.Env = append(os.Environ(), "HOME="+homeDir)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{Uid: uid, Gid: uid},
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	require.NoError(t, err, stderr.String())
+}
+
+func findUnknownUID(t *testing.T) uint32 {
+	t.Helper()
+
+	for uid := uint32(1_000_000); uid < 1_001_000; uid++ {
+		_, err := user.LookupId(strconv.FormatUint(uint64(uid), 10))
+		var unknownUserID user.UnknownUserIdError
+		if errors.As(err, &unknownUserID) {
+			return uid
+		}
+	}
+
+	t.Fatal("unable to find a UID without a passwd entry")
+	return 0
+}


### PR DESCRIPTION
## What changed

- expand config paths with `os.UserHomeDir` instead of `user.Current`
- avoid user and home-directory lookups for paths that do not begin with `~`
- add a Linux integration test that runs the built CLI as a UID with no passwd entry

## Why

The config backend only needs the user's home directory, but `user.Current` performs an NSS account lookup. Statically linked Linux binaries cannot resolve users supplied by services such as SSSD/LDAP, so every command failed during persistent pre-run initialization with `user: unknown userid`.

The integration test creates the real failure condition without mocking: it selects a UID absent from NSS, executes the built CLI under that credential, and verifies config initialization succeeds when `HOME` is available. Running the same test against the old backend reproduces the reported error.

## Validation

- `go test ./internal/... ./cmd/...`
- `golangci-lint run ./internal/config ./test`
- full Linux integration suite in a Go 1.26 Debian container
- regression test against the old backend, which fails with `unable to initialize config backend: user: unknown userid 1000000`
