### PR TITLE
Coach shallow local clones through sandbox sync failures

### DIFF
--- a/cmd/rwx/main.go
+++ b/cmd/rwx/main.go
@@ -196,6 +196,8 @@ func classifyError(err error) string {
 		return "sandbox_setup_failure"
 	case errors.Is(err, internalerrors.ErrSandboxNoGitDir):
 		return "sandbox_no_git_dir"
+	case errors.Is(err, internalerrors.ErrShallowClone):
+		return "shallow_clone"
 	default:
 		return "unknown"
 	}

--- a/cmd/rwx/main.go
+++ b/cmd/rwx/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rwx-cloud/rwx/internal/cli"
 	internalerrors "github.com/rwx-cloud/rwx/internal/errors"
+	"github.com/rwx-cloud/rwx/internal/git"
 	"github.com/spf13/pflag"
 )
 
@@ -93,6 +94,9 @@ func recordTelemetry(err error, start time.Time) {
 		// errors expose the sentinel string rather than what the user saw.
 		if errType == "unknown" && !handled {
 			props["error_message"] = scrubErrorMessage(err.Error())
+		}
+		if errType == "patch_failed" {
+			props["patch_error_reason"] = git.PatchFailureReason(err)
 		}
 		if errType == "unknown_command" {
 			if attempt := extractUnknownCommandAttempt(err); attempt != "" {

--- a/cmd/rwx/main_test.go
+++ b/cmd/rwx/main_test.go
@@ -40,6 +40,7 @@ func TestClassifyError(t *testing.T) {
 		{"network_transient_error", errors.ErrNetworkTransient, "network_transient_error"},
 		{"sandbox_setup_failure", errors.ErrSandboxSetupFailure, "sandbox_setup_failure"},
 		{"sandbox_no_git_dir", errors.ErrSandboxNoGitDir, "sandbox_no_git_dir"},
+		{"shallow_clone", errors.ErrShallowClone, "shallow_clone"},
 	}
 
 	for _, tc := range cases {

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1440,12 +1440,16 @@ func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, cleanPr
 	lfsSkippedCount := 0
 	var syncPushErr error
 	defer func() {
-		s.recordTelemetry("sandbox.sync_push", map[string]any{
+		props := map[string]any{
 			"patch_bytes":       patchBytes,
 			"duration_ms":       time.Since(syncStart).Milliseconds(),
 			"lfs_skipped_count": lfsSkippedCount,
 			"success":           syncPushErr == nil,
-		})
+		}
+		if syncPushErr != nil {
+			props["failure_reason"] = sandboxSyncFailureReason(syncPushErr)
+		}
+		s.recordTelemetry("sandbox.sync_push", props)
 	}()
 
 	if err := s.ensureSandboxHasCommit(localHead, connInfo); err != nil {
@@ -1569,6 +1573,9 @@ func (s Service) pushLocalHeadToSandbox(localHead string, connInfo *api.SandboxC
 	hasCommit := pushErr == nil && s.sandboxHasCommit(localHead)
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 	if pushErr != nil {
+		if isShallowUpdateRejection(pushErr) {
+			return errors.WrapSentinel(errors.New(sandboxShallowSyncMessage), errors.ErrShallowClone)
+		}
 		return errors.Wrap(pushErr, "failed to push git commits to sandbox")
 	}
 	if !hasCommit {
@@ -1576,6 +1583,42 @@ func (s Service) pushLocalHeadToSandbox(localHead string, connInfo *api.SandboxC
 	}
 
 	return nil
+}
+
+// sandboxShallowSyncMessage coaches the recovery path when a shallow local
+// clone causes the sandbox sync push to be rejected. Agents are the primary
+// consumer, so it spells out both fixes explicitly.
+const sandboxShallowSyncMessage = `your local clone is shallow and its history has diverged from the sandbox, so git refused the sync push (shallow update not allowed).
+
+To recover, either:
+  - Unshallow your local clone, then re-run your command:
+      git fetch --unshallow
+  - Set 'fetch-full-depth: true' on the git/clone task in your sandbox config, then re-provision the sandbox:
+      rwx sandbox exec --reset`
+
+func isShallowUpdateRejection(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "shallow update not allowed")
+}
+
+// sandboxSyncFailureReason buckets a sync/patch failure into a stable telemetry
+// category (shallow clone, missing git dir, patch apply) so we can see why syncs
+// fail without leaking raw repo data.
+func sandboxSyncFailureReason(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, errors.ErrShallowClone):
+		return "shallow_clone"
+	case errors.Is(err, errors.ErrSandboxNoGitDir):
+		return "no_git_dir"
+	case errors.Is(err, errors.ErrPatch):
+		return "patch"
+	default:
+		return "other"
+	}
 }
 
 func (s Service) verifySandboxLFSObjects(localHead string) error {

--- a/internal/cli/service_sandbox_internal_test.go
+++ b/internal/cli/service_sandbox_internal_test.go
@@ -1,10 +1,44 @@
 package cli
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/rwx-cloud/rwx/internal/errors"
 	"github.com/stretchr/testify/require"
 )
+
+func TestIsShallowUpdateRejection(t *testing.T) {
+	t.Run("matches the receiver rejection regardless of case", func(t *testing.T) {
+		err := fmt.Errorf("git push failed: To sandbox:.\n ! [remote rejected] abc -> refs/rwx/sync-push (shallow update not allowed)")
+		require.True(t, isShallowUpdateRejection(err))
+	})
+
+	t.Run("does not match unrelated push failures", func(t *testing.T) {
+		require.False(t, isShallowUpdateRejection(nil))
+		require.False(t, isShallowUpdateRejection(fmt.Errorf("git push failed: permission denied")))
+	})
+}
+
+func TestSandboxSyncFailureReason(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{"nil", nil, ""},
+		{"shallow", errors.WrapSentinel(fmt.Errorf("x"), errors.ErrShallowClone), "shallow_clone"},
+		{"no git dir", errors.WrapSentinel(fmt.Errorf("x"), errors.ErrSandboxNoGitDir), "no_git_dir"},
+		{"patch", errors.WrapSentinel(fmt.Errorf("x"), errors.ErrPatch), "patch"},
+		{"other", fmt.Errorf("something else"), "other"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, sandboxSyncFailureReason(tc.err))
+		})
+	}
+}
 
 func TestSandboxLFSFilesFromFsckOutput(t *testing.T) {
 	oid := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -65,6 +65,7 @@ var (
 	ErrRetry                   = errors.New("retry")
 	ErrSandboxNoGitDir         = errors.New("no .git directory found in sandbox. Set 'preserve-git-dir: true' on your git/clone task")
 	ErrSandboxSetupFailure     = errors.New("sandbox setup failure")
+	ErrShallowClone            = errors.New("shallow clone error")
 	ErrSSH                     = errors.New("ssh error")
 	ErrPatch                   = errors.New("patch error")
 	ErrTimeout                 = errors.New("timeout")

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -269,7 +270,26 @@ func (e *PatchError) Error() string {
 // stderr must never be sent to telemetry — it embeds customer file paths,
 // branch names, and repo layout.
 func (e *PatchError) Reason() string {
-	s := strings.ToLower(e.Stderr)
+	return classifyPatchStderr(e.Stderr)
+}
+
+// PatchFailureReason buckets any patch-related error into a stable, PII-free
+// category for telemetry. It prefers a *PatchError's structured stderr and
+// otherwise scans the error message for git-apply and LFS signatures. Only the
+// returned bucket is safe to record — never the underlying message.
+func PatchFailureReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	var pe *PatchError
+	if errors.As(err, &pe) {
+		return pe.Reason()
+	}
+	return classifyPatchStderr(err.Error())
+}
+
+func classifyPatchStderr(s string) string {
+	s = strings.ToLower(s)
 	switch {
 	case strings.Contains(s, "bad object"), strings.Contains(s, "shallow"):
 		return "shallow_clone"
@@ -279,6 +299,14 @@ func (e *PatchError) Reason() string {
 		return "missing_external_filter"
 	case strings.Contains(s, "signal: killed"), strings.Contains(s, "out of memory"), strings.Contains(s, "cannot allocate memory"):
 		return "oom_killed"
+	case strings.Contains(s, "lfs file(s) changed locally"):
+		return "lfs_changed"
+	case strings.Contains(s, "already exists in working directory"):
+		return "already_exists"
+	case strings.Contains(s, "corrupt patch"):
+		return "corrupt_patch"
+	case strings.Contains(s, "does not apply"), strings.Contains(s, "patch failed"), strings.Contains(s, "partially applied"):
+		return "patch_conflict"
 	default:
 		return "unknown"
 	}

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -1,6 +1,7 @@
 package git_test
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -691,6 +692,10 @@ func TestPatchErrorReason(t *testing.T) {
 		{"fatal: pathspec '.rwx' is beyond a symbolic link", "beyond_symlink"},
 		{"error: external filter 'git-lfs filter-process' failed", "missing_external_filter"},
 		{"signal: killed", "oom_killed"},
+		{"error: patch failed: main.go:12", "patch_conflict"},
+		{"error: foo.txt: patch does not apply", "patch_conflict"},
+		{"error: bar.txt: already exists in working directory", "already_exists"},
+		{"error: corrupt patch at line 3", "corrupt_patch"},
 		{"fatal: something else entirely", "unknown"},
 		{"", "unknown"},
 	}
@@ -698,6 +703,35 @@ func TestPatchErrorReason(t *testing.T) {
 	for _, tc := range cases {
 		pe := &git.PatchError{Stderr: tc.stderr}
 		require.Equal(t, tc.want, pe.Reason(), "stderr: %q", tc.stderr)
+	}
+}
+
+func TestPatchFailureReason(t *testing.T) {
+	t.Run("nil is empty", func(t *testing.T) {
+		require.Equal(t, "", git.PatchFailureReason(nil))
+	})
+
+	t.Run("prefers a wrapped *PatchError's structured stderr", func(t *testing.T) {
+		err := fmt.Errorf("failed to generate dirty patch: %w", &git.PatchError{Stderr: "fatal: bad object deadbeef"})
+		require.Equal(t, "shallow_clone", git.PatchFailureReason(err))
+	})
+
+	cases := []struct {
+		name string
+		msg  string
+		want string
+	}{
+		{"git apply conflict", "failed to sync changes to sandbox: git apply failed: error: patch failed: a.go:1", "patch_conflict"},
+		{"already exists", "failed to sync changes to sandbox: git apply failed: error: b.go: already exists in working directory", "already_exists"},
+		{"corrupt patch", "failed to sync changes to sandbox: git apply failed: error: corrupt patch at line 9", "corrupt_patch"},
+		{"lfs changed", "3 LFS file(s) changed locally and cannot be synced to the sandbox", "lfs_changed"},
+		{"unclassified", "failed to apply patch on sandbox: connection reset", "unknown"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, git.PatchFailureReason(fmt.Errorf("%s", tc.msg)))
+		})
 	}
 }
 

--- a/test/integration/sandbox-shallow-clone-sync.sh
+++ b/test/integration/sandbox-shallow-clone-sync.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/sandbox-helpers.sh"
+
+SANDBOX_CONFIG="${SCRIPT_DIR}/definitions/sandbox.yml"
+SANDBOX_RUN_ID=""
+WORKDIR=""
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+cleanup() {
+  set +e
+  if [ -n "$SANDBOX_RUN_ID" ]; then
+    "${RWX_CLI}" sandbox stop --id "$SANDBOX_RUN_ID" >/dev/null 2>&1
+  fi
+  if [ -n "$WORKDIR" ]; then
+    rm -rf "$WORKDIR"
+  fi
+}
+trap cleanup EXIT
+
+sandbox_result=$("${RWX_CLI}" sandbox start "$SANDBOX_CONFIG" --json --init ref=main --init "cli=${COMMIT_SHA}" --wait)
+SANDBOX_RUN_ID=$(echo "$sandbox_result" | jq -r ".RunID")
+
+sandbox_url=$(echo "$sandbox_result" | jq -r ".RunURL // empty")
+if [ -n "$sandbox_url" ]; then
+  echo "Sandbox URL: ${sandbox_url}"
+  echo "$sandbox_url" > "$RWX_LINKS/Sandbox Run"
+fi
+if [ -z "$SANDBOX_RUN_ID" ] || [ "$SANDBOX_RUN_ID" = "null" ]; then
+  echo "$sandbox_result"
+  fail "sandbox start did not return a run id"
+fi
+
+# Build a shallow local clone whose history the sandbox has never seen, so the
+# pre-exec sync must push a commit rooted at a shallow boundary the sandbox
+# lacks. git-receive-pack refuses to record the new graft ("shallow update not
+# allowed"), reproducing the failure from RFC 201.
+WORKDIR=$(mktemp -d)
+ORIGIN="${WORKDIR}/origin"
+SHALLOW="${WORKDIR}/shallow"
+
+git init -q "$ORIGIN"
+for i in 1 2 3; do
+  printf '%s\n' "origin commit $i" > "${ORIGIN}/f"
+  git -C "$ORIGIN" add f
+  git -C "$ORIGIN" -c user.email="shallow-integration@example.com" -c user.name="Shallow Integration" commit -qm "origin commit $i"
+done
+
+git clone -q --depth 1 "file://${ORIGIN}" "$SHALLOW"
+if [ "$(git -C "$SHALLOW" rev-parse --is-shallow-repository)" != "true" ]; then
+  fail "expected the local clone to be shallow"
+fi
+
+printf '%s\n' "local shallow change" > "${SHALLOW}/f"
+git -C "$SHALLOW" add f
+git -C "$SHALLOW" -c user.email="shallow-integration@example.com" -c user.name="Shallow Integration" commit -qm "local commit on shallow boundary"
+
+echo "Scenario: sandbox exec from a shallow local clone is coached, not left with a raw git error"
+output_file=$(mktemp)
+exit_code=0
+( cd "$SHALLOW" && "${RWX_CLI}" sandbox exec --id "$SANDBOX_RUN_ID" -- true ) >"$output_file" 2>&1 || exit_code=$?
+output=$(cat "$output_file")
+rm -f "$output_file"
+echo "$output"
+
+if [ "$exit_code" -eq 0 ]; then
+  fail "sandbox exec unexpectedly succeeded pushing from a shallow local clone"
+fi
+
+echo "$output" | grep -qi "shallow" || fail "sync failure was not about a shallow clone: ${output}"
+echo "$output" | grep -q "git fetch --unshallow" || fail "missing shallow-clone recovery guidance (git fetch --unshallow): ${output}"
+echo "$output" | grep -q "sandbox exec --reset" || fail "missing shallow-clone recovery guidance (sandbox exec --reset): ${output}"
+
+echo "PASS: sandbox shallow-clone sync coaching integration scenario completed"

--- a/test/integration/sandbox-shallow-clone-sync.sh
+++ b/test/integration/sandbox-shallow-clone-sync.sh
@@ -75,6 +75,7 @@ fi
 
 echo "$output" | grep -qi "shallow" || fail "sync failure was not about a shallow clone: ${output}"
 echo "$output" | grep -q "git fetch --unshallow" || fail "missing shallow-clone recovery guidance (git fetch --unshallow): ${output}"
+echo "$output" | grep -q "fetch-full-depth: true" || fail "missing shallow-clone recovery guidance (fetch-full-depth: true): ${output}"
 echo "$output" | grep -q "sandbox exec --reset" || fail "missing shallow-clone recovery guidance (sandbox exec --reset): ${output}"
 
 echo "PASS: sandbox shallow-clone sync coaching integration scenario completed"


### PR DESCRIPTION
### Background

- [RFC 201 — Sandbox git sync fails with "shallow update not allowed"](https://app.notion.com/p/393c3a490d98819d97c6c4232b408f3e)
- [RWX-1266](https://linear.app/rwx-cloud/issue/RWX-1266/coach-shallow-local-clones-through-sandbox-sync-jit-error-logging-dont)
- [Slack thread](https://rwxhq.slack.com/archives/C044VB13K6G/p1783173856572609)

### Problem

`rwx sandbox exec` force-pushes local HEAD to the sandbox first. When both clones are shallow with diverged boundaries, git rejects the push with `shallow update not allowed`, and the CLI prints only the raw error — no recovery hint, and no logging on why the sync failed. Automation that runs across many repos with shallow clones hits this most, and agents need to self-recover.

### Solution

- On a shallow rejection, print two recovery steps instead of the raw error: `git fetch --unshallow`, or set `fetch-full-depth: true` on the git/clone task and `rwx sandbox exec --reset`. (Verified: unshallow is the reliable fix; `--reset` only helps if the sandbox clones full-depth.)
- New `ErrShallowClone` sentinel, so the failure buckets as `shallow_clone` on `cli.error` instead of `unknown`.
- Add `failure_reason` to `sandbox.sync_push`, plus a PII-free `patch_error_reason` on any remaining `cli.error` `patch_failed` (patch_conflict / already_exists / corrupt_patch / lfs_changed / …), so we can see what's left after the shallow case.
- Self-contained red/green integration test for the shallow-local case.

Per the RFC, this coaches at failure time rather than hard-blocking shallow clones up front.

#### Further confirmation needed

- [x] Red baseline run (before the fix): https://cloud.rwx.com/mint/rwx/runs/b10dfbb930074b219cfed23c10b33c00
- [x] Green run (this branch): https://cloud.rwx.com/mint/rwx/runs/2b7a4819ffeb481687d223de2db79cae
- [ ] Full integration-sandbox suite passes in PR CI (regression check on the other sandbox tests)
