### PR TITLE
Fetch full clone depth for synced sandbox integration checkouts

### DIFF
--- a/test/integration/definitions/sandbox-setup-sync.yml
+++ b/test/integration/definitions/sandbox-setup-sync.yml
@@ -34,6 +34,7 @@ tasks:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}
       preserve-git-dir: true
+      fetch-full-depth: true
 
   - key: sandbox
     use: [code, rwx-cli]

--- a/test/integration/definitions/sandbox.yml
+++ b/test/integration/definitions/sandbox.yml
@@ -14,6 +14,7 @@ tasks:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}
       preserve-git-dir: true
+      fetch-full-depth: true
 
   - key: build-def
     use: code


### PR DESCRIPTION
### Problem

The sandbox integration tests clone the CLI repo into a `code` task via `git/clone`, which is shallow by default. Several tests then make a local commit and count on the pre-exec sync to push it into the sandbox. Since the checkout is shallow, git-receive-pack rejects that push with `shallow update not allowed` and the whole `integration-sandbox` suite goes red. That's what sank the run for the previous merge to main.

`fetch-full-depth: true` is already the fix we tell users about (it's in the coaching message #576 added), so this just applies it to the test definitions.

### Solution

- Add `fetch-full-depth: true` to the `code` task in `sandbox.yml` and `sandbox-setup-sync.yml`. Those are the two definitions whose `preserve-git-dir` checkout gets synced into a sandbox, and a full clone removes the shallow boundary the push chokes on.
- Left `sandbox-setup-failure.yml` alone: its sandbox never starts (preflight exits 1), so nothing syncs there.

#### Further confirmation needed

- [ ] The `integration-sandbox` suite passes on this branch.
