### PR TITLE
Support breakpoint sessions in the CLI

### DIFF
--- a/cmd/rwx/debug.go
+++ b/cmd/rwx/debug.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var DebugSession string
+
 var debugCmd = &cobra.Command{
 	GroupID: "execution",
 	Args:    cobra.ExactArgs(1),
@@ -13,11 +15,12 @@ var debugCmd = &cobra.Command{
 		return requireAccessToken()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return service.DebugTask(cli.DebugTaskConfig{DebugKey: args[0]})
+		return service.DebugTask(cli.DebugTaskConfig{DebugKey: args[0], Session: DebugSession})
 	},
 	Short: "Debug a task",
 	Use:   "debug [flags] [debugKey]",
 }
 
 func init() {
+	debugCmd.Flags().StringVar(&DebugSession, "session", "", "select a breakpoint session by ID or unique open name")
 }

--- a/cmd/rwx/debug_test.go
+++ b/cmd/rwx/debug_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebugExposesSessionFlag(t *testing.T) {
+	flag := debugCmd.Flags().Lookup("session")
+
+	require.NotNil(t, flag)
+	require.Equal(t, "string", flag.Value.Type())
+}

--- a/cmd/rwx/main_test.go
+++ b/cmd/rwx/main_test.go
@@ -41,6 +41,10 @@ func TestClassifyError(t *testing.T) {
 		{"sandbox_setup_failure", errors.ErrSandboxSetupFailure, "sandbox_setup_failure"},
 		{"sandbox_no_git_dir", errors.ErrSandboxNoGitDir, "sandbox_no_git_dir"},
 		{"shallow_clone", errors.ErrShallowClone, "shallow_clone"},
+		{"debug_session_selection", &api.DebugSessionSelectionError{}, "bad_request"},
+		{"debug_session_not_connectable", &api.DebugSessionNotConnectableError{}, "bad_request"},
+		{"debug_session_requires_task", &api.DebugSessionRequiresTaskError{}, "bad_request"},
+		{"debug_session_not_found", &api.DebugSessionNotFoundError{}, "not_found"},
 	}
 
 	for _, tc := range cases {

--- a/cmd/rwx/main_test.go
+++ b/cmd/rwx/main_test.go
@@ -45,6 +45,11 @@ func TestClassifyError(t *testing.T) {
 		{"debug_session_not_connectable", &api.DebugSessionNotConnectableError{}, "bad_request"},
 		{"debug_session_requires_task", &api.DebugSessionRequiresTaskError{}, "bad_request"},
 		{"debug_session_not_found", &api.DebugSessionNotFoundError{}, "not_found"},
+		{"debug_session_attachment_bad_request", &api.DebugSessionAttachmentError{Code: "invalid_task"}, "bad_request"},
+		{"debug_session_attachment_unauthenticated", &api.DebugSessionAttachmentError{Code: "vault_access_required"}, "unauthenticated"},
+		{"debug_session_attachment_not_found", &api.DebugSessionAttachmentError{Code: "task_not_found"}, "not_found"},
+		{"debug_session_attachment_gone", &api.DebugSessionAttachmentError{Code: "task_not_running"}, "gone"},
+		{"debug_session_attachment_server_error", &api.DebugSessionAttachmentError{Code: "task_server_error"}, "internal_server_error"},
 	}
 
 	for _, tc := range cases {

--- a/cmd/rwx/root.go
+++ b/cmd/rwx/root.go
@@ -238,6 +238,7 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(sandboxCmd)
 	rootCmd.AddCommand(skillCmd)
+	rootCmd.AddCommand(sshCmd)
 	rootCmd.AddCommand(updateCmd)
 	rootCmd.AddCommand(vaultsCmd)
 	rootCmd.AddCommand(docsCmd)

--- a/cmd/rwx/ssh.go
+++ b/cmd/rwx/ssh.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"github.com/rwx-cloud/rwx/internal/cli"
+
+	"github.com/spf13/cobra"
+)
+
+var SSHSessionName string
+
+var sshCmd = &cobra.Command{
+	GroupID: "execution",
+	Args:    cobra.ExactArgs(1),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return requireAccessToken()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return service.AttachSSHSession(cli.AttachSSHSessionConfig{
+			TaskID: args[0],
+			Name:   SSHSessionName,
+		})
+	},
+	Short: "Attach and connect to a running task",
+	Use:   "ssh [flags] [task-id]",
+}
+
+func init() {
+	sshCmd.Flags().StringVar(&SSHSessionName, "name", "", "name the attached SSH session")
+}

--- a/cmd/rwx/ssh_test.go
+++ b/cmd/rwx/ssh_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSHCommand(t *testing.T) {
+	cmd := findSubcommand(rootCmd, "ssh")
+	require.NotNil(t, cmd, "rwx ssh should exist")
+	require.Equal(t, "ssh [flags] [task-id]", cmd.Use)
+	require.Equal(t, "execution", cmd.GroupID)
+	require.NotNil(t, cmd.Flags().Lookup("name"), "rwx ssh should expose the --name flag")
+
+	require.NoError(t, cmd.Args(cmd, []string{"task-123"}))
+	require.Error(t, cmd.Args(cmd, nil))
+	require.Error(t, cmd.Args(cmd, []string{"task-123", "extra"}))
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -163,10 +163,24 @@ func (c Client) GetDebugConnectionInfo(cfg GetDebugConnectionInfoConfig) (DebugC
 	case 400:
 		connectionError := DebugConnectionInfoError{}
 		if err := json.NewDecoder(resp.Body).Decode(&connectionError); err == nil {
-			return connectionInfo, errors.Wrap(errors.ErrBadRequest, connectionError.Error)
+			if connectionError.Error == "session_requires_task" {
+				return connectionInfo, &DebugSessionRequiresTaskError{}
+			}
+			if connectionError.Error != "" {
+				return connectionInfo, errors.WrapSentinel(errors.New(connectionError.Error), errors.ErrBadRequest)
+			}
 		}
 		return connectionInfo, errors.ErrBadRequest
 	case 404:
+		connectionError := DebugConnectionInfoError{}
+		if err := json.NewDecoder(resp.Body).Decode(&connectionError); err == nil {
+			if connectionError.Error == "debug_session_not_found" {
+				return connectionInfo, &DebugSessionNotFoundError{Selector: cfg.Session}
+			}
+			if connectionError.Error != "" {
+				return connectionInfo, errors.WrapSentinel(errors.New(connectionError.Error), errors.ErrNotFound)
+			}
+		}
 		return connectionInfo, errors.ErrNotFound
 	case http.StatusUnprocessableEntity:
 		connectionError := DebugConnectionInfoError{}
@@ -177,12 +191,17 @@ func (c Client) GetDebugConnectionInfo(cfg GetDebugConnectionInfoConfig) (DebugC
 			case "debug_session_not_connectable":
 				return connectionInfo, &DebugSessionNotConnectableError{DebugSession: connectionError.DebugSession}
 			}
+			if connectionError.Error != "" {
+				return connectionInfo, errors.WrapSentinel(errors.New(connectionError.Error), errors.ErrBadRequest)
+			}
 		}
-		return connectionInfo, errors.New("debug session conflict")
+		return connectionInfo, errors.WrapSentinel(errors.New("Unable to call RWX API - 422 Unprocessable Entity"), errors.ErrBadRequest)
 	case 410:
 		connectionError := DebugConnectionInfoError{}
 		if err := json.NewDecoder(resp.Body).Decode(&connectionError); err == nil {
-			return connectionInfo, errors.Wrap(errors.ErrGone, connectionError.Error)
+			if connectionError.Error != "" {
+				return connectionInfo, errors.WrapSentinel(errors.New(connectionError.Error), errors.ErrGone)
+			}
 		}
 		return connectionInfo, errors.ErrGone
 	default:

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -168,7 +168,7 @@ func (c Client) GetDebugConnectionInfo(cfg GetDebugConnectionInfoConfig) (DebugC
 		return connectionInfo, errors.ErrBadRequest
 	case 404:
 		return connectionInfo, errors.ErrNotFound
-	case 409:
+	case http.StatusUnprocessableEntity:
 		connectionError := DebugConnectionInfoError{}
 		if err := json.NewDecoder(resp.Body).Decode(&connectionError); err == nil {
 			switch connectionError.Error {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -134,14 +134,18 @@ func (c Client) GetSkillLatestVersion() (string, error) {
 	return result.Version, nil
 }
 
-func (c Client) GetDebugConnectionInfo(debugKey string) (DebugConnectionInfo, error) {
+func (c Client) GetDebugConnectionInfo(cfg GetDebugConnectionInfoConfig) (DebugConnectionInfo, error) {
 	connectionInfo := DebugConnectionInfo{}
 
-	if debugKey == "" {
+	if cfg.DebugKey == "" {
 		return connectionInfo, errors.New("missing debugKey")
 	}
 
-	endpoint := fmt.Sprintf("/mint/api/debug_connection_info?debug_key=%s", url.QueryEscape(debugKey))
+	params := url.Values{"debug_key": []string{cfg.DebugKey}}
+	if cfg.Session != "" {
+		params.Set("session", cfg.Session)
+	}
+	endpoint := "/mint/api/debug_connection_info?" + params.Encode()
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
 		return connectionInfo, errors.Wrap(err, "unable to create new HTTP request")
@@ -164,6 +168,17 @@ func (c Client) GetDebugConnectionInfo(debugKey string) (DebugConnectionInfo, er
 		return connectionInfo, errors.ErrBadRequest
 	case 404:
 		return connectionInfo, errors.ErrNotFound
+	case 409:
+		connectionError := DebugConnectionInfoError{}
+		if err := json.NewDecoder(resp.Body).Decode(&connectionError); err == nil {
+			switch connectionError.Error {
+			case "selection_required":
+				return connectionInfo, &DebugSessionSelectionError{DebugSessions: connectionError.DebugSessions}
+			case "debug_session_not_connectable":
+				return connectionInfo, &DebugSessionNotConnectableError{DebugSession: connectionError.DebugSession}
+			}
+		}
+		return connectionInfo, errors.New("debug session conflict")
 	case 410:
 		connectionError := DebugConnectionInfoError{}
 		if err := json.NewDecoder(resp.Body).Decode(&connectionError); err == nil {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -1558,8 +1558,8 @@ func TestAPIClient_GetDebugConnectionInfo(t *testing.T) {
 	t.Run("returns every session when selection is required", func(t *testing.T) {
 		roundTrip := func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
-				Status:     "409 Conflict",
-				StatusCode: http.StatusConflict,
+				Status:     "422 Unprocessable Entity",
+				StatusCode: http.StatusUnprocessableEntity,
 				Body: io.NopCloser(strings.NewReader(`{
 					"error": "selection_required",
 					"debug_sessions": [
@@ -1579,6 +1579,37 @@ func TestAPIClient_GetDebugConnectionInfo(t *testing.T) {
 			{ID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Name: "shell", Status: "connectable"},
 			{ID: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", Status: "connectable"},
 		}, selectionErr.DebugSessions)
+	})
+
+	t.Run("returns the session lifecycle when it is not connectable", func(t *testing.T) {
+		roundTrip := func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "422 Unprocessable Entity",
+				StatusCode: http.StatusUnprocessableEntity,
+				Body: io.NopCloser(strings.NewReader(`{
+					"error": "debug_session_not_connectable",
+					"debug_session": {
+						"id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+						"name": "shell",
+						"status": "starting"
+					}
+				}`)),
+			}, nil
+		}
+
+		c := api.NewClientWithRoundTrip(roundTrip)
+
+		_, err := c.GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig{
+			DebugKey: "task-123",
+			Session:  "shell",
+		})
+		var notConnectableErr *api.DebugSessionNotConnectableError
+		require.ErrorAs(t, err, &notConnectableErr)
+		require.Equal(t, api.DebugSessionSummary{
+			ID:     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Name:   "shell",
+			Status: "starting",
+		}, notConnectableErr.DebugSession)
 	})
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/rwx-cloud/rwx/internal/api"
+	internalErrors "github.com/rwx-cloud/rwx/internal/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1575,6 +1576,7 @@ func TestAPIClient_GetDebugConnectionInfo(t *testing.T) {
 		_, err := c.GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig{DebugKey: "task-123"})
 		var selectionErr *api.DebugSessionSelectionError
 		require.ErrorAs(t, err, &selectionErr)
+		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
 		require.Equal(t, []api.DebugSessionSummary{
 			{ID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Name: "shell", Status: "connectable"},
 			{ID: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", Status: "connectable"},
@@ -1605,11 +1607,154 @@ func TestAPIClient_GetDebugConnectionInfo(t *testing.T) {
 		})
 		var notConnectableErr *api.DebugSessionNotConnectableError
 		require.ErrorAs(t, err, &notConnectableErr)
+		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
 		require.Equal(t, api.DebugSessionSummary{
 			ID:     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 			Name:   "shell",
 			Status: "starting",
 		}, notConnectableErr.DebugSession)
+	})
+
+	t.Run("requires a task key when selecting a session", func(t *testing.T) {
+		roundTrip := func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "400 Bad Request",
+				StatusCode: http.StatusBadRequest,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"session_requires_task"}`)),
+			}, nil
+		}
+
+		c := api.NewClientWithRoundTrip(roundTrip)
+
+		_, err := c.GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig{
+			DebugKey: "run-123",
+			Session:  "shell",
+		})
+		var requiresTaskErr *api.DebugSessionRequiresTaskError
+		require.ErrorAs(t, err, &requiresTaskErr)
+		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
+		require.EqualError(t, err, "--session requires a task ID or task URL")
+	})
+
+	t.Run("reports a missing session selector", func(t *testing.T) {
+		roundTrip := func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "404 Not Found",
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"debug_session_not_found"}`)),
+			}, nil
+		}
+
+		c := api.NewClientWithRoundTrip(roundTrip)
+
+		_, err := c.GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig{
+			DebugKey: "task-123",
+			Session:  "missing",
+		})
+		var notFoundErr *api.DebugSessionNotFoundError
+		require.ErrorAs(t, err, &notFoundErr)
+		require.ErrorIs(t, err, internalErrors.ErrNotFound)
+		require.Equal(t, "missing", notFoundErr.Selector)
+		require.EqualError(t, err, `debug session "missing" was not found`)
+	})
+
+	t.Run("preserves an unknown unprocessable error", func(t *testing.T) {
+		roundTrip := func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "422 Unprocessable Entity",
+				StatusCode: http.StatusUnprocessableEntity,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"future_session_error"}`)),
+			}, nil
+		}
+
+		c := api.NewClientWithRoundTrip(roundTrip)
+
+		_, err := c.GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig{DebugKey: "task-123"})
+		require.EqualError(t, err, "future_session_error")
+		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
+	})
+
+	t.Run("classifies forbidden and unexpected server errors", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			status     string
+			statusCode int
+			body       string
+			sentinel   error
+		}{
+			{
+				name:       "forbidden",
+				status:     "403 Forbidden",
+				statusCode: http.StatusForbidden,
+				body:       `{}`,
+				sentinel:   internalErrors.ErrUnauthenticated,
+			},
+			{
+				name:       "unexpected server error",
+				status:     "500 Internal Server Error",
+				statusCode: http.StatusInternalServerError,
+				body:       `{"error":"unexpected_error"}`,
+				sentinel:   internalErrors.ErrInternalServerError,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						Status:     tt.status,
+						StatusCode: tt.statusCode,
+						Body:       io.NopCloser(strings.NewReader(tt.body)),
+					}, nil
+				})
+
+				_, err := c.GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig{DebugKey: "task-123"})
+				require.ErrorIs(t, err, tt.sentinel)
+			})
+		}
+	})
+
+	t.Run("preserves invalid and ended run messages", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			status     string
+			statusCode int
+			message    string
+			sentinel   error
+		}{
+			{
+				name:       "invalid debug key",
+				status:     "400 Bad Request",
+				statusCode: http.StatusBadRequest,
+				message:    "We could not find a run or task with ID `missing`.",
+				sentinel:   internalErrors.ErrBadRequest,
+			},
+			{
+				name:       "ended run",
+				status:     "410 Gone",
+				statusCode: http.StatusGone,
+				message:    "This run or task is no longer debuggable.",
+				sentinel:   internalErrors.ErrGone,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+					body, err := json.Marshal(api.DebugConnectionInfoError{Error: tt.message})
+					require.NoError(t, err)
+					return &http.Response{
+						Status:     tt.status,
+						StatusCode: tt.statusCode,
+						Body:       io.NopCloser(bytes.NewReader(body)),
+					}, nil
+				})
+
+				_, err := c.GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig{DebugKey: "missing"})
+				require.EqualError(t, err, tt.message)
+				require.ErrorIs(t, err, tt.sentinel)
+			})
+		}
 	})
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -1522,6 +1523,62 @@ func TestAPIClient_GetSandboxConnectionInfo(t *testing.T) {
 		result, err := c.GetSandboxConnectionInfo("run-123", "scoped-token-abc")
 		require.NoError(t, err)
 		require.True(t, result.Sandboxable)
+	})
+}
+
+func TestAPIClient_GetDebugConnectionInfo(t *testing.T) {
+	t.Run("selects a debug session and returns its SSH username", func(t *testing.T) {
+		roundTrip := func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "/mint/api/debug_connection_info", req.URL.Path)
+			require.Equal(t, "task-123", req.URL.Query().Get("debug_key"))
+			require.Equal(t, "shell", req.URL.Query().Get("session"))
+			return &http.Response{
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{
+					"debuggable": true,
+					"address": "192.168.1.1:22",
+					"public_host_key": "public-key",
+					"private_user_key": "private-key",
+					"username": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+				}`)),
+			}, nil
+		}
+
+		c := api.NewClientWithRoundTrip(roundTrip)
+
+		result, err := c.GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig{
+			DebugKey: "task-123",
+			Session:  "shell",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", result.Username)
+	})
+
+	t.Run("returns every session when selection is required", func(t *testing.T) {
+		roundTrip := func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "409 Conflict",
+				StatusCode: http.StatusConflict,
+				Body: io.NopCloser(strings.NewReader(`{
+					"error": "selection_required",
+					"debug_sessions": [
+						{"id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "name": "shell", "status": "connectable"},
+						{"id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "name": null, "status": "connectable"}
+					]
+				}`)),
+			}, nil
+		}
+
+		c := api.NewClientWithRoundTrip(roundTrip)
+
+		_, err := c.GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig{DebugKey: "task-123"})
+		var selectionErr *api.DebugSessionSelectionError
+		require.ErrorAs(t, err, &selectionErr)
+		require.Equal(t, []api.DebugSessionSummary{
+			{ID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Name: "shell", Status: "connectable"},
+			{ID: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", Status: "connectable"},
+		}, selectionErr.DebugSessions)
 	})
 }
 

--- a/internal/api/debug_connection_info.go
+++ b/internal/api/debug_connection_info.go
@@ -1,6 +1,10 @@
 package api
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/rwx-cloud/rwx/internal/errors"
+)
 
 type GetDebugConnectionInfoConfig struct {
 	DebugKey string
@@ -35,6 +39,10 @@ func (e *DebugSessionSelectionError) Error() string {
 	return "multiple debug sessions are connectable"
 }
 
+func (e *DebugSessionSelectionError) Unwrap() error {
+	return errors.ErrBadRequest
+}
+
 type DebugSessionNotConnectableError struct {
 	DebugSession DebugSessionSummary
 }
@@ -45,4 +53,30 @@ func (e *DebugSessionNotConnectableError) Error() string {
 		selector = e.DebugSession.Name
 	}
 	return fmt.Sprintf("debug session %q is %s", selector, e.DebugSession.Status)
+}
+
+func (e *DebugSessionNotConnectableError) Unwrap() error {
+	return errors.ErrBadRequest
+}
+
+type DebugSessionRequiresTaskError struct{}
+
+func (e *DebugSessionRequiresTaskError) Error() string {
+	return "--session requires a task ID or task URL"
+}
+
+func (e *DebugSessionRequiresTaskError) Unwrap() error {
+	return errors.ErrBadRequest
+}
+
+type DebugSessionNotFoundError struct {
+	Selector string
+}
+
+func (e *DebugSessionNotFoundError) Error() string {
+	return fmt.Sprintf("debug session %q was not found", e.Selector)
+}
+
+func (e *DebugSessionNotFoundError) Unwrap() error {
+	return errors.ErrNotFound
 }

--- a/internal/api/debug_connection_info.go
+++ b/internal/api/debug_connection_info.go
@@ -36,7 +36,7 @@ type DebugSessionSelectionError struct {
 }
 
 func (e *DebugSessionSelectionError) Error() string {
-	return "multiple debug sessions are connectable"
+	return "multiple debug sessions are ready for connection"
 }
 
 func (e *DebugSessionSelectionError) Unwrap() error {

--- a/internal/api/debug_connection_info.go
+++ b/internal/api/debug_connection_info.go
@@ -36,7 +36,7 @@ type DebugSessionSelectionError struct {
 }
 
 func (e *DebugSessionSelectionError) Error() string {
-	return "multiple debug sessions are ready for connection"
+	return "multiple debug sessions require selection"
 }
 
 func (e *DebugSessionSelectionError) Unwrap() error {

--- a/internal/api/debug_connection_info.go
+++ b/internal/api/debug_connection_info.go
@@ -1,12 +1,48 @@
 package api
 
+import "fmt"
+
+type GetDebugConnectionInfoConfig struct {
+	DebugKey string
+	Session  string
+}
+
 type DebugConnectionInfo struct {
 	Debuggable     bool
 	Address        string
 	PublicHostKey  string `json:"public_host_key"`
 	PrivateUserKey string `json:"private_user_key"`
+	Username       string `json:"username"`
+}
+
+type DebugSessionSummary struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
 }
 
 type DebugConnectionInfoError struct {
-	Error string
+	Error         string                `json:"error"`
+	DebugSessions []DebugSessionSummary `json:"debug_sessions"`
+	DebugSession  DebugSessionSummary   `json:"debug_session"`
+}
+
+type DebugSessionSelectionError struct {
+	DebugSessions []DebugSessionSummary
+}
+
+func (e *DebugSessionSelectionError) Error() string {
+	return "multiple debug sessions are connectable"
+}
+
+type DebugSessionNotConnectableError struct {
+	DebugSession DebugSessionSummary
+}
+
+func (e *DebugSessionNotConnectableError) Error() string {
+	selector := e.DebugSession.ID
+	if e.DebugSession.Name != "" {
+		selector = e.DebugSession.Name
+	}
+	return fmt.Sprintf("debug session %q is %s", selector, e.DebugSession.Status)
 }

--- a/internal/api/debug_sessions.go
+++ b/internal/api/debug_sessions.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/rwx-cloud/rwx/internal/errors"
+)
+
+type AttachDebugSessionConfig struct {
+	TaskID string
+	Name   string
+}
+
+type DebugSessionAttachmentError struct {
+	Code   string
+	TaskID string
+	Name   string
+}
+
+func (e *DebugSessionAttachmentError) Error() string {
+	switch e.Code {
+	case "invalid_task":
+		return fmt.Sprintf("task %q cannot host an attached SSH session", e.TaskID)
+	case "vault_access_required":
+		return "the access token cannot unlock every vault used by this task"
+	case "task_not_found":
+		return fmt.Sprintf("task %q was not found", e.TaskID)
+	case "task_not_running":
+		return fmt.Sprintf("task %q is no longer running", e.TaskID)
+	case "duplicate_open_name":
+		return fmt.Sprintf("an open debug session named %q already exists", e.Name)
+	case "attachment_closed":
+		return fmt.Sprintf("task %q no longer accepts attached SSH sessions", e.TaskID)
+	case "task_server_error":
+		return "unable to attach an SSH session through the task server"
+	default:
+		return e.Code
+	}
+}
+
+func (e *DebugSessionAttachmentError) Unwrap() error {
+	switch e.Code {
+	case "vault_access_required":
+		return errors.ErrUnauthenticated
+	case "task_not_found":
+		return errors.ErrNotFound
+	case "task_not_running", "attachment_closed":
+		return errors.ErrGone
+	case "task_server_error":
+		return errors.ErrInternalServerError
+	default:
+		return errors.ErrBadRequest
+	}
+}
+
+func (c Client) AttachDebugSession(cfg AttachDebugSessionConfig) (DebugSessionSummary, error) {
+	if cfg.TaskID == "" {
+		return DebugSessionSummary{}, errors.WrapSentinel(errors.New("missing task ID"), errors.ErrBadRequest)
+	}
+
+	requestBody := struct {
+		Name string `json:"name,omitempty"`
+	}{Name: cfg.Name}
+	encodedBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return DebugSessionSummary{}, errors.Wrap(err, "unable to encode as JSON")
+	}
+
+	endpoint := fmt.Sprintf("/mint/api/tasks/%s/debug_sessions", url.PathEscape(cfg.TaskID))
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(encodedBody))
+	if err != nil {
+		return DebugSessionSummary{}, errors.Wrap(err, "unable to create new HTTP request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.RoundTrip(req)
+	if err != nil {
+		return DebugSessionSummary{}, errors.Wrap(err, "HTTP request failed")
+	}
+	defer resp.Body.Close()
+
+	responseBody := struct {
+		DebugSession DebugSessionSummary `json:"debug_session"`
+		Error        string              `json:"error"`
+	}{}
+	if err := json.NewDecoder(resp.Body).Decode(&responseBody); err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			return DebugSessionSummary{}, &DebugSessionAttachmentError{Code: "task_not_found", TaskID: cfg.TaskID, Name: cfg.Name}
+		}
+		return DebugSessionSummary{}, errors.Wrap(err, "unable to parse API response")
+	}
+
+	if resp.StatusCode == http.StatusAccepted {
+		return responseBody.DebugSession, nil
+	}
+
+	code := responseBody.Error
+	if code == "" && resp.StatusCode == http.StatusNotFound {
+		code = "task_not_found"
+	}
+	if code != "" {
+		return DebugSessionSummary{}, &DebugSessionAttachmentError{Code: code, TaskID: cfg.TaskID, Name: cfg.Name}
+	}
+
+	message := fmt.Sprintf("Unable to call RWX API - %s", resp.Status)
+	return DebugSessionSummary{}, classifyHTTPStatusError(resp.StatusCode, message)
+}

--- a/internal/api/debug_sessions_test.go
+++ b/internal/api/debug_sessions_test.go
@@ -1,0 +1,167 @@
+package api_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	internalErrors "github.com/rwx-cloud/rwx/internal/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIClient_AttachDebugSession(t *testing.T) {
+	t.Run("attaches a named session", func(t *testing.T) {
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, http.MethodPost, req.Method)
+			require.Equal(t, "/mint/api/tasks/task-123/debug_sessions", req.URL.Path)
+			require.Equal(t, "application/json", req.Header.Get("Content-Type"))
+
+			var body map[string]any
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			require.Equal(t, map[string]any{"name": "shell"}, body)
+
+			return &http.Response{
+				Status:     "202 Accepted",
+				StatusCode: http.StatusAccepted,
+				Body: io.NopCloser(strings.NewReader(`{
+					"debug_session": {
+						"id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+						"name": "shell",
+						"status": "starting"
+					}
+				}`)),
+			}, nil
+		})
+
+		session, err := c.AttachDebugSession(api.AttachDebugSessionConfig{
+			TaskID: "task-123",
+			Name:   "shell",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, api.DebugSessionSummary{
+			ID:     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			Name:   "shell",
+			Status: "starting",
+		}, session)
+	})
+
+	t.Run("requires a task ID", func(t *testing.T) {
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			t.Fatal("should not make a request")
+			return nil, nil
+		})
+
+		_, err := c.AttachDebugSession(api.AttachDebugSessionConfig{})
+
+		require.EqualError(t, err, "missing task ID")
+		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
+	})
+
+	t.Run("maps admission errors", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			status     string
+			statusCode int
+			code       string
+			sentinel   error
+			message    string
+		}{
+			{
+				name:       "invalid task type",
+				status:     "400 Bad Request",
+				statusCode: http.StatusBadRequest,
+				code:       "invalid_task",
+				sentinel:   internalErrors.ErrBadRequest,
+				message:    `task "task-123" cannot host an attached SSH session`,
+			},
+			{
+				name:       "locked vault",
+				status:     "403 Forbidden",
+				statusCode: http.StatusForbidden,
+				code:       "vault_access_required",
+				sentinel:   internalErrors.ErrUnauthenticated,
+				message:    "the access token cannot unlock every vault used by this task",
+			},
+			{
+				name:       "task not found",
+				status:     "404 Not Found",
+				statusCode: http.StatusNotFound,
+				code:       "task_not_found",
+				sentinel:   internalErrors.ErrNotFound,
+				message:    `task "task-123" was not found`,
+			},
+			{
+				name:       "unavailable task server",
+				status:     "410 Gone",
+				statusCode: http.StatusGone,
+				code:       "task_not_running",
+				sentinel:   internalErrors.ErrGone,
+				message:    `task "task-123" is no longer running`,
+			},
+			{
+				name:       "duplicate name",
+				status:     "422 Unprocessable Entity",
+				statusCode: http.StatusUnprocessableEntity,
+				code:       "duplicate_open_name",
+				sentinel:   internalErrors.ErrBadRequest,
+				message:    `an open debug session named "shell" already exists`,
+			},
+			{
+				name:       "task stopped during admission",
+				status:     "422 Unprocessable Entity",
+				statusCode: http.StatusUnprocessableEntity,
+				code:       "task_not_running",
+				sentinel:   internalErrors.ErrGone,
+				message:    `task "task-123" is no longer running`,
+			},
+			{
+				name:       "attachment closed",
+				status:     "422 Unprocessable Entity",
+				statusCode: http.StatusUnprocessableEntity,
+				code:       "attachment_closed",
+				sentinel:   internalErrors.ErrGone,
+				message:    `task "task-123" no longer accepts attached SSH sessions`,
+			},
+			{
+				name:       "task server error",
+				status:     "502 Bad Gateway",
+				statusCode: http.StatusBadGateway,
+				code:       "task_server_error",
+				sentinel:   internalErrors.ErrInternalServerError,
+				message:    "unable to attach an SSH session through the task server",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+					body := `{}`
+					if tt.code != "task_not_found" {
+						bodyBytes, err := json.Marshal(map[string]string{"error": tt.code})
+						require.NoError(t, err)
+						body = string(bodyBytes)
+					}
+					return &http.Response{
+						Status:     tt.status,
+						StatusCode: tt.statusCode,
+						Body:       io.NopCloser(strings.NewReader(body)),
+					}, nil
+				})
+
+				_, err := c.AttachDebugSession(api.AttachDebugSessionConfig{
+					TaskID: "task-123",
+					Name:   "shell",
+				})
+				var attachmentErr *api.DebugSessionAttachmentError
+				require.ErrorAs(t, err, &attachmentErr)
+				require.Equal(t, tt.code, attachmentErr.Code)
+				require.EqualError(t, err, tt.message)
+				require.ErrorIs(t, err, tt.sentinel)
+			})
+		}
+	})
+}

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -14,6 +14,7 @@ import (
 type APIClient interface {
 	GetSkillContent() (string, error)
 	GetSkillLatestVersion() (string, error)
+	AttachDebugSession(api.AttachDebugSessionConfig) (api.DebugSessionSummary, error)
 	GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig) (api.DebugConnectionInfo, error)
 	GetSandboxConnectionInfo(runID, scopedToken string) (api.SandboxConnectionInfo, error)
 	CreateSandboxToken(api.CreateSandboxTokenConfig) (*api.CreateSandboxTokenResult, error)

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -14,7 +14,7 @@ import (
 type APIClient interface {
 	GetSkillContent() (string, error)
 	GetSkillLatestVersion() (string, error)
-	GetDebugConnectionInfo(debugKey string) (api.DebugConnectionInfo, error)
+	GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig) (api.DebugConnectionInfo, error)
 	GetSandboxConnectionInfo(runID, scopedToken string) (api.SandboxConnectionInfo, error)
 	CreateSandboxToken(api.CreateSandboxTokenConfig) (*api.CreateSandboxTokenResult, error)
 	GetDispatch(api.GetDispatchConfig) (*api.GetDispatchResult, error)

--- a/internal/cli/service_debug.go
+++ b/internal/cli/service_debug.go
@@ -38,6 +38,10 @@ func (s Service) DebugTask(cfg DebugTaskConfig) error {
 		return err
 	}
 
+	return s.connectDebugSession(connectionInfo)
+}
+
+func (s Service) connectDebugSession(connectionInfo api.DebugConnectionInfo) error {
 	if !connectionInfo.Debuggable {
 		return errors.Wrap(errors.ErrRetry, "The task or run is not in a debuggable state")
 	}

--- a/internal/cli/service_debug.go
+++ b/internal/cli/service_debug.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/rwx-cloud/rwx/internal/api"
@@ -12,6 +15,7 @@ import (
 
 type DebugTaskConfig struct {
 	DebugKey string
+	Session  string
 }
 
 func (c DebugTaskConfig) Validate() error {
@@ -29,7 +33,7 @@ func (s Service) DebugTask(cfg DebugTaskConfig) error {
 		return errors.Wrap(err, "validation failed")
 	}
 
-	connectionInfo, err := s.APIClient.GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig{DebugKey: cfg.DebugKey})
+	connectionInfo, err := s.getDebugConnectionInfo(cfg)
 	if err != nil {
 		return err
 	}
@@ -54,7 +58,7 @@ func (s Service) DebugTask(cfg DebugTaskConfig) error {
 	}
 
 	sshConfig := ssh.ClientConfig{
-		User:            rwxCLISSHUser,
+		User:            debugSSHUser(connectionInfo),
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(privateUserKey)},
 		HostKeyCallback: ssh.FixedHostKey(publicHostKey),
 		BannerCallback: func(message string) error {
@@ -107,4 +111,97 @@ func (s Service) DebugTask(cfg DebugTaskConfig) error {
 	})
 
 	return nil
+}
+
+func (s Service) getDebugConnectionInfo(cfg DebugTaskConfig) (api.DebugConnectionInfo, error) {
+	connectionInfo, err := s.APIClient.GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig{
+		DebugKey: cfg.DebugKey,
+		Session:  cfg.Session,
+	})
+	if err == nil {
+		return connectionInfo, nil
+	}
+
+	var selectionErr *api.DebugSessionSelectionError
+	if !errors.As(err, &selectionErr) {
+		return api.DebugConnectionInfo{}, err
+	}
+
+	if !s.StdoutIsTTY || cfg.Session != "" {
+		return api.DebugConnectionInfo{}, debugSessionSelectionError(cfg.DebugKey, selectionErr.DebugSessions)
+	}
+
+	selected, err := s.promptForDebugSession(selectionErr.DebugSessions)
+	if err != nil {
+		return api.DebugConnectionInfo{}, err
+	}
+
+	connectionInfo, err = s.APIClient.GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig{
+		DebugKey: cfg.DebugKey,
+		Session:  selected.ID,
+	})
+	if err != nil {
+		if errors.As(err, &selectionErr) {
+			return api.DebugConnectionInfo{}, debugSessionSelectionError(cfg.DebugKey, selectionErr.DebugSessions)
+		}
+		return api.DebugConnectionInfo{}, err
+	}
+
+	return connectionInfo, nil
+}
+
+func (s Service) promptForDebugSession(sessions []api.DebugSessionSummary) (api.DebugSessionSummary, error) {
+	fmt.Fprintln(s.Stdout, "Select a debug session:")
+	for index, session := range sessions {
+		fmt.Fprintf(s.Stdout, "  %d. %s — %s\n", index+1, debugSessionLabel(session), session.Status)
+	}
+	fmt.Fprintln(s.Stdout)
+	fmt.Fprintf(s.Stdout, "Enter a number (1-%d): ", len(sessions))
+
+	scanner := bufio.NewScanner(s.Stdin)
+	if !scanner.Scan() {
+		return api.DebugSessionSummary{}, errors.New("no debug session selected")
+	}
+
+	choice, err := strconv.Atoi(strings.TrimSpace(scanner.Text()))
+	if err != nil || choice < 1 || choice > len(sessions) {
+		return api.DebugSessionSummary{}, errors.Errorf("invalid debug session selection: %s", scanner.Text())
+	}
+
+	return sessions[choice-1], nil
+}
+
+func debugSessionSelectionError(debugKey string, sessions []api.DebugSessionSummary) error {
+	var message strings.Builder
+	message.WriteString("multiple debug sessions are connectable\n\nAvailable sessions:\n")
+	for _, session := range sessions {
+		name := session.Name
+		if name == "" {
+			name = "(unnamed)"
+		}
+		fmt.Fprintf(&message, "  %s\n    ID: %s\n    Status: %s\n", name, session.ID, session.Status)
+	}
+	if len(sessions) > 0 {
+		fmt.Fprintf(&message, "\nChoose a session and retry:\n  rwx debug --session %s %s", sessions[0].ID, debugKey)
+	}
+
+	return errors.New(message.String())
+}
+
+func debugSessionLabel(session api.DebugSessionSummary) string {
+	shortID := session.ID
+	if len(shortID) > 8 {
+		shortID = shortID[:8]
+	}
+	if session.Name == "" {
+		return shortID
+	}
+	return fmt.Sprintf("%s (%s)", session.Name, shortID)
+}
+
+func debugSSHUser(connectionInfo api.DebugConnectionInfo) string {
+	if connectionInfo.Username != "" {
+		return connectionInfo.Username
+	}
+	return rwxCLISSHUser
 }

--- a/internal/cli/service_debug.go
+++ b/internal/cli/service_debug.go
@@ -157,7 +157,7 @@ func (s Service) getDebugConnectionInfo(cfg DebugTaskConfig) (api.DebugConnectio
 func (s Service) promptForDebugSession(sessions []api.DebugSessionSummary) (api.DebugSessionSummary, error) {
 	fmt.Fprintln(s.Stdout, "Select a debug session:")
 	for index, session := range sessions {
-		fmt.Fprintf(s.Stdout, "  %d. %s — %s\n", index+1, debugSessionLabel(session), debugSessionStatusLabel(session))
+		fmt.Fprintf(s.Stdout, "  %d. %s\n", index+1, debugSessionLabel(session))
 	}
 	fmt.Fprintln(s.Stdout)
 	fmt.Fprintf(s.Stdout, "Enter a number (1-%d): ", len(sessions))
@@ -177,13 +177,13 @@ func (s Service) promptForDebugSession(sessions []api.DebugSessionSummary) (api.
 
 func debugSessionSelectionError(debugKey string, sessions []api.DebugSessionSummary) error {
 	var message strings.Builder
-	message.WriteString("multiple debug sessions are ready for connection\n\nAvailable sessions:\n")
+	message.WriteString("multiple debug sessions require selection\n\nAvailable sessions:\n")
 	for _, session := range sessions {
 		name := session.Name
 		if name == "" {
 			name = "(unnamed)"
 		}
-		fmt.Fprintf(&message, "  %s\n    ID: %s\n    Status: %s\n", name, session.ID, debugSessionStatusLabel(session))
+		fmt.Fprintf(&message, "  %s\n    ID: %s\n", name, session.ID)
 	}
 	if len(sessions) > 0 {
 		fmt.Fprintf(&message, "\nChoose a session and retry:\n  rwx debug --session %s %s", sessions[0].ID, debugKey)
@@ -201,13 +201,6 @@ func debugSessionLabel(session api.DebugSessionSummary) string {
 		return shortID
 	}
 	return fmt.Sprintf("%s (%s)", session.Name, shortID)
-}
-
-func debugSessionStatusLabel(session api.DebugSessionSummary) string {
-	if session.Status == "connectable" {
-		return "Ready for connection"
-	}
-	return session.Status
 }
 
 func debugSSHUser(connectionInfo api.DebugConnectionInfo) string {

--- a/internal/cli/service_debug.go
+++ b/internal/cli/service_debug.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rwx-cloud/rwx/internal/api"
 	"github.com/rwx-cloud/rwx/internal/errors"
 
 	"golang.org/x/crypto/ssh"
@@ -28,7 +29,7 @@ func (s Service) DebugTask(cfg DebugTaskConfig) error {
 		return errors.Wrap(err, "validation failed")
 	}
 
-	connectionInfo, err := s.APIClient.GetDebugConnectionInfo(cfg.DebugKey)
+	connectionInfo, err := s.APIClient.GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig{DebugKey: cfg.DebugKey})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/service_debug.go
+++ b/internal/cli/service_debug.go
@@ -157,7 +157,7 @@ func (s Service) getDebugConnectionInfo(cfg DebugTaskConfig) (api.DebugConnectio
 func (s Service) promptForDebugSession(sessions []api.DebugSessionSummary) (api.DebugSessionSummary, error) {
 	fmt.Fprintln(s.Stdout, "Select a debug session:")
 	for index, session := range sessions {
-		fmt.Fprintf(s.Stdout, "  %d. %s — %s\n", index+1, debugSessionLabel(session), session.Status)
+		fmt.Fprintf(s.Stdout, "  %d. %s — %s\n", index+1, debugSessionLabel(session), debugSessionStatusLabel(session))
 	}
 	fmt.Fprintln(s.Stdout)
 	fmt.Fprintf(s.Stdout, "Enter a number (1-%d): ", len(sessions))
@@ -177,13 +177,13 @@ func (s Service) promptForDebugSession(sessions []api.DebugSessionSummary) (api.
 
 func debugSessionSelectionError(debugKey string, sessions []api.DebugSessionSummary) error {
 	var message strings.Builder
-	message.WriteString("multiple debug sessions are connectable\n\nAvailable sessions:\n")
+	message.WriteString("multiple debug sessions are ready for connection\n\nAvailable sessions:\n")
 	for _, session := range sessions {
 		name := session.Name
 		if name == "" {
 			name = "(unnamed)"
 		}
-		fmt.Fprintf(&message, "  %s\n    ID: %s\n    Status: %s\n", name, session.ID, session.Status)
+		fmt.Fprintf(&message, "  %s\n    ID: %s\n    Status: %s\n", name, session.ID, debugSessionStatusLabel(session))
 	}
 	if len(sessions) > 0 {
 		fmt.Fprintf(&message, "\nChoose a session and retry:\n  rwx debug --session %s %s", sessions[0].ID, debugKey)
@@ -201,6 +201,13 @@ func debugSessionLabel(session api.DebugSessionSummary) string {
 		return shortID
 	}
 	return fmt.Sprintf("%s (%s)", session.Name, shortID)
+}
+
+func debugSessionStatusLabel(session api.DebugSessionSummary) string {
+	if session.Status == "connectable" {
+		return "Ready for connection"
+	}
+	return session.Status
 }
 
 func debugSSHUser(connectionInfo api.DebugConnectionInfo) string {

--- a/internal/cli/service_debug_test.go
+++ b/internal/cli/service_debug_test.go
@@ -103,15 +103,13 @@ AAAEC6442PQKevgYgeT0SIu9zwlnEMl6MF59ZgM+i0ByMv4eLJPqG3xnZcEQmktHj/GY2i
 
 		err := s.service.DebugTask(cli.DebugTaskConfig{DebugKey: "task-123"})
 
-		require.EqualError(t, err, `multiple debug sessions are ready for connection
+		require.EqualError(t, err, `multiple debug sessions require selection
 
 Available sessions:
   shell
     ID: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    Status: Ready for connection
   (unnamed)
     ID: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    Status: Ready for connection
 
 Choose a session and retry:
   rwx debug --session aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa task-123`)
@@ -157,8 +155,8 @@ Choose a session and retry:
 		require.NoError(t, err)
 		require.Equal(t, 2, calls)
 		require.Equal(t, `Select a debug session:
-  1. shell (aaaaaaaa) — Ready for connection
-  2. bbbbbbbb — Ready for connection
+  1. shell (aaaaaaaa)
+  2. bbbbbbbb
 
 Enter a number (1-2): `, s.mockStdout.String())
 	})

--- a/internal/cli/service_debug_test.go
+++ b/internal/cli/service_debug_test.go
@@ -103,15 +103,15 @@ AAAEC6442PQKevgYgeT0SIu9zwlnEMl6MF59ZgM+i0ByMv4eLJPqG3xnZcEQmktHj/GY2i
 
 		err := s.service.DebugTask(cli.DebugTaskConfig{DebugKey: "task-123"})
 
-		require.EqualError(t, err, `multiple debug sessions are connectable
+		require.EqualError(t, err, `multiple debug sessions are ready for connection
 
 Available sessions:
   shell
     ID: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    Status: connectable
+    Status: Ready for connection
   (unnamed)
     ID: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    Status: connectable
+    Status: Ready for connection
 
 Choose a session and retry:
   rwx debug --session aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa task-123`)
@@ -157,8 +157,8 @@ Choose a session and retry:
 		require.NoError(t, err)
 		require.Equal(t, 2, calls)
 		require.Equal(t, `Select a debug session:
-  1. shell (aaaaaaaa) — connectable
-  2. bbbbbbbb — connectable
+  1. shell (aaaaaaaa) — Ready for connection
+  2. bbbbbbbb — Ready for connection
 
 Enter a number (1-2): `, s.mockStdout.String())
 	})

--- a/internal/cli/service_debug_test.go
+++ b/internal/cli/service_debug_test.go
@@ -37,8 +37,8 @@ AAAEC6442PQKevgYgeT0SIu9zwlnEMl6MF59ZgM+i0ByMv4eLJPqG3xnZcEQmktHj/GY2i
 			DebugKey: runID,
 		}
 
-		s.mockAPI.MockGetDebugConnectionInfo = func(runId string) (api.DebugConnectionInfo, error) {
-			require.Equal(t, runID, runId)
+		s.mockAPI.MockGetDebugConnectionInfo = func(cfg api.GetDebugConnectionInfoConfig) (api.DebugConnectionInfo, error) {
+			require.Equal(t, runID, cfg.DebugKey)
 			fetchedConnectionInfo = true
 			return api.DebugConnectionInfo{
 				Debuggable:     true,
@@ -78,8 +78,8 @@ AAAEC6442PQKevgYgeT0SIu9zwlnEMl6MF59ZgM+i0ByMv4eLJPqG3xnZcEQmktHj/GY2i
 			DebugKey: runID,
 		}
 
-		s.mockAPI.MockGetDebugConnectionInfo = func(runId string) (api.DebugConnectionInfo, error) {
-			require.Equal(t, runID, runId)
+		s.mockAPI.MockGetDebugConnectionInfo = func(cfg api.GetDebugConnectionInfoConfig) (api.DebugConnectionInfo, error) {
+			require.Equal(t, runID, cfg.DebugKey)
 			return api.DebugConnectionInfo{Debuggable: false}, nil
 		}
 

--- a/internal/cli/service_debug_test.go
+++ b/internal/cli/service_debug_test.go
@@ -87,4 +87,79 @@ AAAEC6442PQKevgYgeT0SIu9zwlnEMl6MF59ZgM+i0ByMv4eLJPqG3xnZcEQmktHj/GY2i
 
 		require.True(t, errors.Is(err, internalErrors.ErrRetry))
 	})
+
+	t.Run("when multiple sessions require selection in a non-TTY", func(t *testing.T) {
+		s := setupTest(t)
+		s.mockAPI.MockGetDebugConnectionInfo = func(cfg api.GetDebugConnectionInfoConfig) (api.DebugConnectionInfo, error) {
+			require.Equal(t, "task-123", cfg.DebugKey)
+			require.Empty(t, cfg.Session)
+			return api.DebugConnectionInfo{}, &api.DebugSessionSelectionError{
+				DebugSessions: []api.DebugSessionSummary{
+					{ID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Name: "shell", Status: "connectable"},
+					{ID: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", Status: "connectable"},
+				},
+			}
+		}
+
+		err := s.service.DebugTask(cli.DebugTaskConfig{DebugKey: "task-123"})
+
+		require.EqualError(t, err, `multiple debug sessions are connectable
+
+Available sessions:
+  shell
+    ID: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    Status: connectable
+  (unnamed)
+    ID: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    Status: connectable
+
+Choose a session and retry:
+  rwx debug --session aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa task-123`)
+	})
+
+	t.Run("when multiple sessions require selection in a TTY", func(t *testing.T) {
+		s := setupTestWithTTY(t)
+		_, err := s.mockStdin.WriteString("2\n")
+		require.NoError(t, err)
+
+		calls := 0
+		s.mockAPI.MockGetDebugConnectionInfo = func(cfg api.GetDebugConnectionInfoConfig) (api.DebugConnectionInfo, error) {
+			calls++
+			require.Equal(t, "task-123", cfg.DebugKey)
+			if calls == 1 {
+				require.Empty(t, cfg.Session)
+				return api.DebugConnectionInfo{}, &api.DebugSessionSelectionError{
+					DebugSessions: []api.DebugSessionSummary{
+						{ID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Name: "shell", Status: "connectable"},
+						{ID: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", Status: "connectable"},
+					},
+				}
+			}
+
+			require.Equal(t, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", cfg.Session)
+			return api.DebugConnectionInfo{
+				Debuggable:     true,
+				PrivateUserKey: privateTestKey,
+				PublicHostKey:  publicTestKey,
+				Address:        "debug.example.org:22",
+				Username:       cfg.Session,
+			}, nil
+		}
+		s.mockSSH.MockConnect = func(addr string, cfg ssh.ClientConfig) error {
+			require.Equal(t, "debug.example.org:22", addr)
+			require.Equal(t, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", cfg.User)
+			return nil
+		}
+		s.mockSSH.MockInteractiveSession = func() error { return nil }
+
+		err = s.service.DebugTask(cli.DebugTaskConfig{DebugKey: "task-123"})
+
+		require.NoError(t, err)
+		require.Equal(t, 2, calls)
+		require.Equal(t, `Select a debug session:
+  1. shell (aaaaaaaa) — connectable
+  2. bbbbbbbb — connectable
+
+Enter a number (1-2): `, s.mockStdout.String())
+	})
 }

--- a/internal/cli/service_ssh.go
+++ b/internal/cli/service_ssh.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/errors"
+)
+
+const defaultSSHSessionPollInterval = time.Second
+
+type AttachSSHSessionConfig struct {
+	TaskID       string
+	Name         string
+	PollInterval time.Duration
+}
+
+func (c AttachSSHSessionConfig) Validate() error {
+	if c.TaskID == "" {
+		return errors.New("you must specify a task ID")
+	}
+	return nil
+}
+
+func (s Service) AttachSSHSession(cfg AttachSSHSessionConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return errors.Wrap(err, "validation failed")
+	}
+
+	session, err := s.APIClient.AttachDebugSession(api.AttachDebugSessionConfig{
+		TaskID: cfg.TaskID,
+		Name:   cfg.Name,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(s.Stdout, "Attached SSH session %s. The task will continue running.\n", debugSessionLabel(session))
+	stopSpinner := Spin("Waiting for SSH session to be ready...", s.StdoutIsTTY, s.Stdout)
+
+	pollInterval := cfg.PollInterval
+	if pollInterval <= 0 {
+		pollInterval = defaultSSHSessionPollInterval
+	}
+
+	for {
+		connectionInfo, err := s.APIClient.GetDebugConnectionInfo(api.GetDebugConnectionInfoConfig{
+			DebugKey: cfg.TaskID,
+			Session:  session.ID,
+		})
+		if err == nil {
+			stopSpinner()
+			return s.connectDebugSession(connectionInfo)
+		}
+
+		if !debugSessionIsStarting(err) {
+			stopSpinner()
+			return err
+		}
+
+		time.Sleep(pollInterval)
+	}
+}
+
+func debugSessionIsStarting(err error) bool {
+	var notFoundErr *api.DebugSessionNotFoundError
+	if errors.As(err, &notFoundErr) {
+		return true
+	}
+
+	var notConnectableErr *api.DebugSessionNotConnectableError
+	return errors.As(err, &notConnectableErr) && notConnectableErr.DebugSession.Status == "starting"
+}

--- a/internal/cli/service_ssh_test.go
+++ b/internal/cli/service_ssh_test.go
@@ -1,0 +1,102 @@
+package cli_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/cli"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestService_AttachSSHSession(t *testing.T) {
+	t.Run("attaches, waits for ingestion and readiness, then connects", func(t *testing.T) {
+		s := setupTest(t)
+		const sessionID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+		s.mockAPI.MockAttachDebugSession = func(cfg api.AttachDebugSessionConfig) (api.DebugSessionSummary, error) {
+			require.Equal(t, "task-123", cfg.TaskID)
+			require.Equal(t, "shell", cfg.Name)
+			return api.DebugSessionSummary{ID: sessionID, Name: "shell", Status: "starting"}, nil
+		}
+
+		connectionLookups := 0
+		s.mockAPI.MockGetDebugConnectionInfo = func(cfg api.GetDebugConnectionInfoConfig) (api.DebugConnectionInfo, error) {
+			connectionLookups++
+			require.Equal(t, "task-123", cfg.DebugKey)
+			require.Equal(t, sessionID, cfg.Session)
+			switch connectionLookups {
+			case 1:
+				return api.DebugConnectionInfo{}, &api.DebugSessionNotFoundError{Selector: sessionID}
+			case 2:
+				return api.DebugConnectionInfo{}, &api.DebugSessionNotConnectableError{
+					DebugSession: api.DebugSessionSummary{ID: sessionID, Name: "shell", Status: "starting"},
+				}
+			default:
+				return api.DebugConnectionInfo{
+					Debuggable:     true,
+					Address:        "debug.example.org:22",
+					PrivateUserKey: sandboxPrivateTestKey,
+					PublicHostKey:  sandboxPublicTestKey,
+					Username:       sessionID,
+				}, nil
+			}
+		}
+
+		s.mockSSH.MockConnect = func(addr string, cfg ssh.ClientConfig) error {
+			require.Equal(t, "debug.example.org:22", addr)
+			require.Equal(t, sessionID, cfg.User)
+			return nil
+		}
+		s.mockSSH.MockInteractiveSession = func() error { return nil }
+
+		err := s.service.AttachSSHSession(cli.AttachSSHSessionConfig{
+			TaskID:       "task-123",
+			Name:         "shell",
+			PollInterval: time.Millisecond,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 3, connectionLookups)
+		require.Contains(t, s.mockStdout.String(), "Attached SSH session shell (aaaaaaaa). The task will continue running.\n")
+		require.Contains(t, s.mockStdout.String(), "Waiting for SSH session to be ready...\n")
+	})
+
+	t.Run("stops waiting when the attached session ends", func(t *testing.T) {
+		s := setupTest(t)
+		const sessionID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+		s.mockAPI.MockAttachDebugSession = func(api.AttachDebugSessionConfig) (api.DebugSessionSummary, error) {
+			return api.DebugSessionSummary{ID: sessionID, Status: "starting"}, nil
+		}
+		s.mockAPI.MockGetDebugConnectionInfo = func(api.GetDebugConnectionInfoConfig) (api.DebugConnectionInfo, error) {
+			return api.DebugConnectionInfo{}, &api.DebugSessionNotConnectableError{
+				DebugSession: api.DebugSessionSummary{ID: sessionID, Status: "ended"},
+			}
+		}
+
+		err := s.service.AttachSSHSession(cli.AttachSSHSessionConfig{
+			TaskID:       "task-123",
+			PollInterval: time.Millisecond,
+		})
+
+		require.EqualError(t, err, `debug session "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" is ended`)
+	})
+
+	t.Run("returns attachment errors without polling", func(t *testing.T) {
+		s := setupTest(t)
+		attachmentErr := &api.DebugSessionAttachmentError{Code: "attachment_closed", TaskID: "task-123"}
+		s.mockAPI.MockAttachDebugSession = func(api.AttachDebugSessionConfig) (api.DebugSessionSummary, error) {
+			return api.DebugSessionSummary{}, attachmentErr
+		}
+		s.mockAPI.MockGetDebugConnectionInfo = func(api.GetDebugConnectionInfoConfig) (api.DebugConnectionInfo, error) {
+			t.Fatal("should not poll after attachment fails")
+			return api.DebugConnectionInfo{}, nil
+		}
+
+		err := s.service.AttachSSHSession(cli.AttachSSHSessionConfig{TaskID: "task-123"})
+
+		require.ErrorIs(t, err, attachmentErr)
+	})
+}

--- a/internal/cli/service_telemetry_test.go
+++ b/internal/cli/service_telemetry_test.go
@@ -640,7 +640,7 @@ func TestTelemetry_DebugSSH(t *testing.T) {
 	t.Run("records ssh.connect and ssh.command for debug session", func(t *testing.T) {
 		setup := setupTest(t)
 
-		setup.mockAPI.MockGetDebugConnectionInfo = func(runId string) (api.DebugConnectionInfo, error) {
+		setup.mockAPI.MockGetDebugConnectionInfo = func(api.GetDebugConnectionInfoConfig) (api.DebugConnectionInfo, error) {
 			return api.DebugConnectionInfo{
 				Debuggable:     true,
 				PrivateUserKey: sandboxPrivateTestKey,

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -12,6 +12,7 @@ type API struct {
 	MockGetSkillLatestVersion                   func() (string, error)
 	MockInitiateRun                             func(api.InitiateRunConfig) (*api.InitiateRunResult, error)
 	MockDeferredRunStatus                       func(pollingURL string) (api.DeferredRunStatusResult, error)
+	MockAttachDebugSession                      func(api.AttachDebugSessionConfig) (api.DebugSessionSummary, error)
 	MockGetDebugConnectionInfo                  func(api.GetDebugConnectionInfoConfig) (api.DebugConnectionInfo, error)
 	MockGetSandboxConnectionInfo                func(runID, scopedToken string) (api.SandboxConnectionInfo, error)
 	MockCreateSandboxToken                      func(api.CreateSandboxTokenConfig) (*api.CreateSandboxTokenResult, error)
@@ -88,6 +89,14 @@ func (c *API) DeferredRunStatus(pollingURL string) (api.DeferredRunStatusResult,
 	}
 
 	return api.DeferredRunStatusResult{}, errors.New("MockDeferredRunStatus was not configured")
+}
+
+func (c *API) AttachDebugSession(cfg api.AttachDebugSessionConfig) (api.DebugSessionSummary, error) {
+	if c.MockAttachDebugSession != nil {
+		return c.MockAttachDebugSession(cfg)
+	}
+
+	return api.DebugSessionSummary{}, errors.New("MockAttachDebugSession was not configured")
 }
 
 func (c *API) GetDebugConnectionInfo(cfg api.GetDebugConnectionInfoConfig) (api.DebugConnectionInfo, error) {

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -12,7 +12,7 @@ type API struct {
 	MockGetSkillLatestVersion                   func() (string, error)
 	MockInitiateRun                             func(api.InitiateRunConfig) (*api.InitiateRunResult, error)
 	MockDeferredRunStatus                       func(pollingURL string) (api.DeferredRunStatusResult, error)
-	MockGetDebugConnectionInfo                  func(runID string) (api.DebugConnectionInfo, error)
+	MockGetDebugConnectionInfo                  func(api.GetDebugConnectionInfoConfig) (api.DebugConnectionInfo, error)
 	MockGetSandboxConnectionInfo                func(runID, scopedToken string) (api.SandboxConnectionInfo, error)
 	MockCreateSandboxToken                      func(api.CreateSandboxTokenConfig) (*api.CreateSandboxTokenResult, error)
 	MockObtainAuthCode                          func(api.ObtainAuthCodeConfig) (*api.ObtainAuthCodeResult, error)
@@ -90,9 +90,9 @@ func (c *API) DeferredRunStatus(pollingURL string) (api.DeferredRunStatusResult,
 	return api.DeferredRunStatusResult{}, errors.New("MockDeferredRunStatus was not configured")
 }
 
-func (c *API) GetDebugConnectionInfo(runID string) (api.DebugConnectionInfo, error) {
+func (c *API) GetDebugConnectionInfo(cfg api.GetDebugConnectionInfoConfig) (api.DebugConnectionInfo, error) {
 	if c.MockGetDebugConnectionInfo != nil {
-		return c.MockGetDebugConnectionInfo(runID)
+		return c.MockGetDebugConnectionInfo(cfg)
 	}
 
 	return api.DebugConnectionInfo{}, errors.New("MockGetDebugConnectionInfo was not configured")


### PR DESCRIPTION
## Summary

- add `rwx debug --session` selection by full session ID or unique open name
- prompt for a session when multiple sessions are ready for connection in a TTY and provide a copy/pasteable retry command in non-TTY environments
- add `rwx ssh <task-id>` to attach a new session, wait until it is ready for connection, and open an interactive SSH connection
- support optional attached-session names with `rwx ssh --name <name> <task-id>`
- report attachment admission failures with user-facing messages and stable telemetry classifications

## Impact

Users can select existing breakpoint sessions or attach a fresh SSH session directly to a running task. The attach flow tolerates session-ingestion lag, polls while the session is starting, connects to the exact session it created, and stops on terminal or API errors. Existing single-session `rwx debug` commands continue without requiring a selector.

This CLI work consumes the debug-session response and attachment contracts introduced by rwx-cloud/cloud#8055.

## Validation

- `go test -parallel 4 ./internal/... ./cmd/... ./test/...`
- `golangci-lint run ./...`
- `go mod tidy`
- `go build ./cmd/rwx`
- `./rwx ssh --help`

Linear: https://linear.app/rwx-cloud/issue/RWX-1293/cloud-phase-3-expose-breakpoints-v2-ui-and-cli
