### PR TITLE
Harden sandbox patch sync against already_exists collisions

### DIFF
--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -774,7 +774,7 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 	var syncPushMs int64
 	var syncPushPatchBytes int
 	syncPushStart := time.Now()
-	patchBytes, err := s.prepareSandboxForExec(cfg.Json, isNewSandbox, isNewSandbox || execCount == 0, localHeadForSync, connInfo)
+	patchBytes, err := s.prepareSandboxForExec(cfg.Json, isNewSandbox, localHeadForSync, connInfo)
 	syncPushMs = time.Since(syncPushStart).Milliseconds()
 	syncPushPatchBytes = patchBytes
 	if err != nil {
@@ -1428,7 +1428,7 @@ func (s Service) revertSandboxToGitState(localHead string) error {
 	return nil
 }
 
-func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, cleanPreAppliedNewFiles bool, localHead string, connInfo *api.SandboxConnectionInfo) (int, error) {
+func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHead string, connInfo *api.SandboxConnectionInfo) (int, error) {
 	if localHead == "" {
 		return 0, fmt.Errorf("sandbox sync requires a git repository with a valid HEAD")
 	}
@@ -1490,11 +1490,9 @@ func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, cleanPr
 		return patchBytes, syncPushErr
 	}
 
-	if cleanPreAppliedNewFiles {
-		if err := s.removePreAppliedNewFilesFromSandbox(patches); err != nil {
-			syncPushErr = err
-			return patchBytes, syncPushErr
-		}
+	if err := s.removePreAppliedNewFilesFromSandbox(patches); err != nil {
+		syncPushErr = err
+		return patchBytes, syncPushErr
 	}
 
 	if err := s.applyDirtyPatchesToSandbox(patches); err != nil {
@@ -1815,7 +1813,8 @@ func (s Service) removePreAppliedNewFilesFromSandbox(patches git.DirtyPatches) e
 	for i, path := range paths {
 		quoted[i] = quoteShellArg(path)
 	}
-	script := fmt.Sprintf("/usr/bin/git clean -f -- %s >/dev/null 2>&1", strings.Join(quoted, " "))
+	// -x: the pre-applied file the patch re-creates may be gitignored, which a plain git clean skips.
+	script := fmt.Sprintf("/usr/bin/git clean -fdx -- %s >/dev/null 2>&1", strings.Join(quoted, " "))
 
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
 	exitCode, err := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand(script))

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1871,7 +1871,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Equal(t, "run-new", result.RunID)
 
 		cleanIndex := slices.IndexFunc(order, func(cmd string) bool {
-			return strings.Contains(cmd, "git clean -f --") && strings.Contains(cmd, "dir with space/quote") && strings.Contains(cmd, "file.txt")
+			return strings.Contains(cmd, "git clean -fdx --") && strings.Contains(cmd, "dir with space/quote") && strings.Contains(cmd, "file.txt")
 		})
 		applyIndex := sandboxCommandIndex(order, "/usr/bin/git apply --index --allow-empty -")
 		snapshotIndex := slices.IndexFunc(order, func(cmd string) bool {
@@ -1932,7 +1932,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 			switch {
 			case strings.Contains(cmd, "cat-file -e"):
 				return 0, nil
-			case strings.Contains(cmd, "git clean -f --"):
+			case strings.Contains(cmd, "git clean -fdx --"):
 				cleaned = true
 			}
 			order = append(order, cmd)
@@ -1961,7 +1961,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Equal(t, "run-started", result.RunID)
 
 		cleanIndex := slices.IndexFunc(order, func(cmd string) bool {
-			return strings.Contains(cmd, "git clean -f --") && strings.Contains(cmd, newFilePath)
+			return strings.Contains(cmd, "git clean -fdx --") && strings.Contains(cmd, newFilePath)
 		})
 		applyIndex := sandboxCommandIndex(order, "/usr/bin/git apply --index --allow-empty -")
 		snapshotIndex := slices.IndexFunc(order, func(cmd string) bool {
@@ -1973,6 +1973,88 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Less(t, cleanIndex, applyIndex)
 		require.Contains(t, order[snapshotIndex], "/usr/bin/git add -A &&")
 		require.NotContains(t, order[snapshotIndex], "/usr/bin/git update-index --add --remove --")
+	})
+
+	t.Run("reused sandbox on a later exec still removes pre-applied new files before sync", func(t *testing.T) {
+		setup := setupTest(t)
+
+		configFile := setup.absConfig(".rwx/sandbox.yml")
+		require.NoError(t, os.WriteFile(configFile, []byte("base:\n  image: ubuntu:24.04\ntasks:\n  - key: sandbox\n    run: rwx-sandbox\n"), 0o644))
+		localHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		newFilePath := "new-on-reuse.txt"
+		newFilePatch := []byte("diff --git a/" + newFilePath + " b/" + newFilePath + "\nnew file mode 100644\nindex 0000000..c42fa8d\n--- /dev/null\n+++ b/" + newFilePath + "\n@@ -0,0 +1 @@\n+local-change-content\n")
+
+		seedSandboxStorageMulti(t, setup.tmp, map[string]cli.SandboxSession{
+			cli.SessionKey("detached", configFile): {
+				RunID:         "run-reused",
+				ConfigFile:    configFile,
+				ScopedToken:   "reused-token",
+				ExecCount:     3,
+				ResetNagShown: true,
+			},
+		})
+
+		setup.mockGit.MockGetBranch = "feature/reused-exec"
+		setup.mockGit.MockGetHead = localHead
+		setup.mockGit.MockGenerateDirtyPatches = func() (git.DirtyPatches, error) {
+			return git.DirtyPatches{
+				Staged:   newFilePatch,
+				Files:    []string{newFilePath},
+				NewFiles: []string{newFilePath},
+			}, nil
+		}
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			require.Equal(t, "run-reused", runID)
+			require.Equal(t, "reused-token", token)
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error { return nil }
+
+		var order []string
+		cleaned := false
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
+			switch {
+			case strings.Contains(cmd, "cat-file -e"):
+				return 0, nil
+			case strings.Contains(cmd, "git clean -fdx --"):
+				cleaned = true
+			}
+			order = append(order, cmd)
+			return 0, nil
+		}
+		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
+			return 0, "", nil
+		}
+		setup.mockSSH.MockExecuteCommandWithStdinAndCombinedOutput = func(command string, stdin io.Reader) (int, string, error) {
+			order = append(order, command)
+			if !cleaned {
+				return 1, newFilePath + " already exists", nil
+			}
+			return 0, "", nil
+		}
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"true"},
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "run-reused", result.RunID)
+
+		cleanIndex := slices.IndexFunc(order, func(cmd string) bool {
+			return strings.Contains(cmd, "git clean -fdx --") && strings.Contains(cmd, newFilePath)
+		})
+		applyIndex := sandboxCommandIndex(order, "/usr/bin/git apply --index --allow-empty -")
+		require.NotEqual(t, -1, cleanIndex, "pre-apply cleanup must run on a reused sandbox (execCount >= 1)")
+		require.NotEqual(t, -1, applyIndex)
+		require.Less(t, cleanIndex, applyIndex)
 	})
 
 	t.Run("new sandbox sync snapshots staged deletions with unstaged edits", func(t *testing.T) {

--- a/test/integration/sandbox-git-state-sync.sh
+++ b/test/integration/sandbox-git-state-sync.sh
@@ -157,6 +157,8 @@ TEMP_BRANCHES=(
   "${TEST_ID}-lfs-push"
   "${TEST_ID}-lfs-patch"
   "${TEST_ID}-dirty-state"
+  "${TEST_ID}-already-exists"
+  "${TEST_ID}-node-modules"
 )
 TEST_FILES=(
   integration-pushed-commit.txt
@@ -172,6 +174,8 @@ TEST_FILES=(
   integration-lfs-push.bin
   integration-lfs-patch.bin
   integration-staged-state.txt
+  integration-already-exists.txt
+  integration-node-modules-new.txt
 )
 
 cleanup() {
@@ -326,5 +330,77 @@ printf '\n// integration unstaged state\n' >> go.mod
 
 git diff --cached --name-only | grep -qx integration-staged-state.txt || fail "local staged state was not preserved"
 git diff --name-only | grep -qx go.mod || fail "local unstaged state was not preserved"
+
+echo "Scenario: new-file patch applies over a pre-applied gitignored sandbox file (already_exists regression)"
+git reset --hard "$ORIGINAL_HEAD" >/dev/null
+git switch -C "${TEST_ID}-already-exists" "$ORIGINAL_HEAD" >/dev/null
+already_exists_file="integration-already-exists.txt"
+
+# Commit an ignore rule so the sandbox's checked-out tree ignores the path.
+printf '%s\n' "$already_exists_file" >> .gitignore
+git add .gitignore
+git -c user.email="sandbox-integration@example.com" -c user.name="Sandbox Integration" commit -m "integration ignore already-exists path" >/dev/null
+
+# Pre-create the ignored file inside the sandbox. git clean -f would skip it
+# because it is ignored, so it survives into the patch-apply step.
+"${RWX_CLI}" sandbox exec --id "$SANDBOX_RUN_ID" -- sh -c "printf 'sandbox-copy\n' > ${already_exists_file}"
+
+# Force-track the same path locally so the dirty patch creates it. Before the
+# fix, git apply collided with the pre-applied sandbox copy (already_exists).
+printf '%s\n' "local-copy" > "$already_exists_file"
+git add -f "$already_exists_file"
+
+already_exists_output_file=$(mktemp)
+already_exists_exit=0
+run_and_capture_output "$already_exists_output_file" "${RWX_CLI}" sandbox exec --id "$SANDBOX_RUN_ID" -- cat "$already_exists_file" || already_exists_exit=$?
+already_exists_output=$(cat "$already_exists_output_file")
+rm -f "$already_exists_output_file"
+if [ "$already_exists_exit" -ne 0 ]; then
+  fail "sandbox exec failed to sync a new file that already existed in the sandbox: ${already_exists_output}"
+fi
+if echo "$already_exists_output" | grep -q "already exists in working directory"; then
+  fail "patch sync still hit the already_exists collision: ${already_exists_output}"
+fi
+assert_sandbox_file_content "$already_exists_file" "local-copy"
+
+git reset -- "$already_exists_file" .gitignore >/dev/null 2>&1 || true
+rm -f "$already_exists_file"
+
+echo "Scenario: a routine sandbox exec sync does not remove a gitignored node_modules tree (git clean -x blast radius)"
+git reset --hard "$ORIGINAL_HEAD" >/dev/null
+git switch -C "${TEST_ID}-node-modules" "$ORIGINAL_HEAD" >/dev/null
+node_modules_new_file="integration-node-modules-new.txt"
+
+# Ignore node_modules in the committed tree, mirroring a real project layout so
+# the sandbox's checked-out worktree treats the directory as gitignored.
+printf 'node_modules/\n' >> .gitignore
+git add .gitignore
+git -c user.email="sandbox-integration@example.com" -c user.name="Sandbox Integration" commit -m "integration ignore node_modules" >/dev/null
+
+# Populate a gitignored node_modules tree in the sandbox, as a dependency install would.
+"${RWX_CLI}" sandbox exec --id "$SANDBOX_RUN_ID" -- sh -c '
+  set -e
+  cd "$(git rev-parse --show-toplevel)"
+  mkdir -p node_modules/leftpad
+  printf "keep-me\n" > node_modules/leftpad/index.js
+  printf "{}\n" > node_modules/leftpad/package.json
+'
+
+# Add a new file locally so the dirty patch has new-file paths: that is what
+# makes the real sync run its scoped pre-apply cleanup at all.
+printf '%s\n' "node-modules-sibling" > "$node_modules_new_file"
+git add "$node_modules_new_file"
+
+# A routine exec drives the actual CLI sync (reset + scoped clean + apply). No
+# git-clean is run by the test itself, so this cannot drift from the CLI.
+"${RWX_CLI}" sandbox exec --id "$SANDBOX_RUN_ID" -- pwd >/dev/null
+
+# The new file must sync, and the gitignored node_modules tree must survive.
+assert_sandbox_file_content "$node_modules_new_file" "node-modules-sibling"
+assert_sandbox_file_content "node_modules/leftpad/index.js" "keep-me"
+assert_sandbox_file_content "node_modules/leftpad/package.json" "{}"
+
+git reset -- "$node_modules_new_file" .gitignore >/dev/null 2>&1 || true
+rm -f "$node_modules_new_file"
 
 echo "PASS: sandbox git-state sync integration scenarios completed"


### PR DESCRIPTION
### Background
- [RWX-1329](https://linear.app/rwx-cloud/issue/RWX-1329)

### Problem
`rwx sandbox exec` sometimes fails to sync local changes, reporting `patch_error_reason: already_exists`. To sync, we `git reset --hard` to the local HEAD, run `git clean -f` on the paths the dirty patch will create, then `git apply`. But `git clean -f` doesn't touch gitignored files. So if a path is ignored in the sandbox yet shows up as a new file locally, the old copy survives and `git apply` refuses to overwrite it (`already exists in working directory`). The cleanup was also gated to new sandboxes and the first exec, so reused-sandbox loops skipped it entirely. Two orgs hit this on 3.20.0.

### Solution
- Add `-x` to the cleanup (`git clean -fdx`) so ignored files the patch re-creates get removed too. Kept `git clean` rather than `rm -f` so it still refuses to delete tracked files or traverse symlinks.
- Run the removal on every sync, not just the first exec, which covers the reused-sandbox loop.
- Add an integration scenario that reproduces the collision (a gitignored file pre-created in the sandbox), plus updated unit assertions.

#### Further confirmation needed
- [x] integration-sandbox CI, with a red/green baseline: [red (fix reverted)](https://cloud.rwx.com/mint/rwx/runs/f4954c9986e54b3cae250eff55b9b286) fails on the new scenario, [green (fix applied)](https://cloud.rwx.com/mint/rwx/runs/31ef5871cf4d4556be76130125c29348) passes.
