### PR TITLE
Skip git/clone ref scan when CLI init already declares git params

### DIFF
--- a/internal/cli/service_resolve_cli_params.go
+++ b/internal/cli/service_resolve_cli_params.go
@@ -43,18 +43,29 @@ func resolveCliParams(yamlContent string) (string, []string, error) {
 		return "", nil, errors.Wrap(err, "failed to parse YAML")
 	}
 
-	gitParamsMap, err := extractGitParams(doc)
-	gitParamNames := getGitParamNames(gitParamsMap)
+	gitParamsMap := make(map[string]any)
+	gitParamsMap, err = extractGitParamsFromTriggers(doc, gitParamsMap)
 	if err != nil {
-		return "", gitParamNames, err
+		return "", getGitParamNames(gitParamsMap), err
 	}
-	gitParamNames = mergeGitParamNames(gitParamNames, extractCliGitParamNames(doc))
+
+	gitParamNames := mergeGitParamNames(getGitParamNames(gitParamsMap), extractCliGitParamNames(doc))
 
 	// Skip rewriting if CLI init already has git event references, but still
 	// return the git param names so callers can suppress HEAD-based patches.
+	// The git/clone ref scan below is redundant in this case (the params are
+	// already declared), so we skip it — otherwise it would raise a spurious
+	// conflict error for configs that clone multiple repositories with
+	// different ref init params.
 	if cliInit := doc.TryReadStringAtPath("$.on.cli.init"); strings.Contains(cliInit, "event.git.") {
 		return yamlContent, gitParamNames, nil
 	}
+
+	gitParamsMap, err = extractGitParamsFromGitClone(doc, gitParamsMap)
+	if err != nil {
+		return "", gitParamNames, err
+	}
+	gitParamNames = mergeGitParamNames(gitParamNames, getGitParamNames(gitParamsMap))
 
 	if len(gitParamsMap) == 0 {
 		return yamlContent, gitParamNames, nil
@@ -172,22 +183,6 @@ func prependOnSection(yamlContent string, params map[string]any) string {
 		return "---\n" + onSection.String() + strings.TrimPrefix(yamlContent, "---\n")
 	}
 	return onSection.String() + yamlContent
-}
-
-func extractGitParams(doc *YAMLDoc) (map[string]any, error) {
-	result := make(map[string]any)
-
-	result, err := extractGitParamsFromTriggers(doc, result)
-	if err != nil {
-		return nil, err
-	}
-
-	result, err = extractGitParamsFromGitClone(doc, result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
 }
 
 func extractGitParamsFromTriggers(doc *YAMLDoc, result map[string]any) (map[string]any, error) {

--- a/internal/cli/service_resolve_cli_params_test.go
+++ b/internal/cli/service_resolve_cli_params_test.go
@@ -345,6 +345,43 @@ tasks:
 		require.Contains(t, err.Error(), "multiple git/clone")
 	})
 
+	t.Run("does not error on multiple git/clone ref params when CLI init already declares git params", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yml")
+		require.NoError(t, err)
+		defer tmpFile.Close()
+
+		content := `
+on:
+  cli:
+    init:
+      commit-sha: ${{ event.git.sha }}
+      clickhouse-ref: main
+
+tasks:
+  - key: code
+    call: git/clone 2.0.8
+    with:
+      repository: https://github.com/rwx-cloud/task-server-proxy.git
+      ref: ${{ init.commit-sha }}
+  - key: clickhouse-code
+    call: git/clone 2.0.8
+    with:
+      repository: https://github.com/rwx-cloud/clickhouse.git
+      ref: ${{ init.clickhouse-ref }}
+`
+		_, err = tmpFile.WriteString(content)
+		require.NoError(t, err)
+
+		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		require.NoError(t, err)
+		require.False(t, result.Rewritten)
+		require.Equal(t, []string{"commit-sha"}, result.GitParams)
+
+		fileContent, err := os.ReadFile(tmpFile.Name())
+		require.NoError(t, err)
+		require.Equal(t, content, string(fileContent))
+	})
+
 	t.Run("uses init expression when one git/clone has hardcoded ref", func(t *testing.T) {
 		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yml")
 		require.NoError(t, err)

--- a/internal/cli/service_resolve_cli_params_test.go
+++ b/internal/cli/service_resolve_cli_params_test.go
@@ -361,12 +361,12 @@ tasks:
   - key: code
     call: git/clone 2.0.8
     with:
-      repository: https://github.com/rwx-cloud/task-server-proxy.git
+      repository: https://github.com/rwx-cloud/primary-repo.git
       ref: ${{ init.commit-sha }}
   - key: clickhouse-code
     call: git/clone 2.0.8
     with:
-      repository: https://github.com/rwx-cloud/clickhouse.git
+      repository: https://github.com/rwx-cloud/secondary-repo.git
       ref: ${{ init.clickhouse-ref }}
 `
 		_, err = tmpFile.WriteString(content)

--- a/internal/cli/service_resolve_cli_params_test.go
+++ b/internal/cli/service_resolve_cli_params_test.go
@@ -363,7 +363,7 @@ tasks:
     with:
       repository: https://github.com/rwx-cloud/primary-repo.git
       ref: ${{ init.commit-sha }}
-  - key: clickhouse-code
+  - key: secondary-code
     call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/secondary-repo.git

--- a/internal/cli/service_resolve_cli_params_test.go
+++ b/internal/cli/service_resolve_cli_params_test.go
@@ -355,7 +355,7 @@ on:
   cli:
     init:
       commit-sha: ${{ event.git.sha }}
-      clickhouse-ref: main
+      secondary-repo-ref: main
 
 tasks:
   - key: code
@@ -367,7 +367,7 @@ tasks:
     call: git/clone 2.0.8
     with:
       repository: https://github.com/rwx-cloud/secondary-repo.git
-      ref: ${{ init.clickhouse-ref }}
+      ref: ${{ init.secondary-repo-ref }}
 `
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)


### PR DESCRIPTION
## Problem

Running `rwx run` on a config that (a) already declares its CLI init git param under `on.cli.init` and (b) has multiple `git/clone` tasks cloning **different** repositories with different `ref` init params fails with:

```
RWX CLI error: "multiple git/clone packages use different ref init params."
```

This is a false positive. `resolveCliParams` called the git/clone ref scan (`extractGitParams`) *before* the check that short-circuits when `on.cli.init` already wires `event.git.*` references. So the scan errored on a config whose file rewrite it feeds was going to be skipped anyway — the params are already declared.

## Fix

Reorder `resolveCliParams` so the git/clone ref scan runs **only after** the "CLI init already declares git params" skip check, and drop the now-unused `extractGitParams` wrapper (its two calls are inlined around the skip check).

- Trigger-derived and CLI-declared git param names are still collected and returned, so patch-suppression behavior in `service_run.go` is unchanged.
- Configs that genuinely rely on the git/clone scan (no pre-declared CLI init) still hit the scan — and still error on a real conflict — exactly as before.

## Test

Adds a regression test mirroring the reported config (two `git/clone` tasks, different repos, different ref init params, with `on.cli.init` already declaring `commit-sha: \${{ event.git.sha }}`): it now resolves without error and without rewriting.

Note: this is the minimal, contained fix. A follow-up PR adds repo-scoped matching so the scan is also correct for the multi-repo case when the CLI init is *not* pre-declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)