### PR TITLE
Scope git/clone ref-param scan to the current repository

### DIFF
--- a/internal/cli/service_resolve_cli_params.go
+++ b/internal/cli/service_resolve_cli_params.go
@@ -15,13 +15,13 @@ type ResolveCliParamsResult struct {
 	GitParams []string
 }
 
-func ResolveCliParamsForFile(filePath string) (ResolveCliParamsResult, error) {
+func ResolveCliParamsForFile(filePath, originURL string) (ResolveCliParamsResult, error) {
 	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return ResolveCliParamsResult{}, errors.Wrap(err, "unable to read file")
 	}
 
-	resolvedContent, gitParams, err := resolveCliParams(string(content))
+	resolvedContent, gitParams, err := resolveCliParams(string(content), originURL)
 	if err != nil {
 		return ResolveCliParamsResult{GitParams: gitParams}, err
 	}
@@ -37,13 +37,13 @@ func ResolveCliParamsForFile(filePath string) (ResolveCliParamsResult, error) {
 	return ResolveCliParamsResult{Rewritten: false, GitParams: gitParams}, nil
 }
 
-func resolveCliParams(yamlContent string) (string, []string, error) {
+func resolveCliParams(yamlContent, originURL string) (string, []string, error) {
 	doc, err := ParseYAMLDoc(yamlContent)
 	if err != nil {
 		return "", nil, errors.Wrap(err, "failed to parse YAML")
 	}
 
-	gitParamsMap, err := extractGitParams(doc)
+	gitParamsMap, err := extractGitParams(doc, originURL)
 	gitParamNames := getGitParamNames(gitParamsMap)
 	if err != nil {
 		return "", gitParamNames, err
@@ -174,7 +174,7 @@ func prependOnSection(yamlContent string, params map[string]any) string {
 	return onSection.String() + yamlContent
 }
 
-func extractGitParams(doc *YAMLDoc) (map[string]any, error) {
+func extractGitParams(doc *YAMLDoc, originURL string) (map[string]any, error) {
 	result := make(map[string]any)
 
 	result, err := extractGitParamsFromTriggers(doc, result)
@@ -182,7 +182,7 @@ func extractGitParams(doc *YAMLDoc) (map[string]any, error) {
 		return nil, err
 	}
 
-	result, err = extractGitParamsFromGitClone(doc, result)
+	result, err = extractGitParamsFromGitClone(doc, result, originURL)
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +291,12 @@ func extractGitParamsFromInit(node ast.Node, result map[string]any) (map[string]
 	return result, nil
 }
 
-func extractGitParamsFromGitClone(doc *YAMLDoc, result map[string]any) (map[string]any, error) {
+type gitCloneRef struct {
+	repository string
+	paramName  string
+}
+
+func extractGitParamsFromGitClone(doc *YAMLDoc, result map[string]any, originURL string) (map[string]any, error) {
 	tasksNode, err := doc.getNodeAtPath("$.tasks")
 	if err != nil {
 		return result, nil
@@ -302,7 +307,7 @@ func extractGitParamsFromGitClone(doc *YAMLDoc, result map[string]any) (map[stri
 		return result, nil
 	}
 
-	var gitCloneRefParam string
+	var refs []gitCloneRef
 
 	for i := range sequenceNode.Values {
 		callValue := doc.TryReadStringAtPath(fmt.Sprintf("$.tasks[%d].call", i))
@@ -327,18 +332,81 @@ func extractGitParamsFromGitClone(doc *YAMLDoc, result map[string]any) (map[stri
 			continue
 		}
 
-		if gitCloneRefParam != "" && gitCloneRefParam != paramName {
-			return nil, errors.New("multiple git/clone packages use different ref init params")
-		}
-		gitCloneRefParam = paramName
+		repository := doc.TryReadStringAtPath(fmt.Sprintf("$.tasks[%d].with.repository", i))
+		refs = append(refs, gitCloneRef{repository: repository, paramName: paramName})
 	}
 
-	if gitCloneRefParam == "" {
+	if len(refs) == 0 {
 		return result, nil
+	}
+
+	// Prefer the git/clone task(s) that clone the current repository. When the
+	// origin URL is known and at least one git/clone repository matches it,
+	// restrict the ref-param scan to those clones — a clone of a different
+	// repository legitimately uses its own ref init param and must not be
+	// treated as a conflict. If the origin URL is unknown or nothing matches,
+	// fall back to considering every clone, which surfaces the existing conflict
+	// error when they disagree.
+	if originURL != "" {
+		var matched []gitCloneRef
+		for _, ref := range refs {
+			if gitRepositoriesMatch(ref.repository, originURL) {
+				matched = append(matched, ref)
+			}
+		}
+		if len(matched) > 0 {
+			refs = matched
+		}
+	}
+
+	var gitCloneRefParam string
+	for _, ref := range refs {
+		if gitCloneRefParam != "" && gitCloneRefParam != ref.paramName {
+			return nil, errors.New("multiple git/clone packages use different ref init params")
+		}
+		gitCloneRefParam = ref.paramName
 	}
 
 	// Always map to event.git.sha for CLI trigger
 	result[gitCloneRefParam] = "${{ event.git.sha }}"
 
 	return result, nil
+}
+
+// gitRepositoriesMatch reports whether two git repository references identify
+// the same repository, ignoring transport differences (e.g. an HTTPS config
+// repository vs. an SSH origin URL).
+func gitRepositoriesMatch(a, b string) bool {
+	na := normalizeGitRepository(a)
+	return na != "" && na == normalizeGitRepository(b)
+}
+
+// normalizeGitRepository reduces a git repository reference to a comparable
+// host/path identity, stripping the scheme, any userinfo, a trailing ".git",
+// and normalizing scp-style (host:org/repo) to host/org/repo.
+func normalizeGitRepository(repository string) string {
+	repo := strings.TrimSpace(repository)
+	if repo == "" {
+		return ""
+	}
+
+	// Strip a scheme like https://, http://, ssh://, or git://.
+	if idx := strings.Index(repo, "://"); idx != -1 {
+		repo = repo[idx+3:]
+	}
+
+	// Strip a userinfo prefix like git@.
+	if idx := strings.Index(repo, "@"); idx != -1 {
+		repo = repo[idx+1:]
+	}
+
+	// scp-style syntax uses host:org/repo; normalize the host separator to a
+	// slash so it compares equal to host/org/repo URL forms.
+	if slash := strings.Index(repo, "/"); slash == -1 || strings.Index(repo, ":") < slash {
+		repo = strings.Replace(repo, ":", "/", 1)
+	}
+
+	repo = strings.TrimSuffix(repo, "/")
+	repo = strings.TrimSuffix(repo, ".git")
+	return strings.ToLower(repo)
 }

--- a/internal/cli/service_resolve_cli_params_test.go
+++ b/internal/cli/service_resolve_cli_params_test.go
@@ -22,7 +22,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.False(t, result.Rewritten)
 	})
@@ -42,7 +42,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.False(t, result.Rewritten)
 	})
@@ -67,7 +67,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.False(t, result.Rewritten)
 	})
@@ -94,7 +94,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.False(t, result.Rewritten)
 		require.Equal(t, []string{"sha"}, result.GitParams)
@@ -126,7 +126,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.False(t, result.Rewritten)
 		require.Equal(t, []string{"commit-sha", "sha"}, result.GitParams)
@@ -156,7 +156,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.False(t, result.Rewritten)
 		require.Equal(t, []string{"ref"}, result.GitParams)
@@ -184,7 +184,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.False(t, result.Rewritten)
 		require.Equal(t, []string{"init"}, result.GitParams)
@@ -213,7 +213,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.True(t, result.Rewritten)
 
@@ -245,7 +245,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.True(t, result.Rewritten)
 
@@ -278,7 +278,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.True(t, result.Rewritten)
 
@@ -310,7 +310,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.True(t, result.Rewritten)
 
@@ -339,7 +339,120 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
+		require.Error(t, err)
+		require.False(t, result.Rewritten)
+		require.Contains(t, err.Error(), "multiple git/clone")
+	})
+
+	t.Run("scopes git/clone ref param to the clone matching the origin url", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yml")
+		require.NoError(t, err)
+		defer tmpFile.Close()
+
+		content := `
+tasks:
+  - key: code
+    call: git/clone 2.0.8
+    with:
+      repository: https://github.com/rwx-cloud/task-server-proxy.git
+      ref: ${{ init.commit-sha }}
+  - key: clickhouse-code
+    call: git/clone 2.0.8
+    with:
+      repository: https://github.com/rwx-cloud/clickhouse.git
+      ref: ${{ init.clickhouse-ref }}
+`
+		_, err = tmpFile.WriteString(content)
+		require.NoError(t, err)
+
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "git@github.com:rwx-cloud/task-server-proxy.git")
+		require.NoError(t, err)
+		require.True(t, result.Rewritten)
+		require.Equal(t, []string{"commit-sha"}, result.GitParams)
+
+		fileContent, err := os.ReadFile(tmpFile.Name())
+		require.NoError(t, err)
+		require.Contains(t, string(fileContent), "commit-sha: ${{ event.git.sha }}")
+		require.NotContains(t, string(fileContent), "clickhouse-ref: ${{ event.git.sha }}")
+	})
+
+	t.Run("errors on conflicting git/clone ref params when origin url is unknown", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yml")
+		require.NoError(t, err)
+		defer tmpFile.Close()
+
+		content := `
+tasks:
+  - key: code
+    call: git/clone 2.0.8
+    with:
+      repository: https://github.com/rwx-cloud/task-server-proxy.git
+      ref: ${{ init.commit-sha }}
+  - key: clickhouse-code
+    call: git/clone 2.0.8
+    with:
+      repository: https://github.com/rwx-cloud/clickhouse.git
+      ref: ${{ init.clickhouse-ref }}
+`
+		_, err = tmpFile.WriteString(content)
+		require.NoError(t, err)
+
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
+		require.Error(t, err)
+		require.False(t, result.Rewritten)
+		require.Contains(t, err.Error(), "multiple git/clone")
+	})
+
+	t.Run("errors on conflicting git/clone ref params when origin url matches no clone", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yml")
+		require.NoError(t, err)
+		defer tmpFile.Close()
+
+		content := `
+tasks:
+  - key: code
+    call: git/clone 2.0.8
+    with:
+      repository: https://github.com/rwx-cloud/task-server-proxy.git
+      ref: ${{ init.commit-sha }}
+  - key: clickhouse-code
+    call: git/clone 2.0.8
+    with:
+      repository: https://github.com/rwx-cloud/clickhouse.git
+      ref: ${{ init.clickhouse-ref }}
+`
+		_, err = tmpFile.WriteString(content)
+		require.NoError(t, err)
+
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "git@github.com:rwx-cloud/some-other-repo.git")
+		require.Error(t, err)
+		require.False(t, result.Rewritten)
+		require.Contains(t, err.Error(), "multiple git/clone")
+	})
+
+	t.Run("errors when the origin-matching repo is cloned with different ref params", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yml")
+		require.NoError(t, err)
+		defer tmpFile.Close()
+
+		content := `
+tasks:
+  - key: clone1
+    call: git/clone 2.0.8
+    with:
+      repository: https://github.com/rwx-cloud/task-server-proxy.git
+      ref: ${{ init.ref }}
+  - key: clone2
+    call: git/clone 2.0.8
+    with:
+      repository: https://github.com/rwx-cloud/task-server-proxy.git
+      ref: ${{ init.sha }}
+`
+		_, err = tmpFile.WriteString(content)
+		require.NoError(t, err)
+
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "git@github.com:rwx-cloud/task-server-proxy.git")
 		require.Error(t, err)
 		require.False(t, result.Rewritten)
 		require.Contains(t, err.Error(), "multiple git/clone")
@@ -364,7 +477,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.True(t, result.Rewritten)
 
@@ -389,7 +502,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.True(t, result.Rewritten)
 
@@ -415,7 +528,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.True(t, result.Rewritten)
 
@@ -446,7 +559,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.True(t, result.Rewritten)
 
@@ -479,7 +592,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.True(t, result.Rewritten)
 
@@ -508,7 +621,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.False(t, result.Rewritten)
 	})
@@ -535,7 +648,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.NoError(t, err)
 		require.False(t, result.Rewritten)
 
@@ -566,7 +679,7 @@ tasks:
 		_, err = tmpFile.WriteString(content)
 		require.NoError(t, err)
 
-		result, err := ResolveCliParamsForFile(tmpFile.Name())
+		result, err := ResolveCliParamsForFile(tmpFile.Name(), "")
 		require.Error(t, err)
 		require.False(t, result.Rewritten)
 		require.Contains(t, err.Error(), "multiple event triggers")

--- a/internal/cli/service_run.go
+++ b/internal/cli/service_run.go
@@ -224,7 +224,7 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 	// Convert to relative path for display purposes (e.g., run title)
 	relativeRunDefinitionPath := relativePathFromWd(runDefinitionPath)
 
-	resolveResult, err := ResolveCliParamsForFile(relativeRunDefinitionPath)
+	resolveResult, err := ResolveCliParamsForFile(relativeRunDefinitionPath, originUrl)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to resolve CLI init params")
 	}


### PR DESCRIPTION
## Problem

`extractGitParamsFromGitClone` scanned **every** `git/clone` task regardless of which repository it clones. A config that clones a second, unrelated repository with its own `ref` init param fails with:

```
RWX CLI error: "multiple git/clone packages use different ref init params."
```

even though only one of the clones targets the current repository. Example (the reported config):

```yaml
tasks:
  - key: code
    call: git/clone 2.0.8
    with:
      repository: https://github.com/rwx-cloud/task-server-proxy.git   # current repo
      ref: ${{ init.commit-sha }}
  - key: clickhouse-code
    call: git/clone 2.0.8
    with:
      repository: https://github.com/rwx-cloud/clickhouse.git          # different repo
      ref: ${{ init.clickhouse-ref }}
```

The whole point of the scan is to wire the current repo's clone to the local HEAD (`event.git.sha`) and drive the uncommitted-changes patch. Downstream, the `git/clone` package only applies the patch to the clone whose ref resolves to the local HEAD SHA — so the second repo's clone is already correctly ignored at runtime. The pre-flight check was simply stricter than reality.

## Fix

Thread the current repo's origin URL through `ResolveCliParamsForFile → resolveCliParams → extractGitParams → extractGitParamsFromGitClone`.

- When the origin URL is known and at least one `git/clone` `repository:` matches it, restrict the ref-param scan to the matching clone(s). Matching is transport-agnostic (an HTTPS config repository matches an SSH origin) via a small `normalizeGitRepository` helper.
- **If repo-scoped matching fails** — origin URL unknown (no git / no remote), or no clone matches — fall back to the existing all-clones behavior, which still returns the existing conflict error.
- Two clones of the *matching* repository with *different* ref params still error, since that is a genuine ambiguity.

## Tests

Adds coverage for: origin-scoped selection (SSH origin vs HTTPS config), fallback-to-error when origin is unknown, fallback-to-error when origin matches no clone, and the genuine same-repo conflict. Existing call sites updated to pass an explicit origin (`""`).

## Relationship to #581

This overlaps with #581 (the minimal ordering fix) — both touch `service_resolve_cli_params.go` and both independently resolve the reported error. #581 fixes it for configs that already declare their CLI init git param; this PR additionally fixes the multi-repo case where the CLI init is *not* pre-declared. Whichever merges second will need a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)