### PR TITLE
Retry transient failures when downloading artifacts

### DIFF
--- a/.rwx/sandbox.yml
+++ b/.rwx/sandbox.yml
@@ -1,0 +1,80 @@
+on:
+  cli:
+    init:
+      commit-sha: ${{ event.git.sha }}
+
+base:
+  image: ubuntu:24.04
+  config: rwx/base 1.1.1
+
+tasks:
+  - key: code
+    call: git/clone 2.0.8
+    with:
+      preserve-git-dir: true
+      repository: https://github.com/rwx-cloud/rwx.git
+      ref: ${{ init.commit-sha }}
+      github-token: ${{ github['rwx-cloud'].token }}
+
+  - key: tool-versions
+    use: code
+    run: |
+      while read -r tool version _; do
+        printf "%s" "$version" > "$RWX_VALUES/$tool"
+      done < .tool-versions
+      cp language-server-ref $RWX_VALUES
+    filter:
+      - .tool-versions
+      - language-server-ref
+
+  - key: go-installation
+    call: golang/install 1.2.2
+    with:
+      go-version: ${{ tasks.tool-versions.values.golang }}
+
+  - key: go
+    use: go-installation
+    run: echo "$(go env GOPATH)/bin" > "${MINT_ENV}/PATH"
+
+  - key: go-deps
+    use: [go, code]
+    call: golang/mod-download 1.0.2
+    filter: [go.mod, go.sum]
+    with:
+      tool-cache: cli-go-deps
+
+  - key: git
+    run: |
+      sudo apt-get update
+      sudo apt-get install git git-lfs
+      sudo apt-get clean
+
+      git config --global user.name "Testing"
+      git config --global user.email "git@example.com"
+      git config --global init.defaultBranch main
+
+      git lfs install --skip-repo
+
+  - key: lsp-code
+    call: git/clone 2.0.8
+    with:
+      repository: https://github.com/rwx-cloud/language-server.git
+      ref: ${{ tasks.tool-versions.values.language-server-ref }}
+      path: language-server
+
+  - key: lsp-build-def
+    use: lsp-code
+    run: cp language-server/.rwx/build.yml $RWX_ARTIFACTS/build-run-def
+
+  - key: lsp-build
+    call: ${{ tasks.lsp-build-def.artifacts.build-run-def }}
+    init:
+      ref: ${{ tasks.tool-versions.values.language-server-ref }}
+
+  - key: lsp-server
+    use: code
+    run: cp ${{ tasks.lsp-build.tasks.build.artifacts.bundle }} internal/lsp/bundle/server.js
+
+  - key: sandbox
+    use: [go-deps, lsp-server, git]
+    run: rwx-sandbox

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rwx-cloud/rwx/internal/accesstoken"
 	"github.com/rwx-cloud/rwx/internal/errors"
 	"github.com/rwx-cloud/rwx/internal/messages"
+	"github.com/rwx-cloud/rwx/internal/retry"
 	"github.com/rwx-cloud/rwx/internal/versions"
 )
 
@@ -1568,26 +1569,53 @@ func (c Client) GetArtifactDownloadRequestByTaskKey(runID, taskKey, artifactKey 
 	return result, nil
 }
 
+var downloadArtifactRetrySleep = time.Sleep
+
 func (c Client) DownloadArtifact(request ArtifactDownloadRequestResult) ([]byte, error) {
+	backoff := retry.NewBackoff()
+
+	for {
+		artifactBytes, retryable, err := downloadArtifactOnce(request)
+		if err == nil {
+			return artifactBytes, nil
+		}
+
+		if !retryable {
+			return nil, err
+		}
+
+		delay, capErr := backoff.Record()
+		if capErr != nil {
+			return nil, errors.WrapSentinel(
+				fmt.Errorf("download failed after %d attempts: %w", backoff.MaxFailures, err),
+				errors.ErrNetworkTransient,
+			)
+		}
+
+		downloadArtifactRetrySleep(delay)
+	}
+}
+
+func downloadArtifactOnce(request ArtifactDownloadRequestResult) (_ []byte, retryable bool, err error) {
 	req, err := http.NewRequest(http.MethodGet, request.URL, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to create new HTTP request")
+		return nil, false, errors.Wrap(err, "unable to create new HTTP request")
 	}
 	req.Header.Set("Accept", "application/octet-stream")
 
 	// Use http.DefaultClient directly since the artifact will come from storage (S3, etc.)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(err, "HTTP request failed")
+		return nil, retry.IsTransient(err), errors.Wrap(err, "HTTP request failed")
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		artifactBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to read response body")
+			return nil, retry.IsTransient(err), errors.Wrap(err, "unable to read response body")
 		}
-		return artifactBytes, nil
+		return artifactBytes, false, nil
 	}
 
 	bodyBytes, _ := io.ReadAll(resp.Body)
@@ -1595,7 +1623,8 @@ func (c Client) DownloadArtifact(request ArtifactDownloadRequestResult) ([]byte,
 	if errMsg == "" {
 		errMsg = fmt.Sprintf("Unable to download artifact - %s", resp.Status)
 	}
-	return nil, errors.New(errMsg)
+	isTransient := resp.StatusCode == http.StatusTooManyRequests || (resp.StatusCode >= 500 && resp.StatusCode < 600)
+	return nil, isTransient, errors.New(errMsg)
 }
 
 func (c Client) CancelRun(runID, scopedToken string) error {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -5,13 +5,16 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/rwx-cloud/rwx/internal/api"
+	internalerrors "github.com/rwx-cloud/rwx/internal/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1788,5 +1791,138 @@ func TestAPIClient_DownloadArtifact(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, largeContent, result)
 		require.Equal(t, 1024*1024, len(result))
+	})
+}
+
+func TestAPIClient_DownloadArtifact_Retries(t *testing.T) {
+	resetConnection := func(t *testing.T, w http.ResponseWriter) {
+		t.Helper()
+
+		hijacker, ok := w.(http.Hijacker)
+		require.True(t, ok)
+
+		conn, _, err := hijacker.Hijack()
+		require.NoError(t, err)
+
+		if tcpConn, ok := conn.(*net.TCPConn); ok {
+			_ = tcpConn.SetLinger(0)
+		}
+		conn.Close()
+	}
+
+	downloadRequest := api.ArtifactDownloadRequestResult{
+		Filename: "artifact.tar",
+		Kind:     "file",
+		Key:      "my-artifact",
+	}
+
+	t.Run("retries a connection reset and returns the artifact", func(t *testing.T) {
+		var slept []time.Duration
+		restore := api.StubDownloadArtifactRetrySleep(func(d time.Duration) { slept = append(slept, d) })
+		defer restore()
+
+		artifactContents := []byte("artifact binary data")
+		var attempts atomic.Int32
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if attempts.Add(1) == 1 {
+				resetConnection(t, w)
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			_, writeErr := w.Write(artifactContents)
+			require.NoError(t, writeErr)
+		}))
+		defer server.Close()
+
+		request := downloadRequest
+		request.URL = server.URL
+
+		result, err := api.NewClientWithRoundTrip(nil).DownloadArtifact(request)
+
+		require.NoError(t, err)
+		require.Equal(t, artifactContents, result)
+		require.Equal(t, int32(2), attempts.Load())
+		require.Equal(t, []time.Duration{1 * time.Second}, slept)
+	})
+
+	t.Run("gives up after repeated connection resets", func(t *testing.T) {
+		var slept []time.Duration
+		restore := api.StubDownloadArtifactRetrySleep(func(d time.Duration) { slept = append(slept, d) })
+		defer restore()
+
+		var attempts atomic.Int32
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			attempts.Add(1)
+			resetConnection(t, w)
+		}))
+		defer server.Close()
+
+		request := downloadRequest
+		request.URL = server.URL
+
+		_, err := api.NewClientWithRoundTrip(nil).DownloadArtifact(request)
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "HTTP request failed")
+		require.True(t, errors.Is(err, internalerrors.ErrNetworkTransient))
+		require.Equal(t, int32(5), attempts.Load())
+		require.Len(t, slept, 4)
+	})
+
+	t.Run("retries a 503 from storage", func(t *testing.T) {
+		restore := api.StubDownloadArtifactRetrySleep(func(time.Duration) {})
+		defer restore()
+
+		artifactContents := []byte("artifact binary data")
+		var attempts atomic.Int32
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if attempts.Add(1) == 1 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = w.Write([]byte(`<?xml version="1.0"?><Error><Code>SlowDown</Code></Error>`))
+				return
+			}
+
+			w.WriteHeader(http.StatusOK)
+			_, writeErr := w.Write(artifactContents)
+			require.NoError(t, writeErr)
+		}))
+		defer server.Close()
+
+		request := downloadRequest
+		request.URL = server.URL
+
+		result, err := api.NewClientWithRoundTrip(nil).DownloadArtifact(request)
+
+		require.NoError(t, err)
+		require.Equal(t, artifactContents, result)
+		require.Equal(t, int32(2), attempts.Load())
+	})
+
+	t.Run("does not retry a 403 from storage", func(t *testing.T) {
+		restore := api.StubDownloadArtifactRetrySleep(func(time.Duration) {
+			require.FailNow(t, "unexpected retry")
+		})
+		defer restore()
+
+		var attempts atomic.Int32
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			attempts.Add(1)
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><Error><Code>AccessDenied</Code></Error>`))
+		}))
+		defer server.Close()
+
+		request := downloadRequest
+		request.URL = server.URL
+
+		_, err := api.NewClientWithRoundTrip(nil).DownloadArtifact(request)
+
+		require.Error(t, err)
+		require.Equal(t, int32(1), attempts.Load())
 	})
 }

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -10,3 +10,9 @@ func StubListRunsRetrySleep(fn func(time.Duration)) func() {
 	listRunsRetrySleep = fn
 	return func() { listRunsRetrySleep = original }
 }
+
+func StubDownloadArtifactRetrySleep(fn func(time.Duration)) func() {
+	original := downloadArtifactRetrySleep
+	downloadArtifactRetrySleep = fn
+	return func() { downloadArtifactRetrySleep = original }
+}


### PR DESCRIPTION
`rwx artifacts download` made a single unretried request to storage, so a connection reset partway through surfaced as a hard failure:

```
Error: unable to download artifact: HTTP request failed: Get "https://mint-storage-...s3.us-east-2.amazonaws.com/org...
read tcp 192.168.86.51:53581->3.5.89.33:443: read: connection reset by peer
```

`DownloadArtifact` now retries with bounded exponential backoff, following the same shape as `ListRuns`: a `downloadArtifactOnce` helper returns a `retryable` flag, and the caller loops on `retry.NewBackoff()` (5 attempts, 1s→5s, ~12s worst case).

Retried:
- transient transport errors via `retry.IsTransient` — resets, refused, timeouts, EOF
- transient failures reading the response body, so a reset partway through a large artifact restarts instead of failing
- `429` and `5xx` from storage (S3 `SlowDown`)

Not retried: `400`/`403`/`404`, so an expired presigned URL or missing key still surfaces immediately. The same presigned URL is reused across the short retry window.

Exhausted retries are wrapped with `errors.ErrNetworkTransient`, matching `retry.RoundTripper`, so telemetry buckets them as `network_transient_error` rather than `unknown`.

This also covers the parallel multi-artifact download path in `service_artifacts.go`, which goes through the same client method. Retries are silent under the existing "Downloading artifact..." spinner.

### Still buffered, no resume

Artifacts are read fully into memory and a retry restarts from byte zero — there's no `Range`-based resume. A reset late in a multi-GB download still re-transfers the whole thing.

### .rwx/sandbox.yml

Added, since the repo had no sandbox config. It mirrors `ci.yml` (`code` → `tool-versions` → `go`/`go-deps`, plus the `lsp-*` chain so `internal/lsp`'s embedded bundle exists) with a `sandbox` task running `rwx-sandbox`.

### Verification

- `rwx sandbox exec -- go test ./internal/... ./cmd/...` — all packages pass
- `golangci-lint run ./internal/api/...` — 0 issues
- New `TestAPIClient_DownloadArtifact_Retries` covers reset-then-success, exhaustion after 5 attempts with the transient sentinel, 503-then-success, and 403 not retried. Resets are simulated by hijacking the connection with `SetLinger(0)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)