### PR TITLE
Print the service account name in rwx whoami

### DIFF
--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -255,14 +255,17 @@ func TestAPIClient_AcquireToken(t *testing.T) {
 func TestAPIClient_Whoami(t *testing.T) {
 	t.Run("makes the request", func(t *testing.T) {
 		email := "some-email@example.com"
+		serviceAccountName := "deploy bot"
 		body := struct {
-			OrganizationSlug string  `json:"organization_slug"`
-			TokenKind        string  `json:"token_kind"`
-			UserEmail        *string `json:"user_email,omitempty"`
+			OrganizationSlug   string  `json:"organization_slug"`
+			TokenKind          string  `json:"token_kind"`
+			UserEmail          *string `json:"user_email,omitempty"`
+			ServiceAccountName *string `json:"service_account_name,omitempty"`
 		}{
-			OrganizationSlug: "some-org",
-			TokenKind:        "personal_access_token",
-			UserEmail:        &email,
+			OrganizationSlug:   "some-org",
+			TokenKind:          "personal_access_token",
+			UserEmail:          &email,
+			ServiceAccountName: &serviceAccountName,
 		}
 		bodyBytes, _ := json.Marshal(body)
 
@@ -277,8 +280,9 @@ func TestAPIClient_Whoami(t *testing.T) {
 
 		c := api.NewClientWithRoundTrip(roundTrip)
 
-		_, err := c.Whoami()
+		result, err := c.Whoami()
 		require.NoError(t, err)
+		require.Equal(t, &serviceAccountName, result.ServiceAccountName)
 	})
 }
 

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -145,9 +145,10 @@ type AcquireTokenResult struct {
 }
 
 type WhoamiResult struct {
-	OrganizationSlug string  `json:"organization_slug"`
-	TokenKind        string  `json:"token_kind"` // organization_access_token, personal_access_token
-	UserEmail        *string `json:"user_email,omitempty"`
+	OrganizationSlug   string  `json:"organization_slug"`
+	TokenKind          string  `json:"token_kind"` // organization_access_token, personal_access_token
+	UserEmail          *string `json:"user_email,omitempty"`
+	ServiceAccountName *string `json:"service_account_name,omitempty"`
 }
 
 type DocsTokenResult struct {

--- a/internal/cli/service_whoami.go
+++ b/internal/cli/service_whoami.go
@@ -31,8 +31,16 @@ func (s Service) Whoami(cfg WhoamiConfig) (*api.WhoamiResult, error) {
 
 		fmt.Fprint(s.Stdout, string(encoded))
 	} else {
-		fmt.Fprintf(s.Stdout, "Token Kind: %v\n", strings.ReplaceAll(result.TokenKind, "_", " "))
+		tokenKind := strings.ReplaceAll(result.TokenKind, "_", " ")
+		if result.ServiceAccountName != nil {
+			tokenKind = "service account"
+		}
+
+		fmt.Fprintf(s.Stdout, "Token Kind: %v\n", tokenKind)
 		fmt.Fprintf(s.Stdout, "Organization: %v\n", result.OrganizationSlug)
+		if result.ServiceAccountName != nil {
+			fmt.Fprintf(s.Stdout, "Service Account: %v\n", *result.ServiceAccountName)
+		}
 		if result.UserEmail != nil {
 			fmt.Fprintf(s.Stdout, "User: %v\n", *result.UserEmail)
 		}

--- a/internal/cli/service_whoami_test.go
+++ b/internal/cli/service_whoami_test.go
@@ -74,6 +74,29 @@ func TestService_Whoami(t *testing.T) {
 			require.Contains(t, s.mockStdout.String(), `"token_kind": "organization_access_token"`)
 			require.Contains(t, s.mockStdout.String(), `"organization_slug": "rwx"`)
 			require.NotContains(t, s.mockStdout.String(), `"user_email"`)
+			require.NotContains(t, s.mockStdout.String(), `"service_account_name"`)
+		})
+
+		t.Run("when there is a service account name", func(t *testing.T) {
+			s := setupTest(t)
+
+			serviceAccountName := "deploy bot"
+			s.mockAPI.MockWhoami = func() (*api.WhoamiResult, error) {
+				return &api.WhoamiResult{
+					TokenKind:          "organization_access_token",
+					OrganizationSlug:   "rwx",
+					ServiceAccountName: &serviceAccountName,
+				}, nil
+			}
+
+			result, err := s.service.Whoami(cli.WhoamiConfig{
+				Json: true,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, &serviceAccountName, result.ServiceAccountName)
+			require.Contains(t, s.mockStdout.String(), `"token_kind": "organization_access_token"`)
+			require.Contains(t, s.mockStdout.String(), `"service_account_name": "deploy bot"`)
 		})
 	})
 
@@ -140,6 +163,31 @@ func TestService_Whoami(t *testing.T) {
 			require.Nil(t, result.UserEmail)
 			require.Contains(t, s.mockStdout.String(), "Token Kind: organization access token")
 			require.Contains(t, s.mockStdout.String(), "Organization: rwx")
+			require.NotContains(t, s.mockStdout.String(), "User:")
+			require.NotContains(t, s.mockStdout.String(), "Service Account:")
+		})
+
+		t.Run("when there is a service account name", func(t *testing.T) {
+			s := setupTest(t)
+
+			serviceAccountName := "deploy bot"
+			s.mockAPI.MockWhoami = func() (*api.WhoamiResult, error) {
+				return &api.WhoamiResult{
+					TokenKind:          "organization_access_token",
+					OrganizationSlug:   "rwx",
+					ServiceAccountName: &serviceAccountName,
+				}, nil
+			}
+
+			result, err := s.service.Whoami(cli.WhoamiConfig{
+				Json: false,
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, &serviceAccountName, result.ServiceAccountName)
+			require.Contains(t, s.mockStdout.String(), "Token Kind: service account")
+			require.Contains(t, s.mockStdout.String(), "Organization: rwx")
+			require.Contains(t, s.mockStdout.String(), "Service Account: deploy bot")
 			require.NotContains(t, s.mockStdout.String(), "User:")
 		})
 	})


### PR DESCRIPTION
### Background

- Linear: https://linear.app/rwx-cloud/issue/RWX-1426/rwx-whoami-should-print-the-service-account-name-and-kind
- Cloud side: https://github.com/rwx-cloud/cloud/pull/8192

### Problem

With a service account token, `rwx whoami` prints `Token Kind: organization access token` and never names the account. The CLI doesn't interpret anything; it swaps underscores for spaces in `token_kind`. If you have a few service accounts, you can't tell which token you're holding.

### Solution

- Add `ServiceAccountName` to `WhoamiResult`.
- When it's set, print `Service Account: <name>` and call the kind "service account".
- `--json` keeps the raw `token_kind`. The relabel is display-only, and older servers that omit the field print exactly what they do today.

```
╰─⠠⠵ RWX_HOST=cloud.local ./rwx whoami
Token Kind: service account
Organization: staging
Service Account: mint.rake testing token
```
