### PR TITLE
Print the token description and link in rwx whoami

### DIFF
--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -256,16 +256,22 @@ func TestAPIClient_Whoami(t *testing.T) {
 	t.Run("makes the request", func(t *testing.T) {
 		email := "some-email@example.com"
 		serviceAccountName := "deploy bot"
+		tokenDescription := "CI release token"
+		tokenURL := "https://cloud.rwx.com/org/some-org/manage/service_accounts/123"
 		body := struct {
 			OrganizationSlug   string  `json:"organization_slug"`
 			TokenKind          string  `json:"token_kind"`
 			UserEmail          *string `json:"user_email,omitempty"`
 			ServiceAccountName *string `json:"service_account_name,omitempty"`
+			TokenDescription   *string `json:"token_description,omitempty"`
+			TokenURL           *string `json:"token_url,omitempty"`
 		}{
 			OrganizationSlug:   "some-org",
 			TokenKind:          "personal_access_token",
 			UserEmail:          &email,
 			ServiceAccountName: &serviceAccountName,
+			TokenDescription:   &tokenDescription,
+			TokenURL:           &tokenURL,
 		}
 		bodyBytes, _ := json.Marshal(body)
 
@@ -283,6 +289,8 @@ func TestAPIClient_Whoami(t *testing.T) {
 		result, err := c.Whoami()
 		require.NoError(t, err)
 		require.Equal(t, &serviceAccountName, result.ServiceAccountName)
+		require.Equal(t, &tokenDescription, result.TokenDescription)
+		require.Equal(t, &tokenURL, result.TokenURL)
 	})
 }
 

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -146,9 +146,11 @@ type AcquireTokenResult struct {
 
 type WhoamiResult struct {
 	OrganizationSlug   string  `json:"organization_slug"`
-	TokenKind          string  `json:"token_kind"` // organization_access_token, personal_access_token
+	TokenKind          string  `json:"token_kind"` // service_account, personal_access_token
 	UserEmail          *string `json:"user_email,omitempty"`
 	ServiceAccountName *string `json:"service_account_name,omitempty"`
+	TokenDescription   *string `json:"token_description,omitempty"`
+	TokenURL           *string `json:"token_url,omitempty"`
 }
 
 type DocsTokenResult struct {

--- a/internal/cli/service_whoami.go
+++ b/internal/cli/service_whoami.go
@@ -44,6 +44,12 @@ func (s Service) Whoami(cfg WhoamiConfig) (*api.WhoamiResult, error) {
 		if result.UserEmail != nil {
 			fmt.Fprintf(s.Stdout, "User: %v\n", *result.UserEmail)
 		}
+		if result.TokenDescription != nil {
+			fmt.Fprintf(s.Stdout, "Token Description: %v\n", *result.TokenDescription)
+		}
+		if result.TokenURL != nil {
+			fmt.Fprintf(s.Stdout, "Token URL: %v\n", *result.TokenURL)
+		}
 	}
 
 	return result, nil

--- a/internal/cli/service_whoami_test.go
+++ b/internal/cli/service_whoami_test.go
@@ -32,11 +32,15 @@ func TestService_Whoami(t *testing.T) {
 			s := setupTest(t)
 
 			email := "someone@rwx.com"
+			tokenDescription := "MacBook"
+			tokenURL := "https://cloud.rwx.com/_/personal_access_tokens/123/edit"
 			s.mockAPI.MockWhoami = func() (*api.WhoamiResult, error) {
 				return &api.WhoamiResult{
 					TokenKind:        "personal_access_token",
 					OrganizationSlug: "rwx",
 					UserEmail:        &email,
+					TokenDescription: &tokenDescription,
+					TokenURL:         &tokenURL,
 				}, nil
 			}
 
@@ -51,6 +55,8 @@ func TestService_Whoami(t *testing.T) {
 			require.Contains(t, s.mockStdout.String(), `"token_kind": "personal_access_token"`)
 			require.Contains(t, s.mockStdout.String(), `"organization_slug": "rwx"`)
 			require.Contains(t, s.mockStdout.String(), `"user_email": "someone@rwx.com"`)
+			require.Contains(t, s.mockStdout.String(), `"token_description": "MacBook"`)
+			require.Contains(t, s.mockStdout.String(), `"token_url": "https://cloud.rwx.com/_/personal_access_tokens/123/edit"`)
 		})
 
 		t.Run("when there is not an email", func(t *testing.T) {
@@ -75,17 +81,23 @@ func TestService_Whoami(t *testing.T) {
 			require.Contains(t, s.mockStdout.String(), `"organization_slug": "rwx"`)
 			require.NotContains(t, s.mockStdout.String(), `"user_email"`)
 			require.NotContains(t, s.mockStdout.String(), `"service_account_name"`)
+			require.NotContains(t, s.mockStdout.String(), `"token_description"`)
+			require.NotContains(t, s.mockStdout.String(), `"token_url"`)
 		})
 
 		t.Run("when there is a service account name", func(t *testing.T) {
 			s := setupTest(t)
 
 			serviceAccountName := "deploy bot"
+			tokenDescription := "CI release token"
+			tokenURL := "https://cloud.rwx.com/org/rwx/manage/service_accounts/123"
 			s.mockAPI.MockWhoami = func() (*api.WhoamiResult, error) {
 				return &api.WhoamiResult{
 					TokenKind:          "organization_access_token",
 					OrganizationSlug:   "rwx",
 					ServiceAccountName: &serviceAccountName,
+					TokenDescription:   &tokenDescription,
+					TokenURL:           &tokenURL,
 				}, nil
 			}
 
@@ -97,6 +109,8 @@ func TestService_Whoami(t *testing.T) {
 			require.Equal(t, &serviceAccountName, result.ServiceAccountName)
 			require.Contains(t, s.mockStdout.String(), `"token_kind": "organization_access_token"`)
 			require.Contains(t, s.mockStdout.String(), `"service_account_name": "deploy bot"`)
+			require.Contains(t, s.mockStdout.String(), `"token_description": "CI release token"`)
+			require.Contains(t, s.mockStdout.String(), `"token_url": "https://cloud.rwx.com/org/rwx/manage/service_accounts/123"`)
 		})
 	})
 
@@ -122,11 +136,15 @@ func TestService_Whoami(t *testing.T) {
 			s := setupTest(t)
 
 			email := "someone@rwx.com"
+			tokenDescription := "MacBook"
+			tokenURL := "https://cloud.rwx.com/_/personal_access_tokens/123/edit"
 			s.mockAPI.MockWhoami = func() (*api.WhoamiResult, error) {
 				return &api.WhoamiResult{
 					TokenKind:        "personal_access_token",
 					OrganizationSlug: "rwx",
 					UserEmail:        &email,
+					TokenDescription: &tokenDescription,
+					TokenURL:         &tokenURL,
 				}, nil
 			}
 
@@ -141,6 +159,8 @@ func TestService_Whoami(t *testing.T) {
 			require.Contains(t, s.mockStdout.String(), "Token Kind: personal access token")
 			require.Contains(t, s.mockStdout.String(), "Organization: rwx")
 			require.Contains(t, s.mockStdout.String(), "User: someone@rwx.com")
+			require.Contains(t, s.mockStdout.String(), "Token Description: MacBook")
+			require.Contains(t, s.mockStdout.String(), "Token URL: https://cloud.rwx.com/_/personal_access_tokens/123/edit")
 		})
 
 		t.Run("when there is not an email", func(t *testing.T) {
@@ -165,17 +185,23 @@ func TestService_Whoami(t *testing.T) {
 			require.Contains(t, s.mockStdout.String(), "Organization: rwx")
 			require.NotContains(t, s.mockStdout.String(), "User:")
 			require.NotContains(t, s.mockStdout.String(), "Service Account:")
+			require.NotContains(t, s.mockStdout.String(), "Token Description:")
+			require.NotContains(t, s.mockStdout.String(), "Token URL:")
 		})
 
 		t.Run("when there is a service account name", func(t *testing.T) {
 			s := setupTest(t)
 
 			serviceAccountName := "deploy bot"
+			tokenDescription := "CI release token"
+			tokenURL := "https://cloud.rwx.com/org/rwx/manage/service_accounts/123"
 			s.mockAPI.MockWhoami = func() (*api.WhoamiResult, error) {
 				return &api.WhoamiResult{
 					TokenKind:          "organization_access_token",
 					OrganizationSlug:   "rwx",
 					ServiceAccountName: &serviceAccountName,
+					TokenDescription:   &tokenDescription,
+					TokenURL:           &tokenURL,
 				}, nil
 			}
 
@@ -188,6 +214,8 @@ func TestService_Whoami(t *testing.T) {
 			require.Contains(t, s.mockStdout.String(), "Token Kind: service account")
 			require.Contains(t, s.mockStdout.String(), "Organization: rwx")
 			require.Contains(t, s.mockStdout.String(), "Service Account: deploy bot")
+			require.Contains(t, s.mockStdout.String(), "Token Description: CI release token")
+			require.Contains(t, s.mockStdout.String(), "Token URL: https://cloud.rwx.com/org/rwx/manage/service_accounts/123")
 			require.NotContains(t, s.mockStdout.String(), "User:")
 		})
 	})


### PR DESCRIPTION
### Background

- [RWX-1529](https://linear.app/rwx-cloud/issue/RWX-1529/print-the-token-description-and-link-in-rwx-whoami)
- Cloud half: [rwx-cloud/cloud#8315](https://github.com/rwx-cloud/cloud/pull/8315)
- Precedent: #587

### Problem

`rwx whoami` names the identity, but not the credential:

```
Token Kind: personal access token
Organization: rwx
User: jason@rwx.com
```

A user with several personal access tokens cannot tell which token the machine holds.

### Solution

- Read `token_description` and `token_url` from the whoami API, then print them after the `User:` line.
- Both fields are pointers with `omitempty`. An older cloud sends nothing, so the fields stay nil, the CLI prints no extra lines, and `--json` omits the keys.
- Correct the comment on `TokenKind`. Cloud sends `service_account`, not `organization_access_token`.

Personal access token:

```
Token Kind: personal access token
Organization: rwx
User: jason@rwx.com
Token Description: MacBook
Token URL: https://cloud.rwx.com/_/personal_access_tokens/123/edit
```

Service account token:

```
Token Kind: service account
Organization: rwx
Service Account: deploy bot
Token Description: CI release token
Token URL: https://cloud.rwx.com/org/rwx/manage/service_accounts/123
```

Merge this after cloud PR #8315 deploys.

#### Further confirmation needed

- [x] Run `rwx whoami` against a deploy that has cloud PR #8315, with a personal access token and with a service account token.
- [x] Open each printed URL.
