### PR TITLE
Inject base config for tasks that call local packages

### DIFF
--- a/internal/cli/service_insert_base_test.go
+++ b/internal/cli/service_insert_base_test.go
@@ -448,4 +448,94 @@ tasks:
 `, string(contents))
 		})
 	})
+
+	t.Run("when yaml file calls into the packages directory and doesn't include base", func(t *testing.T) {
+		bl := setupBaseLayer(t)
+
+		err := os.WriteFile(filepath.Join(bl.mintDir, "foo.yaml"), []byte(`tasks:
+  - key: a
+    call: ${{ run.dir }}/packages/my-package
+`), 0o644)
+		require.NoError(t, err)
+
+		t.Run("adds base to file", func(t *testing.T) {
+			_, err = bl.s.service.InsertBase(cli.InsertBaseConfig{})
+			require.NoError(t, err)
+
+			var contents []byte
+
+			contents, err = os.ReadFile(filepath.Join(bl.mintDir, "foo.yaml"))
+			require.NoError(t, err)
+			require.Equal(t, `base:
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
+
+tasks:
+  - key: a
+    call: ${{ run.dir }}/packages/my-package
+`, string(contents))
+		})
+	})
+
+	t.Run("when yaml file calls with an expression and 'with' and doesn't include base", func(t *testing.T) {
+		bl := setupBaseLayer(t)
+
+		err := os.WriteFile(filepath.Join(bl.mintDir, "foo.yaml"), []byte(`tasks:
+  - key: a
+    call: ${{ run.dir }}/my-package
+    with:
+      some-param: some-value
+`), 0o644)
+		require.NoError(t, err)
+
+		t.Run("adds base to file", func(t *testing.T) {
+			_, err = bl.s.service.InsertBase(cli.InsertBaseConfig{})
+			require.NoError(t, err)
+
+			var contents []byte
+
+			contents, err = os.ReadFile(filepath.Join(bl.mintDir, "foo.yaml"))
+			require.NoError(t, err)
+			require.Equal(t, `base:
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
+
+tasks:
+  - key: a
+    call: ${{ run.dir }}/my-package
+    with:
+      some-param: some-value
+`, string(contents))
+		})
+	})
+
+	t.Run("when yaml file calls with an expression and 'use' and doesn't include base", func(t *testing.T) {
+		bl := setupBaseLayer(t)
+
+		err := os.WriteFile(filepath.Join(bl.mintDir, "foo.yaml"), []byte(`tasks:
+  - key: a
+    use: setup
+    call: ${{ run.dir }}/my-package
+`), 0o644)
+		require.NoError(t, err)
+
+		t.Run("adds base to file", func(t *testing.T) {
+			_, err = bl.s.service.InsertBase(cli.InsertBaseConfig{})
+			require.NoError(t, err)
+
+			var contents []byte
+
+			contents, err = os.ReadFile(filepath.Join(bl.mintDir, "foo.yaml"))
+			require.NoError(t, err)
+			require.Equal(t, `base:
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
+
+tasks:
+  - key: a
+    use: setup
+    call: ${{ run.dir }}/my-package
+`, string(contents))
+		})
+	})
 }

--- a/internal/cli/yaml.go
+++ b/internal/cli/yaml.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -70,6 +71,10 @@ func (doc *YAMLDoc) HasTasks() bool {
 	return doc.hasPath("$.tasks")
 }
 
+// packagesDirCallRe matches calls into the local packages directory, eg.
+// `call: ${{ run.dir }}/packages/my-package`
+var packagesDirCallRe = regexp.MustCompile(`^\$\{\{\s*run\.dir\s*\}\}/packages/`)
+
 func (doc *YAMLDoc) AllTasksAreEmbeddedRuns() bool {
 	err := doc.ForEachNode("$.tasks[*]", func(node ast.Node) error {
 		mapNode, ok := node.(*ast.MappingNode)
@@ -77,20 +82,24 @@ func (doc *YAMLDoc) AllTasksAreEmbeddedRuns() bool {
 			return fmt.Errorf("expected mapping node, got %T", node)
 		}
 
-		hasEmbeddedRun := false
+		callValue := ""
+		hasPackageMarker := false
 		for _, entry := range mapNode.Values {
-			if entry.Key.String() != "call" {
-				continue
+			switch entry.Key.String() {
+			case "call":
+				callValue = entry.Value.String()
+			case "with", "use":
+				// `with` and `use` are only valid on package calls, so their
+				// presence means this is a local package call, not an embedded run.
+				hasPackageMarker = true
 			}
-
-			if strings.HasPrefix(entry.Value.String(), "${{") {
-				hasEmbeddedRun = true
-			}
-
-			break
 		}
 
-		if !hasEmbeddedRun {
+		isEmbeddedRun := strings.HasPrefix(callValue, "${{") &&
+			!hasPackageMarker &&
+			!packagesDirCallRe.MatchString(callValue)
+
+		if !isEmbeddedRun {
 			return errors.New("no embedded run found")
 		}
 


### PR DESCRIPTION
A task calling with an expression was always treated as an embedded run, so files containing only such tasks never got a base injected. But local package calls also use expressions (e.g. `call: ${{ run.dir }}/packages/...`) and do need a base.

Treat a call as a local package call, rather than an embedded run, when the task has a `with` or `use` key, or when the call references the packages directory.