### PR TITLE
Use a short-lived token via a vault service account for CI

### DIFF
--- a/.rwx/integration-sandbox.yml
+++ b/.rwx/integration-sandbox.yml
@@ -93,12 +93,11 @@ tasks:
           "  use: [rwx-cli, git]" \
           "  run: ./${script}" \
           "  env:" \
-          "    RWX_ACCESS_TOKEN: ${RWX_ACCESS_TOKEN}" \
+          '    RWX_ACCESS_TOKEN: \${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}' \
           "    COMMIT_SHA: ${COMMIT_SHA}" \
           >> "$RWX_DYNAMIC_TASKS/sandbox-tests.yml"
       done
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
       COMMIT_SHA: ${{ init.commit-sha }}
     filter:
       - test/integration/sandbox-*.sh

--- a/.rwx/integration/artifacts-test.yml
+++ b/.rwx/integration/artifacts-test.yml
@@ -52,7 +52,7 @@ tasks:
       echo "$run_url" > "$RWX_VALUES/run-url"
       echo "$run_url" > "$RWX_LINKS/Run URL"
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
       RUN_DEF: ${{ run.dir }}/integration/artifacts-test/run-def.yml
 
   - key: test-list-artifacts
@@ -76,7 +76,7 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-download-single-artifact
     use: rwx-cli
@@ -94,7 +94,7 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-download-all-artifacts
     use: rwx-cli
@@ -122,7 +122,7 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-download-all-artifacts-with-auto-extract
     use: rwx-cli
@@ -150,7 +150,7 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-download-single-artifact-with-output
     use: rwx-cli
@@ -167,7 +167,7 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-download-directory-artifact-with-auto-extract
     use: rwx-cli
@@ -194,7 +194,7 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-download-directory-artifact-as-tar
     use: rwx-cli
@@ -216,7 +216,7 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-download-artifact-json-output
     use: rwx-cli
@@ -239,7 +239,7 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-download-file-artifact-output-directory-fails
     use: rwx-cli
@@ -261,7 +261,7 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-download-directory-artifact-output-file-fails
     use: rwx-cli
@@ -283,4 +283,4 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}

--- a/.rwx/integration/dispatch-test.yml
+++ b/.rwx/integration/dispatch-test.yml
@@ -47,7 +47,7 @@ tasks:
 
       echo "$run_url" > "$RWX_LINKS/Run URL"
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-dispatch-failure
     use: rwx-cli
@@ -85,7 +85,7 @@ tasks:
         exit 1
       fi
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-dispatch-fail-fast
     use: rwx-cli
@@ -123,4 +123,4 @@ tasks:
         exit 1
       fi
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}

--- a/.rwx/integration/image-test.yml
+++ b/.rwx/integration/image-test.yml
@@ -127,5 +127,5 @@ tasks:
         exit 1
       fi
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
       BUILD_IMAGE_DEF: ${{ run.dir }}/integration/image-test/build-image.yml

--- a/.rwx/integration/logs-test.yml
+++ b/.rwx/integration/logs-test.yml
@@ -48,7 +48,7 @@ tasks:
       echo "$run_url" > "$RWX_VALUES/run-url"
       echo "$run_url" > "$RWX_LINKS/Run URL"
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
       RUN_DEF: ${{ run.dir }}/integration/logs-test/run-def.yml
 
   - key: test-download-and-extract-logs
@@ -76,7 +76,7 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-download-logs-as-zip
     use: rwx-cli
@@ -97,7 +97,7 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-download-logs-json-extract-output
     use: rwx-cli
@@ -130,7 +130,7 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-download-logs-json-zip-output
     use: rwx-cli
@@ -152,7 +152,7 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-download-logs-zip-output-directory-fails
     use: rwx-cli
@@ -174,7 +174,7 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-download-logs-extract-output-file-fails
     use: rwx-cli
@@ -196,4 +196,4 @@ tasks:
     env:
       RUN_ID: ${{ tasks.rwx-run.values.run-id }}
       RUN_URL: ${{ tasks.rwx-run.values.run-url }}
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}

--- a/.rwx/integration/resolve-update-test.yml
+++ b/.rwx/integration/resolve-update-test.yml
@@ -52,7 +52,7 @@ tasks:
         exit 1
       fi
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-resolve-packages-adds-version-pin
     use: rwx-cli
@@ -78,7 +78,7 @@ tasks:
 
       rm -rf "$tmpdir"
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-update-packages-bumps-old-version
     use: rwx-cli
@@ -101,7 +101,7 @@ tasks:
         exit 1
       fi
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-update-packages-bumps-base-config
     use: rwx-cli
@@ -134,7 +134,7 @@ tasks:
       fi
       rm -rf "$tmpdir"
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-update-base-updates-base-image
     use: rwx-cli
@@ -160,7 +160,7 @@ tasks:
         exit 1
       fi
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-update-packages-allow-major-version-change
     use: rwx-cli
@@ -182,7 +182,7 @@ tasks:
         exit 1
       fi
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-resolve-packages-with-file-argument
     use: rwx-cli
@@ -204,4 +204,4 @@ tasks:
         exit 1
       fi
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}

--- a/.rwx/integration/results-test.yml
+++ b/.rwx/integration/results-test.yml
@@ -73,7 +73,7 @@ tasks:
         exit 1
       fi
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
       RUN_DEF: ${{ run.dir }}/integration/results-test/passing.yml
 
   - key: test-results-fail-fast
@@ -124,7 +124,7 @@ tasks:
         exit 1
       fi
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
       RUN_DEF: ${{ run.dir }}/integration/results-test/failing.yml
 
   - key: test-results-task-level
@@ -148,5 +148,5 @@ tasks:
         exit 1
       fi
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
       RUN_DEF: ${{ run.dir }}/integration/results-test/mixed-task-statuses.yml

--- a/.rwx/integration/run-test.yml
+++ b/.rwx/integration/run-test.yml
@@ -64,7 +64,7 @@ tasks:
       fi
     env:
       RUN_DEF: ${{ run.dir }}/integration/run-test/simple-def.yml
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-run-target
     use: rwx-cli
@@ -90,7 +90,7 @@ tasks:
       fi
     env:
       RUN_DEF: ${{ run.dir }}/integration/run-test/multi-task-def.yml
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-run-dir
     use: rwx-cli
@@ -109,7 +109,7 @@ tasks:
       fi
     env:
       RUN_DIR_PARENT: ${{ run.dir }}/integration/run-test/dir-test
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   - key: test-run-fail-fast
     use: rwx-cli
@@ -148,7 +148,7 @@ tasks:
         exit 1
       fi
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
       RUN_DEF: ${{ run.dir }}/integration/run-test/failing-def.yml
 
   # `rwx runs start` is the noun-verb alias for `rwx run`; it must initiate a
@@ -177,7 +177,7 @@ tasks:
       fi
     env:
       RUN_DEF: ${{ run.dir }}/integration/run-test/simple-def.yml
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
 
   # Bare `rwx runs` is a pure parent command: it prints help and must never
   # initiate a run. No access token is required because help short-circuits

--- a/.rwx/integration/runs-list-test.yml
+++ b/.rwx/integration/runs-list-test.yml
@@ -135,5 +135,5 @@ tasks:
         exit 1
       fi
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
       RUN_DEF: ${{ run.dir }}/integration/runs-list-test/passing.yml

--- a/.rwx/integration/whoami-test.yml
+++ b/.rwx/integration/whoami-test.yml
@@ -49,4 +49,4 @@ tasks:
         exit 1
       fi
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}

--- a/.rwx/release.yml
+++ b/.rwx/release.yml
@@ -360,4 +360,4 @@ tasks:
       trimmed_version="${version#v}"
       rwx dispatch release-homebrew-tap --param version="${trimmed_version}"
     env:
-      RWX_ACCESS_TOKEN: ${{ secrets.RWX_ACCESS_TOKEN }}
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}


### PR DESCRIPTION
This PR updates the access token used for integration testing so that it uses a vault service account, which means runs kicked off from this repo will use short-lived tokens rather than a long-lived one.