### PR TITLE
Add `rwx package build` to build and upload packages

### DIFF
--- a/.rwx/integration.yml
+++ b/.rwx/integration.yml
@@ -53,6 +53,11 @@ tasks:
     init:
       ref: ${{ init.commit-sha }}
 
+  - key: run-rwx-package-build-test
+    call: ${{ run.dir }}/integration/package-build-test.yml
+    init:
+      ref: ${{ init.commit-sha }}
+
   - key: run-rwx-skill-test
     call: ${{ run.dir }}/integration/skill-test.yml
     init:

--- a/.rwx/integration/package-build-test.yml
+++ b/.rwx/integration/package-build-test.yml
@@ -1,0 +1,249 @@
+# Package fixtures in this file are written by the shell at runtime so that
+# intentionally invalid ones are not caught by real linting.
+
+on:
+  cli:
+    init:
+      ref: ${{ event.git.sha }}
+
+base:
+  image: ubuntu:24.04
+  config: rwx/base 1.1.1
+
+tasks:
+  - key: code
+    call: git/clone 2.0.8
+    with:
+      repository: https://github.com/rwx-cloud/rwx.git
+      ref: ${{ init.ref }}
+
+  - key: build-def
+    use: code
+    run: cp .rwx/build.yml $RWX_ARTIFACTS/build-yml
+
+  - key: build-rwx-cli
+    call: ${{ tasks.build-def.artifacts.build-yml }}
+    init:
+      ref: ${{ init.ref }}
+
+  - key: rwx-cli
+    run: sudo install "$CLI_BINARY" /usr/local/bin
+    env:
+      CLI_BINARY: ${{ tasks.build-rwx-cli.tasks.build.artifacts.rwx }}
+
+  # Uploads a real package and returns a server-computed digest.
+  - key: test-package-build-uploads-and-returns-a-digest
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      org=$(rwx whoami --json | jq -r '.organization_slug')
+      tmpdir=$(mktemp -d)
+      cat > "$tmpdir/rwx-package.yml" << EOF
+      name: $org/rwx-cli-integration-test
+      version: 0.0.1
+      description: Fixture uploaded by the rwx CLI integration suite
+      tasks:
+        - key: noop
+          run: echo hello
+      EOF
+      echo "# rwx-cli-integration-test" > "$tmpdir/README.md"
+
+      output=$(rwx package build "$tmpdir")
+      echo "$output"
+
+      digest=$(echo "$output" | sed -n 's/^Uploaded package with digest: //p')
+      if ! echo "$digest" | grep -qE '^[0-9a-f]{64}$'; then
+        echo "expected a 64 character hex digest, got: '$digest'"
+        exit 1
+      fi
+    env:
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
+
+  # --timestamp must make the digest reproducible even when mtimes change,
+  # which is what makes content-based caching work.
+  - key: test-package-build-timestamp-produces-a-stable-digest
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      org=$(rwx whoami --json | jq -r '.organization_slug')
+      tmpdir=$(mktemp -d)
+      cat > "$tmpdir/rwx-package.yml" << EOF
+      name: $org/rwx-cli-integration-test
+      version: 0.0.1
+      description: Fixture uploaded by the rwx CLI integration suite
+      tasks:
+        - key: noop
+          run: echo hello
+      EOF
+      echo "# rwx-cli-integration-test" > "$tmpdir/README.md"
+
+      build_digest() {
+        rwx package build "$tmpdir" --timestamp 202601020304 --json | jq -r '.Digest'
+      }
+
+      find "$tmpdir" -exec touch -t 202001010000 {} \;
+      first=$(build_digest)
+
+      # Rewriting every modification time must not change the digest.
+      find "$tmpdir" -exec touch -t 202412250000 {} \;
+      second=$(build_digest)
+
+      if [ "$first" != "$second" ]; then
+        echo "--timestamp did not produce a reproducible digest"
+        echo "first:  $first"
+        echo "second: $second"
+        exit 1
+      fi
+
+      # Sanity check that the files themselves were not rewritten by the build.
+      if [ -n "$(find "$tmpdir" -newermt '2025-01-01' -print -quit)" ]; then
+        echo "package build modified file timestamps on disk"
+        exit 1
+      fi
+    env:
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
+
+  # Without --timestamp the real mtimes are preserved, so the digest tracks them.
+  - key: test-package-build-without-timestamp-tracks-mtimes
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      org=$(rwx whoami --json | jq -r '.organization_slug')
+      tmpdir=$(mktemp -d)
+      cat > "$tmpdir/rwx-package.yml" << EOF
+      name: $org/rwx-cli-integration-test
+      version: 0.0.1
+      description: Fixture uploaded by the rwx CLI integration suite
+      tasks:
+        - key: noop
+          run: echo hello
+      EOF
+      echo "# rwx-cli-integration-test" > "$tmpdir/README.md"
+
+      find "$tmpdir" -exec touch -t 202001010000 {} \;
+      first=$(rwx package build "$tmpdir" --json | jq -r '.Digest')
+
+      find "$tmpdir" -exec touch -t 202412250000 {} \;
+      second=$(rwx package build "$tmpdir" --json | jq -r '.Digest')
+
+      if [ "$first" = "$second" ]; then
+        echo "expected the digest to change with file mtimes when --timestamp is omitted"
+        exit 1
+      fi
+    env:
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
+
+  # Every validation failure the registry can return must reach the user.
+  - key: test-package-build-displays-server-validation-errors
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      org=$(rwx whoami --json | jq -r '.organization_slug')
+
+      # assert_error <case name> <expected substring> <fixture dir>
+      assert_error() {
+        name="$1"; expected="$2"; dir="$3"
+
+        if output=$(rwx package build "$dir" 2>&1); then
+          echo "[$name] expected a non-zero exit, but the build succeeded:"
+          echo "$output"
+          exit 1
+        fi
+
+        if ! echo "$output" | grep -qF "$expected"; then
+          echo "[$name] expected output to contain: $expected"
+          echo "actual output:"
+          echo "$output"
+          exit 1
+        fi
+        echo "[$name] ok"
+      }
+
+      # Missing rwx-package.yml. The server also lists what was uploaded, which
+      # is multi-line and must not be truncated.
+      d=$(mktemp -d)
+      echo "# readme" > "$d/README.md"
+      assert_error "missing rwx-package.yml" "Upload did not contain rwx-package.yml" "$d"
+      assert_error "missing rwx-package.yml lists files" "Files in upload:" "$d"
+
+      # Missing README.md
+      d=$(mktemp -d)
+      printf 'name: %s/rwx-cli-integration-test\nversion: 0.0.1\ndescription: d\ntasks:\n  - key: noop\n    run: echo hi\n' "$org" > "$d/rwx-package.yml"
+      assert_error "missing README.md" "Upload did not contain README.md" "$d"
+
+      # Invalid YAML
+      d=$(mktemp -d)
+      echo "# readme" > "$d/README.md"
+      printf 'name: [unclosed\n  bad: : :\n' > "$d/rwx-package.yml"
+      assert_error "invalid yaml" "did not find expected" "$d"
+
+      # Manifest without a name
+      d=$(mktemp -d)
+      echo "# readme" > "$d/README.md"
+      printf 'description: no name here\n' > "$d/rwx-package.yml"
+      assert_error "missing name" "did not contain a name" "$d"
+
+      # Version that is not semver
+      d=$(mktemp -d)
+      echo "# readme" > "$d/README.md"
+      printf 'name: %s/rwx-cli-integration-test\nversion: not-a-version\ndescription: d\ntasks:\n  - key: noop\n    run: echo hi\n' "$org" > "$d/rwx-package.yml"
+      assert_error "invalid version" "did not contain a valid version" "$d"
+
+      # Package name owned by a different organization
+      d=$(mktemp -d)
+      echo "# readme" > "$d/README.md"
+      printf 'name: not-your-org/rwx-cli-integration-test\nversion: 0.0.1\ndescription: d\ntasks:\n  - key: noop\n    run: echo hi\n' > "$d/rwx-package.yml"
+      assert_error "wrong organization" "but request was made under organization" "$d"
+    env:
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
+
+  - key: test-package-build-displays-unauthorized-error
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      tmpdir=$(mktemp -d)
+      echo "# readme" > "$tmpdir/README.md"
+      printf 'name: rwx/rwx-cli-integration-test\nversion: 0.0.1\ndescription: d\ntasks:\n  - key: noop\n    run: echo hi\n' > "$tmpdir/rwx-package.yml"
+
+      if output=$(rwx package build "$tmpdir" --access-token rwxp_not_a_real_token 2>&1); then
+        echo "expected a non-zero exit with an invalid access token"
+        echo "$output"
+        exit 1
+      fi
+
+      if ! echo "$output" | grep -qi "unauthorized"; then
+        echo "expected the unauthorized error to be displayed, got:"
+        echo "$output"
+        exit 1
+      fi
+    env:
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
+
+  # A malformed --timestamp is rejected locally, before anything is uploaded.
+  - key: test-package-build-rejects-an-invalid-timestamp
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      tmpdir=$(mktemp -d)
+      echo "# readme" > "$tmpdir/README.md"
+      printf 'name: rwx/rwx-cli-integration-test\nversion: 0.0.1\ndescription: d\ntasks:\n  - key: noop\n    run: echo hi\n' > "$tmpdir/rwx-package.yml"
+
+      if output=$(rwx package build "$tmpdir" --timestamp 2026-01-02 2>&1); then
+        echo "expected a non-zero exit for a malformed timestamp"
+        echo "$output"
+        exit 1
+      fi
+
+      if ! echo "$output" | grep -q "YYYYMMDDHHmm"; then
+        echo "expected the timestamp format to be explained, got:"
+        echo "$output"
+        exit 1
+      fi
+    env:
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}

--- a/cmd/rwx/packages.go
+++ b/cmd/rwx/packages.go
@@ -6,6 +6,7 @@ import (
 )
 
 var packagesCmd = &cobra.Command{
+	Aliases: []string{"package"},
 	GroupID: "definitions",
 	Hidden:  true,
 	Short:   "Manage RWX packages",
@@ -14,7 +15,33 @@ var packagesCmd = &cobra.Command{
 
 var (
 	PackagesAllowMajorVersionChange bool
+	PackagesBuildTimestamp          string
 	PackagesShowNoReadme            bool
+
+	packagesBuildCmd = &cobra.Command{
+		Args: cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return requireAccessToken()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			directory := "."
+			if len(args) == 1 {
+				directory = args[0]
+			}
+
+			_, err := service.BuildPackage(cli.PackageBuildConfig{
+				Directory: directory,
+				Timestamp: PackagesBuildTimestamp,
+				Json:      useJsonOutput(),
+			})
+			return err
+		},
+		Short: "Build and upload a package",
+		Long: "Build and upload a package.\n" +
+			"Zips the contents of the given directory (the current directory by default), " +
+			"uploads it to RWX, and prints the resulting content digest.",
+		Use: "build [flags] [directory]",
+	}
 
 	packagesListCmd = &cobra.Command{
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -66,9 +93,11 @@ var (
 )
 
 func init() {
+	packagesBuildCmd.Flags().StringVar(&PackagesBuildTimestamp, "timestamp", "", "normalize file modification times in the zip to this `timestamp` (format: YYYYMMDDHHmm) for reproducible builds")
 	packagesShowCmd.Flags().BoolVar(&PackagesShowNoReadme, "no-readme", false, "hide the readme documentation")
 	packagesUpdateCmd.Flags().BoolVar(&PackagesAllowMajorVersionChange, "allow-major-version-change", false, "update packages to the latest major version")
 	addRwxDirFlag(packagesUpdateCmd)
+	packagesCmd.AddCommand(packagesBuildCmd)
 	packagesCmd.AddCommand(packagesListCmd)
 	packagesCmd.AddCommand(packagesShowCmd)
 	packagesCmd.AddCommand(packagesUpdateCmd)

--- a/cmd/rwx/packages_test.go
+++ b/cmd/rwx/packages_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackagesBuildIsReachableAsPackageBuild(t *testing.T) {
+	// The feature is documented as `rwx package build`, which resolves through
+	// the singular alias on the packages parent.
+	require.Contains(t, packagesCmd.Aliases, "package")
+
+	cmd, _, err := rootCmd.Find([]string{"package", "build"})
+	require.NoError(t, err)
+	require.Equal(t, "build", cmd.Name())
+	require.Same(t, packagesBuildCmd, cmd)
+
+	cmd, _, err = rootCmd.Find([]string{"packages", "build"})
+	require.NoError(t, err)
+	require.Same(t, packagesBuildCmd, cmd)
+}
+
+func TestPackagesBuildAcceptsAnOptionalDirectory(t *testing.T) {
+	require.NoError(t, packagesBuildCmd.Args(packagesBuildCmd, []string{}))
+	require.NoError(t, packagesBuildCmd.Args(packagesBuildCmd, []string{"rwx/package"}))
+	require.Error(t, packagesBuildCmd.Args(packagesBuildCmd, []string{"a", "b"}))
+}
+
+func TestPackagesBuildExposesTimestampFlagAndRequiresAuth(t *testing.T) {
+	flag := packagesBuildCmd.Flags().Lookup("timestamp")
+	require.NotNil(t, flag, "build should expose the --timestamp flag")
+	require.Equal(t, "", flag.DefValue, "timestamp normalization should be opt-in")
+
+	// Uploading requires an authenticated API call.
+	require.NotNil(t, packagesBuildCmd.PreRunE)
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strings"
@@ -957,6 +958,58 @@ func (c Client) GetPackageVersions() (*PackageVersionsResult, error) {
 	}
 
 	respBody := PackageVersionsResult{}
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		return nil, errors.Wrap(err, "unable to parse API response")
+	}
+
+	return &respBody, nil
+}
+
+// UploadPackage uploads a zipped package to the RWX package registry and
+// returns the content digest assigned by the server.
+func (c Client) UploadPackage(cfg UploadPackageConfig) (*UploadPackageResult, error) {
+	endpoint := "/mint/api/leaves"
+
+	var body bytes.Buffer
+	form := multipart.NewWriter(&body)
+
+	part, err := form.CreateFormFile("file", cfg.FileName)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to build multipart form")
+	}
+
+	if _, err := io.Copy(part, cfg.Contents); err != nil {
+		return nil, errors.Wrap(err, "unable to write package contents")
+	}
+
+	if err := form.Close(); err != nil {
+		return nil, errors.Wrap(err, "unable to finalize multipart form")
+	}
+
+	req, err := http.NewRequest(http.MethodPost, endpoint, &body)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to create new HTTP request")
+	}
+
+	req.Header.Set("Content-Type", form.FormDataContentType())
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.RoundTrip(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "HTTP request failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		msg := extractErrorMessage(resp.Body)
+		if msg == "" {
+			msg = fmt.Sprintf("Unable to call RWX API - %s", resp.Status)
+		}
+
+		return nil, errors.New(msg)
+	}
+
+	respBody := UploadPackageResult{}
 	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
 		return nil, errors.Wrap(err, "unable to parse API response")
 	}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1000,21 +1000,15 @@ func (c Client) UploadPackage(cfg UploadPackageConfig) (*UploadPackageResult, er
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		msg := extractErrorMessage(resp.Body)
-		if msg == "" {
-			msg = fmt.Sprintf("Unable to call RWX API - %s", resp.Status)
-		}
-
-		return nil, errors.New(msg)
+	// Package validation failures (missing rwx-package.yml or README.md, invalid
+	// YAML, a name owned by another organization, ...) come back as
+	// {"error": "..."} and are surfaced verbatim to the user.
+	result := UploadPackageResult{}
+	if err := decodeResponseJSON(resp, &result); err != nil {
+		return nil, err
 	}
 
-	respBody := UploadPackageResult{}
-	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
-		return nil, errors.Wrap(err, "unable to parse API response")
-	}
-
-	return &respBody, nil
+	return &result, nil
 }
 
 func (c Client) GetPackageDocumentation(packageName string) (*PackageDocumentationResult, error) {

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -245,6 +245,15 @@ type PackageVersionsResult struct {
 	Packages    map[string]ApiPackageInfo    `json:"packages"`
 }
 
+type UploadPackageConfig struct {
+	FileName string
+	Contents io.Reader
+}
+
+type UploadPackageResult struct {
+	Digest string `json:"digest"`
+}
+
 type PackageDocumentationParameter struct {
 	Name        string           `json:"name"`
 	Required    bool             `json:"required"`

--- a/internal/api/upload_package_test.go
+++ b/internal/api/upload_package_test.go
@@ -1,0 +1,99 @@
+package api_test
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIClient_UploadPackage(t *testing.T) {
+	t.Run("posts the archive as multipart form data and parses the digest", func(t *testing.T) {
+		var gotPath, gotMethod, gotAccept, gotFieldName, gotFileName string
+		var gotFileContents []byte
+
+		roundTrip := func(req *http.Request) (*http.Response, error) {
+			gotPath = req.URL.Path
+			gotMethod = req.Method
+			gotAccept = req.Header.Get("Accept")
+
+			mediaType, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+			require.NoError(t, err)
+			require.Equal(t, "multipart/form-data", mediaType)
+
+			reader := multipart.NewReader(req.Body, params["boundary"])
+			part, err := reader.NextPart()
+			require.NoError(t, err)
+
+			gotFieldName = part.FormName()
+			gotFileName = part.FileName()
+			gotFileContents, err = io.ReadAll(part)
+			require.NoError(t, err)
+
+			_, err = reader.NextPart()
+			require.ErrorIs(t, err, io.EOF, "only one part should be sent")
+
+			return &http.Response{
+				Status:     "201 Created",
+				StatusCode: 201,
+				Body:       io.NopCloser(strings.NewReader(`{"digest":"sha256:deadbeef"}`)),
+			}, nil
+		}
+
+		c := api.NewClientWithRoundTrip(roundTrip)
+
+		result, err := c.UploadPackage(api.UploadPackageConfig{
+			FileName: "package.zip",
+			Contents: bytes.NewReader([]byte("zip-bytes")),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "sha256:deadbeef", result.Digest)
+
+		require.Equal(t, "/mint/api/leaves", gotPath)
+		require.Equal(t, http.MethodPost, gotMethod)
+		require.Equal(t, "application/json", gotAccept)
+		require.Equal(t, "file", gotFieldName)
+		require.Equal(t, "package.zip", gotFileName)
+		require.Equal(t, []byte("zip-bytes"), gotFileContents)
+	})
+
+	t.Run("surfaces the error body on a failure response", func(t *testing.T) {
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "422 Unprocessable Entity",
+				StatusCode: 422,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"invalid package"}`)),
+			}, nil
+		})
+
+		_, err := c.UploadPackage(api.UploadPackageConfig{
+			FileName: "package.zip",
+			Contents: bytes.NewReader([]byte("zip-bytes")),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid package")
+	})
+
+	t.Run("falls back to the status when the error body is not JSON", func(t *testing.T) {
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "500 Internal Server Error",
+				StatusCode: 500,
+				Body:       io.NopCloser(strings.NewReader("boom")),
+			}, nil
+		})
+
+		_, err := c.UploadPackage(api.UploadPackageConfig{
+			FileName: "package.zip",
+			Contents: bytes.NewReader([]byte("zip-bytes")),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "500 Internal Server Error")
+	})
+}

--- a/internal/api/upload_package_test.go
+++ b/internal/api/upload_package_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/rwx-cloud/rwx/internal/api"
+	internalErrors "github.com/rwx-cloud/rwx/internal/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,12 +64,69 @@ func TestAPIClient_UploadPackage(t *testing.T) {
 		require.Equal(t, []byte("zip-bytes"), gotFileContents)
 	})
 
-	t.Run("surfaces the error body on a failure response", func(t *testing.T) {
+	// The bodies below are verbatim responses captured from cloud.rwx.com.
+	t.Run("surfaces real package validation errors verbatim", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			body string
+			want string
+		}{
+			{
+				name: "missing rwx-package.yml lists the files that were uploaded",
+				body: `{"error":"Upload did not contain rwx-package.yml\n\nFiles in upload:\n* README.md"}`,
+				want: "Upload did not contain rwx-package.yml\n\nFiles in upload:\n* README.md",
+			},
+			{
+				name: "missing README.md",
+				body: `{"error":"Upload did not contain README.md\n\nFiles in upload:\n* rwx-package.yml"}`,
+				want: "Upload did not contain README.md",
+			},
+			{
+				name: "invalid yaml",
+				body: `{"error":"(\u003cunknown\u003e): did not find expected ',' or ']' while parsing a flow sequence at line 1 column 7"}`,
+				want: "did not find expected ',' or ']' while parsing a flow sequence at line 1 column 7",
+			},
+			{
+				name: "missing name",
+				body: `{"error":"mint-leaf.yml did not contain a name"}`,
+				want: "mint-leaf.yml did not contain a name",
+			},
+			{
+				name: "invalid version",
+				body: `{"error":"mint-leaf.yml did not contain a valid version"}`,
+				want: "mint-leaf.yml did not contain a valid version",
+			},
+			{
+				name: "name owned by another organization",
+				body: "{\"error\":\"mint-leaf.yml has a leaf name owned by `someoneelse`, but request was made under organization `rwx`\"}",
+				want: "has a leaf name owned by `someoneelse`, but request was made under organization `rwx`",
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						Status:     "400 Bad Request",
+						StatusCode: 400,
+						Body:       io.NopCloser(strings.NewReader(tc.body)),
+					}, nil
+				})
+
+				_, err := c.UploadPackage(api.UploadPackageConfig{
+					FileName: "package.zip",
+					Contents: bytes.NewReader([]byte("zip-bytes")),
+				})
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.want)
+			})
+		}
+	})
+
+	t.Run("classifies an unauthorized response so telemetry does not bucket it as unknown", func(t *testing.T) {
 		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
-				Status:     "422 Unprocessable Entity",
-				StatusCode: 422,
-				Body:       io.NopCloser(strings.NewReader(`{"error":"invalid package"}`)),
+				Status:     "401 Unauthorized",
+				StatusCode: 401,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"Unauthorized"}`)),
 			}, nil
 		})
 
@@ -77,15 +135,34 @@ func TestAPIClient_UploadPackage(t *testing.T) {
 			Contents: bytes.NewReader([]byte("zip-bytes")),
 		})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid package")
+		require.Contains(t, err.Error(), "Unauthorized")
+		require.ErrorIs(t, err, internalErrors.ErrUnauthenticated)
+	})
+
+	t.Run("classifies a server error", func(t *testing.T) {
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "500 Internal Server Error",
+				StatusCode: 500,
+				Body:       io.NopCloser(strings.NewReader(`{"status":500,"error":"Internal Server Error"}`)),
+			}, nil
+		})
+
+		_, err := c.UploadPackage(api.UploadPackageConfig{
+			FileName: "package.zip",
+			Contents: bytes.NewReader([]byte("zip-bytes")),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Internal Server Error")
+		require.ErrorIs(t, err, internalErrors.ErrInternalServerError)
 	})
 
 	t.Run("falls back to the status when the error body is not JSON", func(t *testing.T) {
 		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
 			return &http.Response{
-				Status:     "500 Internal Server Error",
-				StatusCode: 500,
-				Body:       io.NopCloser(strings.NewReader("boom")),
+				Status:     "502 Bad Gateway",
+				StatusCode: 502,
+				Body:       io.NopCloser(strings.NewReader("<html>boom</html>")),
 			}, nil
 		})
 
@@ -94,6 +171,6 @@ func TestAPIClient_UploadPackage(t *testing.T) {
 			Contents: bytes.NewReader([]byte("zip-bytes")),
 		})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "500 Internal Server Error")
+		require.Contains(t, err.Error(), "502 Bad Gateway")
 	})
 }

--- a/internal/api/upload_package_test.go
+++ b/internal/api/upload_package_test.go
@@ -64,7 +64,11 @@ func TestAPIClient_UploadPackage(t *testing.T) {
 		require.Equal(t, []byte("zip-bytes"), gotFileContents)
 	})
 
-	// The bodies below are verbatim responses captured from cloud.rwx.com.
+	// The bodies below are verbatim responses from cloud.rwx.com. The registry
+	// reports every validation failure as 400 {"error": "<single string>"}, so
+	// the CLI's job is to display it unchanged. Messages that name the manifest
+	// use whichever filename was uploaded, so assertions here avoid depending on
+	// rwx-package.yml vs the legacy mint-leaf.yml.
 	t.Run("surfaces real package validation errors verbatim", func(t *testing.T) {
 		for _, tc := range []struct {
 			name string
@@ -100,6 +104,51 @@ func TestAPIClient_UploadPackage(t *testing.T) {
 				name: "name owned by another organization",
 				body: "{\"error\":\"mint-leaf.yml has a leaf name owned by `someoneelse`, but request was made under organization `rwx`\"}",
 				want: "has a leaf name owned by `someoneelse`, but request was made under organization `rwx`",
+			},
+			{
+				name: "missing description",
+				body: `{"error":"rwx-package.yml did not contain a description"}`,
+				want: "rwx-package.yml did not contain a description",
+			},
+			{
+				name: "manifest is not a mapping",
+				body: `{"error":"rwx-package.yml did not contain a mapping"}`,
+				want: "rwx-package.yml did not contain a mapping",
+			},
+			{
+				name: "invalid parameters",
+				body: `{"error":"rwx-package.yml did not contain valid parameters"}`,
+				want: "rwx-package.yml did not contain valid parameters",
+			},
+			{
+				name: "no file in the upload",
+				body: `{"error":"Upload did not contain a file"}`,
+				want: "Upload did not contain a file",
+			},
+			{
+				name: "not a readable zip",
+				body: `{"error":"Upload was not a readable zip archive"}`,
+				want: "Upload was not a readable zip archive",
+			},
+			{
+				name: "compressed size limit",
+				body: `{"error":"Upload exceeded the 10 MB compressed size limit"}`,
+				want: "Upload exceeded the 10 MB compressed size limit",
+			},
+			{
+				name: "uncompressed size limit",
+				body: `{"error":"Upload exceeded the 100 MB uncompressed size limit"}`,
+				want: "Upload exceeded the 100 MB uncompressed size limit",
+			},
+			{
+				name: "file count limit",
+				body: `{"error":"Upload exceeded the 10,000 file limit"}`,
+				want: "Upload exceeded the 10,000 file limit",
+			},
+			{
+				name: "already published",
+				body: `{"error":"rwx/thing 1.0.0 has already been published. Bump the version number according to semver."}`,
+				want: "has already been published. Bump the version number according to semver.",
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -35,6 +35,7 @@ type APIClient interface {
 	DeleteVar(api.DeleteVarConfig) (*api.DeleteVarResult, error)
 	GetPackageVersions() (*api.PackageVersionsResult, error)
 	GetPackageDocumentation(packageName string) (*api.PackageDocumentationResult, error)
+	UploadPackage(api.UploadPackageConfig) (*api.UploadPackageResult, error)
 	GetDefaultBase() (api.DefaultBaseResult, error)
 	StartImagePush(cfg api.StartImagePushConfig) (api.StartImagePushResult, error)
 	ImagePushStatus(pushID string) (api.ImagePushStatusResult, error)

--- a/internal/cli/service_package_build.go
+++ b/internal/cli/service_package_build.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/errors"
+)
+
+// PackageTimestampLayout is the accepted format for --timestamp (YYYYMMDDHHmm).
+const PackageTimestampLayout = "200601021504"
+
+type PackageBuildConfig struct {
+	Directory string
+	Timestamp string
+	Json      bool
+}
+
+type PackageBuildResult struct {
+	Digest string
+}
+
+// BuildPackage zips the contents of a directory and uploads it to the RWX
+// package registry, returning the digest assigned by the server.
+func (s Service) BuildPackage(cfg PackageBuildConfig) (result *PackageBuildResult, err error) {
+	start := time.Now()
+	defer func() {
+		s.recordTelemetry("package.build", map[string]any{
+			"duration_ms": time.Since(start).Milliseconds(),
+			"normalized":  cfg.Timestamp != "",
+			"success":     err == nil,
+		})
+	}()
+
+	directory := cfg.Directory
+	if directory == "" {
+		directory = "."
+	}
+
+	// An empty timestamp leaves each file's own modification time in place.
+	var modTime *time.Time
+	if cfg.Timestamp != "" {
+		parsed, parseErr := time.ParseInLocation(PackageTimestampLayout, cfg.Timestamp, time.UTC)
+		if parseErr != nil {
+			return nil, errors.Wrapf(parseErr, "invalid timestamp %q; expected format YYYYMMDDHHmm", cfg.Timestamp)
+		}
+		modTime = &parsed
+	}
+
+	info, err := os.Stat(directory)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to read %q", directory)
+	}
+	if !info.IsDir() {
+		return nil, errors.Errorf("%q is not a directory", directory)
+	}
+
+	archive, err := zipDirectory(directory, modTime)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to zip %q", directory)
+	}
+
+	uploaded, err := s.APIClient.UploadPackage(api.UploadPackageConfig{
+		FileName: "package.zip",
+		Contents: bytes.NewReader(archive),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to upload package")
+	}
+	if uploaded.Digest == "" {
+		return nil, errors.New("the RWX API did not return a package digest")
+	}
+
+	result = &PackageBuildResult{Digest: uploaded.Digest}
+
+	if cfg.Json {
+		if err := json.NewEncoder(s.Stdout).Encode(result); err != nil {
+			return nil, errors.Wrap(err, "unable to encode JSON output")
+		}
+	} else {
+		fmt.Fprintf(s.Stdout, "Uploaded package with digest: %s\n", result.Digest)
+	}
+
+	return result, nil
+}
+
+// zipDirectory recursively zips the contents of root, placing them at the root
+// of the archive. Entries are written in a stable order and, when modTime is
+// non-nil, every entry's modification time is normalized in the zip header
+// rather than on disk, so the archive is reproducible without mutating the
+// source tree.
+func zipDirectory(root string, modTime *time.Time) ([]byte, error) {
+	var relPaths []string
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+
+		relPaths = append(relPaths, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(relPaths)
+
+	buf := new(bytes.Buffer)
+	archive := zip.NewWriter(buf)
+
+	for _, rel := range relPaths {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+
+		// Stat rather than Lstat so symlinks are followed and stored as their
+		// target, matching `zip -r` without `-y`.
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, err
+		}
+		if !info.IsDir() && !info.Mode().IsRegular() {
+			continue
+		}
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return nil, err
+		}
+		header.Name = rel
+		if info.IsDir() {
+			header.Name += "/"
+			header.Method = zip.Store
+		} else {
+			header.Method = zip.Deflate
+		}
+		if modTime != nil {
+			header.Modified = *modTime
+		}
+
+		entry, err := archive.CreateHeader(header)
+		if err != nil {
+			return nil, err
+		}
+		if info.IsDir() {
+			continue
+		}
+
+		if err := copyFileInto(entry, path); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := archive.Close(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func copyFileInto(w io.Writer, path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = io.Copy(w, file)
+	return err
+}

--- a/internal/cli/service_package_build_test.go
+++ b/internal/cli/service_package_build_test.go
@@ -1,0 +1,257 @@
+package cli_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/cli"
+	"github.com/stretchr/testify/require"
+)
+
+// writePackageFixture creates a small package tree and returns its path.
+func writePackageFixture(t *testing.T, dir string) string {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "bin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "rwx-package.yml"), []byte("name: acme/thing\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".hidden"), []byte("hidden\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bin", "helper"), []byte("#!/bin/sh\n"), 0o755))
+
+	return dir
+}
+
+// readZip returns the uploaded archive's entries keyed by name.
+func readZip(t *testing.T, contents []byte) map[string]*zip.File {
+	t.Helper()
+
+	reader, err := zip.NewReader(bytes.NewReader(contents), int64(len(contents)))
+	require.NoError(t, err)
+
+	entries := make(map[string]*zip.File, len(reader.File))
+	for _, f := range reader.File {
+		entries[f.Name] = f
+	}
+	return entries
+}
+
+func TestService_BuildPackage(t *testing.T) {
+	t.Run("zips the directory contents at the archive root and reports the digest", func(t *testing.T) {
+		s := setupTest(t)
+		dir := writePackageFixture(t, filepath.Join(s.tmp, "pkg"))
+
+		var uploaded []byte
+		var uploadedName string
+		s.mockAPI.MockUploadPackage = func(cfg api.UploadPackageConfig) (*api.UploadPackageResult, error) {
+			var err error
+			uploaded, err = io.ReadAll(cfg.Contents)
+			require.NoError(t, err)
+			uploadedName = cfg.FileName
+			return &api.UploadPackageResult{Digest: "abc123"}, nil
+		}
+
+		result, err := s.service.BuildPackage(cli.PackageBuildConfig{Directory: dir})
+		require.NoError(t, err)
+		require.Equal(t, "abc123", result.Digest)
+		require.Equal(t, "package.zip", uploadedName)
+		require.Contains(t, s.mockStdout.String(), "Uploaded package with digest: abc123")
+
+		entries := readZip(t, uploaded)
+		require.Contains(t, entries, "rwx-package.yml")
+		require.Contains(t, entries, ".hidden")
+		require.Contains(t, entries, "bin/")
+		require.Contains(t, entries, "bin/helper")
+		// The directory name itself must not be part of the archive paths.
+		require.NotContains(t, entries, "pkg/rwx-package.yml")
+
+		body, err := entries["rwx-package.yml"].Open()
+		require.NoError(t, err)
+		defer body.Close()
+		contents, err := io.ReadAll(body)
+		require.NoError(t, err)
+		require.Equal(t, "name: acme/thing\n", string(contents))
+
+		require.Equal(t, os.FileMode(0o755), entries["bin/helper"].Mode().Perm(), "executable bit should be preserved")
+	})
+
+	t.Run("normalizes entry timestamps without touching the files on disk", func(t *testing.T) {
+		s := setupTest(t)
+		dir := writePackageFixture(t, filepath.Join(s.tmp, "pkg"))
+
+		file := filepath.Join(dir, "rwx-package.yml")
+		before, err := os.Stat(file)
+		require.NoError(t, err)
+
+		var uploaded []byte
+		s.mockAPI.MockUploadPackage = func(cfg api.UploadPackageConfig) (*api.UploadPackageResult, error) {
+			uploaded, err = io.ReadAll(cfg.Contents)
+			require.NoError(t, err)
+			return &api.UploadPackageResult{Digest: "abc123"}, nil
+		}
+
+		_, err = s.service.BuildPackage(cli.PackageBuildConfig{Directory: dir, Timestamp: "202601020304"})
+		require.NoError(t, err)
+
+		expected := time.Date(2026, 1, 2, 3, 4, 0, 0, time.UTC)
+		for name, entry := range readZip(t, uploaded) {
+			require.Equal(t, expected, entry.Modified.UTC(), "entry %s should carry the normalized timestamp", name)
+		}
+
+		after, err := os.Stat(file)
+		require.NoError(t, err)
+		require.Equal(t, before.ModTime(), after.ModTime(), "source files must not be modified on disk")
+	})
+
+	t.Run("produces byte-identical archives for the same input and timestamp", func(t *testing.T) {
+		s := setupTest(t)
+		dir := writePackageFixture(t, filepath.Join(s.tmp, "pkg"))
+
+		var archives [][]byte
+		s.mockAPI.MockUploadPackage = func(cfg api.UploadPackageConfig) (*api.UploadPackageResult, error) {
+			contents, err := io.ReadAll(cfg.Contents)
+			require.NoError(t, err)
+			archives = append(archives, contents)
+			return &api.UploadPackageResult{Digest: "abc123"}, nil
+		}
+
+		for range 2 {
+			_, err := s.service.BuildPackage(cli.PackageBuildConfig{Directory: dir, Timestamp: "202601020304"})
+			require.NoError(t, err)
+		}
+
+		require.Len(t, archives, 2)
+		require.Equal(t, archives[0], archives[1])
+	})
+
+	t.Run("preserves original modification times when no timestamp is given", func(t *testing.T) {
+		s := setupTest(t)
+		dir := writePackageFixture(t, filepath.Join(s.tmp, "pkg"))
+
+		modTime := time.Date(2020, 5, 6, 7, 8, 0, 0, time.UTC)
+		require.NoError(t, os.Chtimes(filepath.Join(dir, "rwx-package.yml"), modTime, modTime))
+
+		var uploaded []byte
+		s.mockAPI.MockUploadPackage = func(cfg api.UploadPackageConfig) (*api.UploadPackageResult, error) {
+			var err error
+			uploaded, err = io.ReadAll(cfg.Contents)
+			require.NoError(t, err)
+			return &api.UploadPackageResult{Digest: "abc123"}, nil
+		}
+
+		_, err := s.service.BuildPackage(cli.PackageBuildConfig{Directory: dir})
+		require.NoError(t, err)
+
+		// Zip stores timestamps at two-second granularity.
+		actual := readZip(t, uploaded)["rwx-package.yml"].Modified.UTC()
+		require.WithinDuration(t, modTime, actual, 2*time.Second)
+	})
+
+	t.Run("defaults to the current directory", func(t *testing.T) {
+		s := setupTest(t)
+		writePackageFixture(t, s.tmp)
+
+		var uploaded []byte
+		s.mockAPI.MockUploadPackage = func(cfg api.UploadPackageConfig) (*api.UploadPackageResult, error) {
+			var err error
+			uploaded, err = io.ReadAll(cfg.Contents)
+			require.NoError(t, err)
+			return &api.UploadPackageResult{Digest: "abc123"}, nil
+		}
+
+		_, err := s.service.BuildPackage(cli.PackageBuildConfig{})
+		require.NoError(t, err)
+		require.Contains(t, readZip(t, uploaded), "rwx-package.yml")
+	})
+
+	t.Run("writes JSON output when requested", func(t *testing.T) {
+		s := setupTest(t)
+		dir := writePackageFixture(t, filepath.Join(s.tmp, "pkg"))
+
+		s.mockAPI.MockUploadPackage = func(cfg api.UploadPackageConfig) (*api.UploadPackageResult, error) {
+			return &api.UploadPackageResult{Digest: "abc123"}, nil
+		}
+
+		_, err := s.service.BuildPackage(cli.PackageBuildConfig{Directory: dir, Json: true})
+		require.NoError(t, err)
+
+		var decoded struct{ Digest string }
+		require.NoError(t, json.Unmarshal([]byte(s.mockStdout.String()), &decoded))
+		require.Equal(t, "abc123", decoded.Digest)
+	})
+
+	t.Run("rejects a malformed timestamp before uploading", func(t *testing.T) {
+		s := setupTest(t)
+		dir := writePackageFixture(t, filepath.Join(s.tmp, "pkg"))
+
+		s.mockAPI.MockUploadPackage = func(cfg api.UploadPackageConfig) (*api.UploadPackageResult, error) {
+			t.Fatal("upload should not be attempted")
+			return nil, nil
+		}
+
+		_, err := s.service.BuildPackage(cli.PackageBuildConfig{Directory: dir, Timestamp: "2026-01-02"})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "YYYYMMDDHHmm")
+	})
+
+	t.Run("errors when the directory does not exist", func(t *testing.T) {
+		s := setupTest(t)
+
+		_, err := s.service.BuildPackage(cli.PackageBuildConfig{Directory: filepath.Join(s.tmp, "nope")})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unable to read")
+	})
+
+	t.Run("errors when the path is not a directory", func(t *testing.T) {
+		s := setupTest(t)
+		file := filepath.Join(s.tmp, "file.txt")
+		require.NoError(t, os.WriteFile(file, []byte("hi"), 0o644))
+
+		_, err := s.service.BuildPackage(cli.PackageBuildConfig{Directory: file})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "is not a directory")
+	})
+
+	t.Run("errors when the API returns no digest", func(t *testing.T) {
+		s := setupTest(t)
+		dir := writePackageFixture(t, filepath.Join(s.tmp, "pkg"))
+
+		s.mockAPI.MockUploadPackage = func(cfg api.UploadPackageConfig) (*api.UploadPackageResult, error) {
+			return &api.UploadPackageResult{}, nil
+		}
+
+		_, err := s.service.BuildPackage(cli.PackageBuildConfig{Directory: dir})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "did not return a package digest")
+	})
+
+	t.Run("records telemetry on success and failure", func(t *testing.T) {
+		s := setupTest(t)
+		dir := writePackageFixture(t, filepath.Join(s.tmp, "pkg"))
+
+		s.mockAPI.MockUploadPackage = func(cfg api.UploadPackageConfig) (*api.UploadPackageResult, error) {
+			return &api.UploadPackageResult{Digest: "abc123"}, nil
+		}
+
+		_, err := s.service.BuildPackage(cli.PackageBuildConfig{Directory: dir, Timestamp: "202601020304"})
+		require.NoError(t, err)
+
+		event := findEvent(s.drainEvents(), "package.build")
+		require.NotNil(t, event)
+		require.Equal(t, true, event.Props["success"])
+		require.Equal(t, true, event.Props["normalized"])
+
+		_, err = s.service.BuildPackage(cli.PackageBuildConfig{Directory: filepath.Join(s.tmp, "nope")})
+		require.Error(t, err)
+
+		event = findEvent(s.drainEvents(), "package.build")
+		require.NotNil(t, event)
+		require.Equal(t, false, event.Props["success"])
+		require.Equal(t, false, event.Props["normalized"])
+	})
+}

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -29,6 +29,7 @@ type API struct {
 	MockDeleteVar                               func(api.DeleteVarConfig) (*api.DeleteVarResult, error)
 	MockGetPackageVersions                      func() (*api.PackageVersionsResult, error)
 	MockGetPackageDocumentation                 func(string) (*api.PackageDocumentationResult, error)
+	MockUploadPackage                           func(api.UploadPackageConfig) (*api.UploadPackageResult, error)
 	MockInitiateDispatch                        func(api.InitiateDispatchConfig) (*api.InitiateDispatchResult, error)
 	MockGetDispatch                             func(api.GetDispatchConfig) (*api.GetDispatchResult, error)
 	MockGetDefaultBase                          func() (api.DefaultBaseResult, error)
@@ -225,6 +226,14 @@ func (c *API) GetPackageDocumentation(packageName string) (*api.PackageDocumenta
 	}
 
 	return nil, errors.New("MockGetPackageDocumentation was not configured")
+}
+
+func (c *API) UploadPackage(cfg api.UploadPackageConfig) (*api.UploadPackageResult, error) {
+	if c.MockUploadPackage != nil {
+		return c.MockUploadPackage(cfg)
+	}
+
+	return nil, errors.New("MockUploadPackage was not configured")
 }
 
 func (c *API) InitiateDispatch(cfg api.InitiateDispatchConfig) (*api.InitiateDispatchResult, error) {


### PR DESCRIPTION
Implements `rwx package build`, which zips a directory and uploads it to the RWX package registry, printing the content digest returned by the server.

```
rwx package build [directory] [--timestamp YYYYMMDDHHmm]
```

Ports the logic from [rwx-cloud/packages#338](https://github.com/rwx-cloud/packages/pull/338).

## Timestamps are optional and applied inline

The reference implementation shells out to `find "$DIRECTORY" -exec touch -t "$TIMESTAMP" {} \;` before zipping. This version instead sets each entry's modification time directly in the zip header via `archive/zip`, so the source tree is never mutated.

- `--timestamp` is optional. Omitting it preserves each file's real mtime.
- Entries are written in sorted order, so the same tree and timestamp always produce identical archive bytes.

## Changes

| File | Change |
|---|---|
| `internal/api/config.go` | `UploadPackageConfig` / `UploadPackageResult{Digest}` |
| `internal/api/client.go` | `Client.UploadPackage` — multipart `POST /mint/api/leaves`, form field `file`; non-2xx surfaces the response body |
| `internal/cli/interfaces.go`, `internal/mocks/api.go` | Interface + mock plumbing |
| `internal/cli/service_package_build.go` | `Service.BuildPackage` + deterministic `zipDirectory` |
| `cmd/rwx/packages.go` | `build` subcommand, `--timestamp` flag, `package` alias on the parent |

Contents land at the archive root (not nested under the directory name), matching `cd dir && zip -r … .`. Exec bits are preserved and symlinks are followed, matching `zip` without `-y`.

`rwx package build` works via a `package` alias on the existing `packages` group, so `rwx packages build` works too. The group's existing `Hidden` setting was left as-is.

## Verification

`go build ./...`, `go vet`, and `golangci-lint run ./...` are clean, and 17 new tests cover the three layers.

Verified live against the API:

```
# with --timestamp, before and after mutating every mtime on disk
Uploaded package with digest: 774dd467c210d622bffe18fe071c3ab2c97850be5f591f93350fdebe5242f85f
Uploaded package with digest: 774dd467c210d622bffe18fe071c3ab2c97850be5f591f93350fdebe5242f85f

# without --timestamp, before and after mutating every mtime on disk
Uploaded package with digest: 3a0c3206102d9a3444707ac1e292e7498f9b06d87cc3933f5937c7a830ab0d44
Uploaded package with digest: feb951c0951dca4214b6f917ba6bfb9b7cdfd43f77117a1f9458154691c491c4
```

An earlier attempt returned `mint-leaf.yml has a leaf name owned by 'rwx-cli-smoke', but request was made under organization 'rwx'`, confirming the server parses the uploaded archive layout correctly.

## For review

- **Digest is not byte-compatible with the shell package.** Go's zip writer differs from Info-ZIP, so the same source yields a different digest than `rwx/package` produces. Stable and correct, but a one-time cache miss for anything moving between the two.
- **UTC vs. local time.** `touch -t` treats the timestamp as local wall-clock; this parses it as UTC so digests don't vary by machine timezone. Worth confirming that's desired.
- **Build only, no publish.** Matches #338; `/mint/api/leaves/publish` is deliberately out of scope.
- The archive is buffered in memory — fine for packages, not for very large trees.
