### PR TITLE
Stop PascalCase conversion from mangling env keys in results JSON

### DIFF
--- a/cmd/rwx/results.go
+++ b/cmd/rwx/results.go
@@ -249,14 +249,28 @@ func MergeEnrichedResults(base, details map[string]any) map[string]any {
 	return merged
 }
 
+// opaqueValueKeys names the fields whose values are user-controlled maps rather
+// than wire schema: environment variable names, init parameters, and package
+// parameters. Their keys carry meaning, so rewriting them destroys data. For
+// example, pascalCase turns GIT_LFS_SKIP_SMUDGE into GITLFSSKIPSMUDGE.
+var opaqueValueKeys = map[string]bool{
+	"env":            true,
+	"init":           true,
+	"package_params": true,
+}
+
 // pascalCaseKeys recursively rewrites map keys from snake_case to PascalCase,
 // recursing into nested maps and slices. Non-map/slice values are returned
-// unchanged.
+// unchanged. Values under an opaqueValueKeys field are copied through untouched.
 func pascalCaseKeys(v any) any {
 	switch value := v.(type) {
 	case map[string]any:
 		result := make(map[string]any, len(value))
 		for key, nested := range value {
+			if opaqueValueKeys[key] {
+				result[pascalCase(key)] = nested
+				continue
+			}
 			result[pascalCase(key)] = pascalCaseKeys(nested)
 		}
 		return result

--- a/cmd/rwx/results_test.go
+++ b/cmd/rwx/results_test.go
@@ -98,6 +98,29 @@ func TestMergeEnrichedResults(t *testing.T) {
 		require.Equal(t, []any{map[string]any{"ID": "task_def456", "CompletedRuntimeSeconds": float64(250)}}, merged["Tasks"])
 	})
 
+	t.Run("leaves env, init, and package_params keys untouched", func(t *testing.T) {
+		base := map[string]any{"RunID": "abc123"}
+		details := map[string]any{
+			"init":           map[string]any{"commit-sha": "d603c0b", "deploy_target": "staging"},
+			"package_params": map[string]any{"github-token": "secret"},
+			"tasks": []any{
+				map[string]any{
+					"id":  "task_def456",
+					"env": map[string]any{"GIT_LFS_SKIP_SMUDGE": "1", "RWX_TASK_ID": "task_def456"},
+				},
+			},
+		}
+
+		merged := rwx.MergeEnrichedResults(base, details)
+
+		require.Equal(t, map[string]any{"commit-sha": "d603c0b", "deploy_target": "staging"}, merged["Init"])
+		require.Equal(t, map[string]any{"github-token": "secret"}, merged["PackageParams"])
+
+		task := merged["Tasks"].([]any)[0].(map[string]any)
+		require.Equal(t, "task_def456", task["ID"])
+		require.Equal(t, map[string]any{"GIT_LFS_SKIP_SMUDGE": "1", "RWX_TASK_ID": "task_def456"}, task["Env"])
+	})
+
 	t.Run("keeps the enriched id as ID alongside the base id keys", func(t *testing.T) {
 		base := map[string]any{"RunID": "abc123"}
 		details := map[string]any{"id": "abc123", "branch": "main"}


### PR DESCRIPTION
In converting server-provided JSON keys to PascalCase, the CLI was mangling `env`, `init`, and `package_params` sub-keys from their original values.

This PR defines some user-controlled keys (the three listed above) and skips re-casing for anything inside of them.

This is technically a breaking change, but also a bug fix, so will be a point release.