### PR TITLE
Normalize sandbox before execution and preserve changes after pull

### DIFF
--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -848,17 +848,6 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 		"rej_file_count": syncPullRejCount,
 	})
 
-	// Revert sandbox to clean HEAD so the next exec starts from a known state
-	var revertErr error
-	if localHeadForSync != "" {
-		revertErr = s.revertSandboxToGitState(localHeadForSync)
-	} else {
-		revertErr = s.revertSandbox()
-	}
-	if revertErr != nil {
-		fmt.Fprintf(s.Stderr, "Warning: failed to revert sandbox: %v\n", revertErr)
-	}
-
 	// Update session exec count and last exec time
 	execNow := time.Now().UTC()
 	if lockFile, lockErr := s.lockSandboxStorageWithInfo(cfg.Json); lockErr == nil {
@@ -1390,44 +1379,6 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 	return files, patchBytes, nil
 }
 
-// revertSandbox resets the sandbox working tree to a clean HEAD state.
-// This runs after pull so the next exec starts from a known clean baseline.
-func (s Service) revertSandbox() error {
-	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
-
-	exitCode, err := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand("/usr/bin/git checkout . >/dev/null 2>&1; /usr/bin/git clean -fd >/dev/null 2>&1; /usr/bin/git update-ref refs/rwx-sync HEAD 2>/dev/null"))
-
-	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
-
-	if err != nil {
-		return errors.Wrap(err, "failed to revert sandbox")
-	}
-	if exitCode != 0 {
-		return fmt.Errorf("failed to revert sandbox (exit code %d)", exitCode)
-	}
-	return nil
-}
-
-func (s Service) revertSandboxToGitState(localHead string) error {
-	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
-
-	if err := s.checkoutSandboxHead(localHead); err != nil {
-		_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
-		return err
-	}
-
-	exitCode, err := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand("/usr/bin/git clean -fd >/dev/null 2>&1; /usr/bin/git update-ref refs/rwx-sync HEAD 2>/dev/null"))
-	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
-	if err != nil {
-		return errors.Wrap(err, "failed to clean sandbox after reset")
-	}
-	if exitCode != 0 {
-		return fmt.Errorf("failed to clean sandbox after reset (exit code %d)", exitCode)
-	}
-
-	return nil
-}
-
 func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHead string, connInfo *api.SandboxConnectionInfo) (int, error) {
 	if localHead == "" {
 		return 0, fmt.Errorf("sandbox sync requires a git repository with a valid HEAD")
@@ -1458,7 +1409,22 @@ func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHe
 	}
 
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")
-	if err := s.checkoutSandboxHead(localHead); err != nil {
+	head := quoteShellArg(localHead)
+	branch := s.GitClient.GetBranch()
+	gitCommand := "GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/bin/false SSH_ASKPASS=/bin/false /usr/bin/git"
+	var checkoutCommand string
+	if branch == "" {
+		checkoutCommand = fmt.Sprintf("%s checkout -f --detach %s >/dev/null 2>&1 && %s reset --hard %s >/dev/null 2>&1", gitCommand, head, gitCommand, head)
+	} else {
+		checkoutCommand = fmt.Sprintf("%s checkout -f -B %s %s >/dev/null 2>&1 && %s reset --hard %s >/dev/null 2>&1", gitCommand, quoteShellArg(branch), head, gitCommand, head)
+	}
+	checkoutExitCode, checkoutErr := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand(checkoutCommand))
+	if checkoutErr != nil {
+		checkoutErr = errors.Wrap(checkoutErr, "failed to reset sandbox to local git state")
+	} else if checkoutExitCode != 0 {
+		checkoutErr = fmt.Errorf("failed to reset sandbox to local git state (exit code %d)", checkoutExitCode)
+	}
+	if checkoutErr != nil {
 		// Prefer the more actionable "missing LFS objects" error, but ignore a
 		// failure of the check itself so it can't mask the checkout error.
 		lfsMissing, _ := s.checkSandboxLFSObjects(localHead)
@@ -1467,13 +1433,30 @@ func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHe
 			syncPushErr = lfsMissing
 			return patchBytes, syncPushErr
 		}
-		syncPushErr = err
+		syncPushErr = checkoutErr
 		return patchBytes, syncPushErr
 	}
 	if err := s.verifySandboxLFSObjects(localHead); err != nil {
 		_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 		syncPushErr = err
 		return patchBytes, syncPushErr
+	}
+	// A reused sandbox may still contain untracked files from the previous exec.
+	// Remove them before applying local dirty state so the command starts from a
+	// known baseline. A new sandbox may contain files prepared by its setup tasks,
+	// so preserve those on its first exec.
+	if !isNewSandbox {
+		exitCode, cleanErr := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand("/usr/bin/git clean -fd >/dev/null 2>&1"))
+		if cleanErr != nil {
+			_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
+			syncPushErr = errors.Wrap(cleanErr, "failed to clean sandbox before sync")
+			return patchBytes, syncPushErr
+		}
+		if exitCode != 0 {
+			_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
+			syncPushErr = fmt.Errorf("failed to clean sandbox before sync (exit code %d)", exitCode)
+			return patchBytes, syncPushErr
+		}
 	}
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_end__")
 
@@ -1764,27 +1747,6 @@ func sandboxGitPushOptions(localHead string, connInfo *api.SandboxConnectionInfo
 func (s Service) sandboxHasCommit(sha string) bool {
 	exitCode, err := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand(fmt.Sprintf("/usr/bin/git cat-file -e %s^{commit} >/dev/null 2>&1", quoteShellArg(sha))))
 	return err == nil && exitCode == 0
-}
-
-func (s Service) checkoutSandboxHead(localHead string) error {
-	head := quoteShellArg(localHead)
-	branch := s.GitClient.GetBranch()
-	git := "GIT_TERMINAL_PROMPT=0 GIT_ASKPASS=/bin/false SSH_ASKPASS=/bin/false /usr/bin/git"
-	var cmd string
-	if branch == "" {
-		cmd = fmt.Sprintf("%s checkout -f --detach %s >/dev/null 2>&1 && %s reset --hard %s >/dev/null 2>&1", git, head, git, head)
-	} else {
-		cmd = fmt.Sprintf("%s checkout -f -B %s %s >/dev/null 2>&1 && %s reset --hard %s >/dev/null 2>&1", git, quoteShellArg(branch), head, git, head)
-	}
-
-	exitCode, err := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand(cmd))
-	if err != nil {
-		return errors.Wrap(err, "failed to reset sandbox to local git state")
-	}
-	if exitCode != 0 {
-		return fmt.Errorf("failed to reset sandbox to local git state (exit code %d)", exitCode)
-	}
-	return nil
 }
 
 func (s Service) applyDirtyPatchesToSandbox(patches git.DirtyPatches) error {

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1337,13 +1337,15 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.Contains(t, err.Error(), "git apply failed")
 	})
 
-	t.Run("syncs changes and reverts sandbox after pull", func(t *testing.T) {
+	t.Run("resets before command and leaves sandbox state after pull", func(t *testing.T) {
 		setup := setupTest(t)
 
 		runID := "run-sync-123"
 		address := "192.168.1.1:22"
+		sandboxPatch := "diff --git a/generated.txt b/generated.txt\nnew file mode 100644\nindex 0000000..3e75765\n--- /dev/null\n+++ b/generated.txt\n@@ -0,0 +1 @@\n+generated\n"
 		var commandOrder []string
 		var stdinCommandOrder []string
+		pulledPatchApplied := false
 
 		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
 			return api.SandboxConnectionInfo{
@@ -1368,12 +1370,21 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		}
 
 		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
+			commandOrder = append(commandOrder, cmd)
+			if isSandboxPullDiffCommand(cmd) {
+				return 0, sandboxPatch, nil
+			}
 			return 0, "", nil
 		}
 
 		setup.mockSSH.MockExecuteCommandWithStdinAndCombinedOutput = func(command string, stdin io.Reader) (int, string, error) {
 			stdinCommandOrder = append(stdinCommandOrder, command)
 			return 0, "", nil
+		}
+		setup.mockGit.MockApplyPatch = func(patch []byte) *exec.Cmd {
+			require.Equal(t, sandboxPatch, string(patch))
+			pulledPatchApplied = true
+			return exec.Command("true")
 		}
 
 		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
@@ -1386,20 +1397,32 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, runID, result.RunID)
 		require.Equal(t, 0, result.ExitCode)
+		require.Equal(t, []string{"generated.txt"}, result.PulledFiles)
+		require.True(t, pulledPatchApplied, "command-created changes should be applied locally")
 		require.Equal(t, "__rwx_sandbox_lock_requested__", commandOrder[0])
 		require.Contains(t, commandOrder, "__rwx_sandbox_sync_start__")
 		require.Contains(t, commandOrder, "echo hello")
 		// git apply uses stdin method
 		require.GreaterOrEqual(t, len(stdinCommandOrder), 1)
 		requireSandboxWorktreeRootCommand(t, stdinCommandOrder[0], "/usr/bin/git apply --allow-empty -")
-		// Sandbox should be reverted back to local git state after pull.
-		revertIdx := -1
+		// A reused sandbox should be normalized before the user command, then left
+		// untouched after its changes have been pulled back.
+		cleanIndexes := []int{}
+		execIdx := slices.Index(commandOrder, "echo hello")
+		pullIdx := slices.IndexFunc(commandOrder, isSandboxPullDiffCommand)
 		for i, cmd := range commandOrder {
-			if strings.Contains(cmd, "git clean -fd") && strings.Contains(cmd, "update-ref refs/rwx-sync HEAD") {
-				revertIdx = i
+			if strings.Contains(cmd, "/usr/bin/git clean -fd >/dev/null 2>&1") {
+				requireSandboxWorktreeRootCommand(t, cmd, "/usr/bin/git clean -fd >/dev/null 2>&1")
+				cleanIndexes = append(cleanIndexes, i)
 			}
 		}
-		require.NotEqual(t, -1, revertIdx, "sandbox should be reverted after pull")
+		require.Len(t, cleanIndexes, 1, "sandbox should be cleaned exactly once")
+		require.Less(t, cleanIndexes[0], execIdx, "sandbox should be cleaned before the user command")
+		require.Less(t, execIdx, pullIdx, "sandbox changes should be pulled after the user command")
+		for _, cmd := range commandOrder[pullIdx+1:] {
+			require.NotContains(t, cmd, "git clean", "sandbox should not be cleaned after pull")
+			require.NotContains(t, cmd, "git checkout", "sandbox should not be reset after pull")
+		}
 
 		// Snapshot and reset git commands must be wrapped in sync markers
 		// so they don't appear in task logs. Find the sync block that contains them.
@@ -1881,6 +1904,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.NotEqual(t, -1, applyIndex)
 		require.NotEqual(t, -1, snapshotIndex)
 		require.Less(t, cleanIndex, applyIndex)
+		require.Equal(t, -1, sandboxCommandIndex(order, "/usr/bin/git clean -fd >/dev/null 2>&1"), "first exec should preserve setup-created files")
 		require.Contains(t, order[snapshotIndex], "/usr/bin/git update-index --add --remove --")
 		require.Contains(t, order[snapshotIndex], "dir with space/quote")
 		require.Contains(t, order[snapshotIndex], "file.txt")
@@ -2780,7 +2804,7 @@ func TestService_ExecSandbox_Pull(t *testing.T) {
 		require.Equal(t, 1, len(result.PulledFiles))
 	})
 
-	t.Run("returns pull errors without cleaning sandbox", func(t *testing.T) {
+	t.Run("pull errors leave sandbox changes intact", func(t *testing.T) {
 		setup := setupTest(t)
 
 		runID := "run-pull-err-123"
@@ -2799,14 +2823,15 @@ func TestService_ExecSandbox_Pull(t *testing.T) {
 			return nil
 		}
 
+		var commandOrder []string
 		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
+			commandOrder = append(commandOrder, cmd)
 			if strings.Contains(cmd, "git ls-files") {
 				return 1, "fatal: not a git repository", nil // Pull fails
 			}
 			return 0, "", nil
 		}
 
-		var commandOrder []string
 		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
 			commandOrder = append(commandOrder, cmd)
 			if strings.Contains(cmd, "rev-parse --verify -q refs/rwx-sync") {
@@ -2825,8 +2850,19 @@ func TestService_ExecSandbox_Pull(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, result)
 		require.Contains(t, err.Error(), "failed to pull changes from sandbox")
-		commandText := strings.Join(commandOrder, "\n")
-		require.NotContains(t, commandText, "git update-ref refs/rwx-sync HEAD 2>/dev/null")
+
+		cleanIdx := sandboxCommandIndex(commandOrder, "/usr/bin/git clean -fd >/dev/null 2>&1")
+		execIdx := slices.Index(commandOrder, "echo hello")
+		pullIdx := slices.IndexFunc(commandOrder, func(cmd string) bool {
+			return strings.Contains(cmd, "git ls-files") && strings.Contains(cmd, "--others")
+		})
+		require.NotEqual(t, -1, cleanIdx, "sandbox should still be cleaned before exec")
+		require.Less(t, cleanIdx, execIdx)
+		require.Less(t, execIdx, pullIdx)
+		for _, cmd := range commandOrder[pullIdx+1:] {
+			require.NotContains(t, cmd, "git clean", "pull failure must not trigger post-command cleanup")
+			require.NotContains(t, cmd, "git checkout", "pull failure must not trigger post-command reset")
+		}
 	})
 
 }


### PR DESCRIPTION
Closes RWX-1628

With this change `sandbox exec` now resets and cleans the sandbox before running a command, instead of after pulling the command’s changes locally.

This keeps each exec based on a known local state while leaving command-generated files in the sandbox afterward.

This is a precursor to the sandbox preview work.

A running preview server can continue seeing generated files (e.g a rails migration) after the CLI pulls them back locally. The next exec performs normalization before it runs, preventing stale sandbox state from leaking into subsequent commands.

Planning to encourage everyone to use this a bit before release. I've been testing it locally and so far it's working as intended.

<details>
<summary>Manual test script</summary>

```
set -euo pipefail

RWX_TEST="/tmp/rwx-preserve-test.$$"
SANDBOX_CONFIG="$PWD/test/integration/definitions/sandbox.yml"
TEST_SHA="$(git rev-parse HEAD)"
TEST_FILE="sandbox-preserve-probe.txt"
RUN_ID="${RUN_ID:-}"
STARTED_SANDBOX=0

if test -e "$TEST_FILE"; then
  echo "Refusing to overwrite existing $TEST_FILE"
  return 1 2>/dev/null || exit 1
fi

cleanup() {
  status=$?
  if test "$STARTED_SANDBOX" = 1; then
    "$RWX_TEST" sandbox stop --id "$RUN_ID" || true
  fi
  rm -f "$TEST_FILE" "$RWX_TEST"
  exit "$status"
}
trap cleanup EXIT

echo "Building CLI..."
go build -o "$RWX_TEST" ./cmd/rwx

if test -z "$RUN_ID"; then
  echo "Starting sandbox..."
  START_JSON=$(
    "$RWX_TEST" sandbox start "$SANDBOX_CONFIG" \
      --init "ref=$TEST_SHA" \
      --wait \
      --json
  )
  RUN_ID="$(echo "$START_JSON" | jq -r .RunID)"
  STARTED_SANDBOX=1
fi

echo "Using sandbox: $RUN_ID"

echo "Creating file during exec..."
"$RWX_TEST" sandbox exec --id "$RUN_ID" -- sh -c \
  'printf "generated by sandbox exec\n" > sandbox-preserve-probe.txt; nohup sh -c "sleep 5; if test -f sandbox-preserve-probe.txt; then echo present; else echo missing; fi > /tmp/sandbox-preserve-result" >/tmp/sandbox-preserve-probe.log 2>&1 </dev/null &'

grep -qx "generated by sandbox exec" "$TEST_FILE"
echo "PASS: command-created file was pulled locally"

sleep 7

"$RWX_TEST" sandbox exec --id "$RUN_ID" -- sh -c \
  'result=$(cat /tmp/sandbox-preserve-result); echo "Post-pull state: $result"; test "$result" = present'

echo "PASS: file remained in the sandbox after pull"

rm -f "$TEST_FILE"

"$RWX_TEST" sandbox exec --id "$RUN_ID" -- sh -c \
  'if test -e sandbox-preserve-probe.txt; then echo "FAIL: file survived pre-exec cleanup"; exit 1; else echo "PASS: file was removed before the next command"; fi'

echo
echo "All sandbox cleanup-ordering tests passed."
```

</details>

<details>
<summary>AI</summary>

## Summary

- Reset reused sandboxes before executing commands.
- Preserve sandbox changes after pulling them back instead of reverting afterward.
- Keep setup-created files intact on a sandbox’s first execution.
- Update sync and pull tests to verify command ordering and state preservation.

## Testing

- Updated unit tests for sandbox sync and pull behavior.
</details>