### PR TITLE
Add --max-duration to rwx ssh

### DIFF
--- a/cmd/rwx/ssh.go
+++ b/cmd/rwx/ssh.go
@@ -7,6 +7,7 @@ import (
 )
 
 var SSHSessionName string
+var SSHSessionMaxDuration string
 
 var sshCmd = &cobra.Command{
 	GroupID: "execution",
@@ -16,8 +17,9 @@ var sshCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return service.AttachSSHSession(cli.AttachSSHSessionConfig{
-			TaskID: args[0],
-			Name:   SSHSessionName,
+			TaskID:      args[0],
+			Name:        SSHSessionName,
+			MaxDuration: SSHSessionMaxDuration,
 		})
 	},
 	Short: "Attach and connect to a running task",
@@ -26,4 +28,5 @@ var sshCmd = &cobra.Command{
 
 func init() {
 	sshCmd.Flags().StringVar(&SSHSessionName, "name", "", "name the attached SSH session")
+	sshCmd.Flags().StringVar(&SSHSessionMaxDuration, "max-duration", "", "set how long the attached SSH session can run (for example, 1h)")
 }

--- a/cmd/rwx/ssh_test.go
+++ b/cmd/rwx/ssh_test.go
@@ -12,6 +12,7 @@ func TestSSHCommand(t *testing.T) {
 	require.Equal(t, "ssh [flags] [task-id]", cmd.Use)
 	require.Equal(t, "execution", cmd.GroupID)
 	require.NotNil(t, cmd.Flags().Lookup("name"), "rwx ssh should expose the --name flag")
+	require.NotNil(t, cmd.Flags().Lookup("max-duration"), "rwx ssh should expose the --max-duration flag")
 
 	require.NoError(t, cmd.Args(cmd, []string{"task-123"}))
 	require.Error(t, cmd.Args(cmd, nil))

--- a/internal/api/debug_sessions.go
+++ b/internal/api/debug_sessions.go
@@ -11,8 +11,9 @@ import (
 )
 
 type AttachDebugSessionConfig struct {
-	TaskID string
-	Name   string
+	TaskID      string
+	Name        string
+	MaxDuration string
 }
 
 type DebugSessionAttachmentError struct {
@@ -63,8 +64,12 @@ func (c Client) AttachDebugSession(cfg AttachDebugSessionConfig) (DebugSessionSu
 	}
 
 	requestBody := struct {
-		Name string `json:"name,omitempty"`
-	}{Name: cfg.Name}
+		Name        string `json:"name,omitempty"`
+		MaxDuration string `json:"max_duration,omitempty"`
+	}{
+		Name:        cfg.Name,
+		MaxDuration: cfg.MaxDuration,
+	}
 	encodedBody, err := json.Marshal(requestBody)
 	if err != nil {
 		return DebugSessionSummary{}, errors.Wrap(err, "unable to encode as JSON")

--- a/internal/api/debug_sessions_test.go
+++ b/internal/api/debug_sessions_test.go
@@ -13,6 +13,37 @@ import (
 )
 
 func TestAPIClient_AttachDebugSession(t *testing.T) {
+	t.Run("includes a maximum duration", func(t *testing.T) {
+		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			var body map[string]any
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			require.Equal(t, map[string]any{
+				"name":         "shell",
+				"max_duration": "1h",
+			}, body)
+
+			return &http.Response{
+				Status:     "202 Accepted",
+				StatusCode: http.StatusAccepted,
+				Body: io.NopCloser(strings.NewReader(`{
+					"debug_session": {
+						"id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+						"name": "shell",
+						"status": "starting"
+					}
+				}`)),
+			}, nil
+		})
+
+		_, err := c.AttachDebugSession(api.AttachDebugSessionConfig{
+			TaskID:      "task-123",
+			Name:        "shell",
+			MaxDuration: "1h",
+		})
+
+		require.NoError(t, err)
+	})
+
 	t.Run("attaches a named session", func(t *testing.T) {
 		c := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
 			require.Equal(t, http.MethodPost, req.Method)

--- a/internal/cli/service_ssh.go
+++ b/internal/cli/service_ssh.go
@@ -13,6 +13,7 @@ const defaultSSHSessionPollInterval = time.Second
 type AttachSSHSessionConfig struct {
 	TaskID       string
 	Name         string
+	MaxDuration  string
 	PollInterval time.Duration
 }
 
@@ -29,8 +30,9 @@ func (s Service) AttachSSHSession(cfg AttachSSHSessionConfig) error {
 	}
 
 	session, err := s.APIClient.AttachDebugSession(api.AttachDebugSessionConfig{
-		TaskID: cfg.TaskID,
-		Name:   cfg.Name,
+		TaskID:      cfg.TaskID,
+		Name:        cfg.Name,
+		MaxDuration: cfg.MaxDuration,
 	})
 	if err != nil {
 		return err

--- a/internal/cli/service_ssh_test.go
+++ b/internal/cli/service_ssh_test.go
@@ -18,6 +18,7 @@ func TestService_AttachSSHSession(t *testing.T) {
 		s.mockAPI.MockAttachDebugSession = func(cfg api.AttachDebugSessionConfig) (api.DebugSessionSummary, error) {
 			require.Equal(t, "task-123", cfg.TaskID)
 			require.Equal(t, "shell", cfg.Name)
+			require.Equal(t, "1h", cfg.MaxDuration)
 			return api.DebugSessionSummary{ID: sessionID, Name: "shell", Status: "starting"}, nil
 		}
 
@@ -54,6 +55,7 @@ func TestService_AttachSSHSession(t *testing.T) {
 		err := s.service.AttachSSHSession(cli.AttachSSHSessionConfig{
 			TaskID:       "task-123",
 			Name:         "shell",
+			MaxDuration:  "1h",
 			PollInterval: time.Millisecond,
 		})
 


### PR DESCRIPTION
A redo of #603. This time, with a much more obviously named option of `--max-duration` to reflect that it's the maximum amount of time your ssh session will be alive.