### PR TITLE
Add sandbox push and background process support

### DIFF
--- a/.rwx/integration-sandbox.yml
+++ b/.rwx/integration-sandbox.yml
@@ -46,7 +46,7 @@ tasks:
   - key: git
     run: |
       sudo apt-get update
-      sudo apt-get install git git-lfs
+      sudo apt-get install git git-lfs curl
       sudo apt-get clean
 
       git config --global user.name "Testing"

--- a/cmd/rwx/root.go
+++ b/cmd/rwx/root.go
@@ -86,8 +86,9 @@ var (
 			}
 
 			service, err = cli.NewService(cli.Config{
-				APIClient: c,
-				SSHClient: new(ssh.Client),
+				APIClient:        c,
+				SSHClient:        new(ssh.Client),
+				SSHTunnelManager: ssh.NewTunnelManager(),
 				GitClient: &git.Client{
 					Binary: "git",
 					Dir:    dir,

--- a/cmd/rwx/sandbox.go
+++ b/cmd/rwx/sandbox.go
@@ -246,7 +246,7 @@ var sandboxSyncCmd = &cobra.Command{
 	Hidden: true,
 	Args:   cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return requireAccessToken()
+		return requireExperimentalSandboxAccess()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		useJson := useJsonOutput()
@@ -279,7 +279,7 @@ Local changes are synced before the process starts. When --port is provided,
 the port is forwarded locally and its localhost URL is printed.`,
 	Args: cobra.ArbitraryArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return requireAccessToken()
+		return requireExperimentalSandboxAccess()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dashIndex := cmd.ArgsLenAtDash()
@@ -321,7 +321,7 @@ var sandboxBackgroundRestartCmd = &cobra.Command{
 	Hidden: true,
 	Args:   cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return requireAccessToken()
+		return requireExperimentalSandboxAccess()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		useJson := useJsonOutput()
@@ -350,7 +350,7 @@ var sandboxBackgroundStopCmd = &cobra.Command{
 	Hidden: true,
 	Args:   cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return requireAccessToken()
+		return requireExperimentalSandboxAccess()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		useJson := useJsonOutput()
@@ -379,7 +379,7 @@ var sandboxBackgroundLogsCmd = &cobra.Command{
 	Hidden: true,
 	Args:   cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return requireAccessToken()
+		return requireExperimentalSandboxAccess()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		useJson := useJsonOutput()
@@ -565,6 +565,13 @@ var (
 	sandboxBackgroundFollow    bool
 	sandboxInitParams          []string
 )
+
+func requireExperimentalSandboxAccess() error {
+	if os.Getenv("EXPERIMENTAL") != "true" {
+		return fmt.Errorf("this command is experimental; set EXPERIMENTAL=true to use it")
+	}
+	return requireAccessToken()
+}
 
 func init() {
 	sandboxCmd.AddCommand(sandboxInitCmd)

--- a/cmd/rwx/sandbox.go
+++ b/cmd/rwx/sandbox.go
@@ -296,6 +296,7 @@ the port is forwarded locally and its localhost URL is printed.`,
 			Name:       sandboxBackgroundName,
 			TargetPort: sandboxBackgroundPort,
 			LocalPort:  sandboxBackgroundLocalPort,
+			Scheme:     sandboxBackgroundScheme,
 			RunID:      sandboxRunID,
 			Json:       useJson,
 		})
@@ -560,6 +561,7 @@ var (
 	sandboxBackgroundName      string
 	sandboxBackgroundPort      int
 	sandboxBackgroundLocalPort int
+	sandboxBackgroundScheme    string
 	sandboxBackgroundFollow    bool
 	sandboxInitParams          []string
 )
@@ -603,6 +605,7 @@ func init() {
 	sandboxBackgroundCmd.PersistentFlags().StringVar(&sandboxBackgroundName, "name", "", "Name of the managed sandbox process")
 	sandboxBackgroundCmd.Flags().IntVar(&sandboxBackgroundPort, "port", 0, "Sandbox port to forward locally")
 	sandboxBackgroundCmd.Flags().IntVar(&sandboxBackgroundLocalPort, "local-port", 0, "Local port to use (default: allocate or reuse one)")
+	sandboxBackgroundCmd.Flags().StringVar(&sandboxBackgroundScheme, "scheme", "", "URL scheme for the forwarded port: http or https (default: http)")
 	sandboxBackgroundLogsCmd.Flags().BoolVarP(&sandboxBackgroundFollow, "follow", "f", false, "Follow log output")
 	if err := sandboxBackgroundCmd.MarkPersistentFlagRequired("name"); err != nil {
 		panic(err)

--- a/cmd/rwx/sandbox.go
+++ b/cmd/rwx/sandbox.go
@@ -240,9 +240,9 @@ CONFIG FILE
 	},
 }
 
-var sandboxSyncCmd = &cobra.Command{
-	Use:    "sync",
-	Short:  "Sync local changes to a sandbox",
+var sandboxPushCmd = &cobra.Command{
+	Use:    "push",
+	Short:  "Push local changes to a sandbox",
 	Hidden: true,
 	Args:   cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -577,7 +577,7 @@ func init() {
 	sandboxCmd.AddCommand(sandboxInitCmd)
 	sandboxCmd.AddCommand(sandboxStartCmd)
 	sandboxCmd.AddCommand(sandboxExecCmd)
-	sandboxCmd.AddCommand(sandboxSyncCmd)
+	sandboxCmd.AddCommand(sandboxPushCmd)
 	sandboxBackgroundCmd.AddCommand(sandboxBackgroundRestartCmd)
 	sandboxBackgroundCmd.AddCommand(sandboxBackgroundStopCmd)
 	sandboxBackgroundCmd.AddCommand(sandboxBackgroundLogsCmd)
@@ -604,8 +604,8 @@ func init() {
 	sandboxExecCmd.Flags().BoolVar(&sandboxReset, "reset", false, "Reset the sandbox before executing")
 	sandboxExecCmd.Flags().StringArrayVar(&sandboxInitParams, "init", []string{}, "initialization parameters for the sandbox run, available in the `init` context. Can be specified multiple times")
 
-	// sync flags
-	sandboxSyncCmd.Flags().StringVar(&sandboxRunID, "id", "", "Use specific run ID")
+	// push flags
+	sandboxPushCmd.Flags().StringVar(&sandboxRunID, "id", "", "Use specific run ID")
 
 	// background flags
 	sandboxBackgroundCmd.PersistentFlags().StringVar(&sandboxRunID, "id", "", "Use specific run ID")

--- a/cmd/rwx/sandbox.go
+++ b/cmd/rwx/sandbox.go
@@ -567,8 +567,8 @@ var (
 )
 
 func requireExperimentalSandboxAccess() error {
-	if os.Getenv("EXPERIMENTAL") != "true" {
-		return fmt.Errorf("this command is experimental; set EXPERIMENTAL=true to use it")
+	if os.Getenv("RWX_EXPERIMENTAL") != "true" {
+		return fmt.Errorf("this command is experimental; set RWX_EXPERIMENTAL=true to use it")
 	}
 	return requireAccessToken()
 }

--- a/cmd/rwx/sandbox.go
+++ b/cmd/rwx/sandbox.go
@@ -240,6 +240,168 @@ CONFIG FILE
 	},
 }
 
+var sandboxSyncCmd = &cobra.Command{
+	Use:    "sync",
+	Short:  "Sync local changes to a sandbox",
+	Hidden: true,
+	Args:   cobra.NoArgs,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return requireAccessToken()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		useJson := useJsonOutput()
+		result, err := service.SyncSandbox(cli.SyncSandboxConfig{
+			RunID: sandboxRunID,
+			Json:  useJson,
+		})
+		if err != nil {
+			return err
+		}
+
+		if useJson {
+			jsonOutput, err := json.Marshal(result)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(jsonOutput))
+		}
+
+		return nil
+	},
+}
+
+var sandboxBackgroundCmd = &cobra.Command{
+	Use:    "background -- <command>",
+	Short:  "Start or replace a sandbox background process",
+	Hidden: true,
+	Long: `Start or replace a named managed process in an existing sandbox.
+Local changes are synced before the process starts. When --port is provided,
+the port is forwarded locally and its localhost URL is printed.`,
+	Args: cobra.ArbitraryArgs,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return requireAccessToken()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dashIndex := cmd.ArgsLenAtDash()
+		if dashIndex < 0 || dashIndex >= len(args) {
+			return fmt.Errorf("No command specified. Usage: rwx sandbox background -- <command>")
+		}
+		if dashIndex != 0 {
+			return fmt.Errorf("Unexpected arguments before '--'. Usage: rwx sandbox background -- <command>")
+		}
+
+		useJson := useJsonOutput()
+		result, err := service.BackgroundSandbox(cli.BackgroundSandboxConfig{
+			Command:    args[dashIndex:],
+			Name:       sandboxBackgroundName,
+			TargetPort: sandboxBackgroundPort,
+			LocalPort:  sandboxBackgroundLocalPort,
+			RunID:      sandboxRunID,
+			Json:       useJson,
+		})
+		if err != nil {
+			return err
+		}
+
+		if useJson {
+			output, err := json.Marshal(result)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(os.Stdout, string(output))
+		}
+		return nil
+	},
+}
+
+var sandboxBackgroundRestartCmd = &cobra.Command{
+	Use:    "restart",
+	Short:  "Sync changes and restart a sandbox background process",
+	Hidden: true,
+	Args:   cobra.NoArgs,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return requireAccessToken()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		useJson := useJsonOutput()
+		result, err := service.RestartSandboxBackground(cli.SandboxBackgroundConfig{
+			Name:  sandboxBackgroundName,
+			RunID: sandboxRunID,
+			Json:  useJson,
+		})
+		if err != nil {
+			return err
+		}
+		if useJson {
+			output, err := json.Marshal(result)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(os.Stdout, string(output))
+		}
+		return nil
+	},
+}
+
+var sandboxBackgroundStopCmd = &cobra.Command{
+	Use:    "stop",
+	Short:  "Stop a sandbox background process",
+	Hidden: true,
+	Args:   cobra.NoArgs,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return requireAccessToken()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		useJson := useJsonOutput()
+		result, err := service.StopSandboxBackground(cli.SandboxBackgroundConfig{
+			Name:  sandboxBackgroundName,
+			RunID: sandboxRunID,
+			Json:  useJson,
+		})
+		if err != nil {
+			return err
+		}
+		if useJson {
+			output, err := json.Marshal(result)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(os.Stdout, string(output))
+		}
+		return nil
+	},
+}
+
+var sandboxBackgroundLogsCmd = &cobra.Command{
+	Use:    "logs",
+	Short:  "Show logs for a sandbox background process",
+	Hidden: true,
+	Args:   cobra.NoArgs,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return requireAccessToken()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		useJson := useJsonOutput()
+		result, err := service.LogsSandboxBackground(cli.SandboxBackgroundLogsConfig{
+			Name:   sandboxBackgroundName,
+			RunID:  sandboxRunID,
+			Json:   useJson,
+			Follow: sandboxBackgroundFollow,
+		})
+		if err != nil {
+			return err
+		}
+		if useJson {
+			output, err := json.Marshal(result)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(os.Stdout, string(output))
+		}
+		return nil
+	},
+}
+
 var sandboxListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List sandbox sessions with status",
@@ -389,19 +551,28 @@ var sandboxResetCmd = &cobra.Command{
 }
 
 var (
-	sandboxRunID      string
-	sandboxStopAll    bool
-	sandboxRwxDir     string
-	sandboxOpen       bool
-	sandboxWait       bool
-	sandboxReset      bool
-	sandboxInitParams []string
+	sandboxRunID               string
+	sandboxStopAll             bool
+	sandboxRwxDir              string
+	sandboxOpen                bool
+	sandboxWait                bool
+	sandboxReset               bool
+	sandboxBackgroundName      string
+	sandboxBackgroundPort      int
+	sandboxBackgroundLocalPort int
+	sandboxBackgroundFollow    bool
+	sandboxInitParams          []string
 )
 
 func init() {
 	sandboxCmd.AddCommand(sandboxInitCmd)
 	sandboxCmd.AddCommand(sandboxStartCmd)
 	sandboxCmd.AddCommand(sandboxExecCmd)
+	sandboxCmd.AddCommand(sandboxSyncCmd)
+	sandboxBackgroundCmd.AddCommand(sandboxBackgroundRestartCmd)
+	sandboxBackgroundCmd.AddCommand(sandboxBackgroundStopCmd)
+	sandboxBackgroundCmd.AddCommand(sandboxBackgroundLogsCmd)
+	sandboxCmd.AddCommand(sandboxBackgroundCmd)
 	sandboxCmd.AddCommand(sandboxListCmd)
 	sandboxCmd.AddCommand(sandboxStopCmd)
 	sandboxCmd.AddCommand(sandboxResetCmd)
@@ -423,6 +594,19 @@ func init() {
 	}
 	sandboxExecCmd.Flags().BoolVar(&sandboxReset, "reset", false, "Reset the sandbox before executing")
 	sandboxExecCmd.Flags().StringArrayVar(&sandboxInitParams, "init", []string{}, "initialization parameters for the sandbox run, available in the `init` context. Can be specified multiple times")
+
+	// sync flags
+	sandboxSyncCmd.Flags().StringVar(&sandboxRunID, "id", "", "Use specific run ID")
+
+	// background flags
+	sandboxBackgroundCmd.PersistentFlags().StringVar(&sandboxRunID, "id", "", "Use specific run ID")
+	sandboxBackgroundCmd.PersistentFlags().StringVar(&sandboxBackgroundName, "name", "", "Name of the managed sandbox process")
+	sandboxBackgroundCmd.Flags().IntVar(&sandboxBackgroundPort, "port", 0, "Sandbox port to forward locally")
+	sandboxBackgroundCmd.Flags().IntVar(&sandboxBackgroundLocalPort, "local-port", 0, "Local port to use (default: allocate or reuse one)")
+	sandboxBackgroundLogsCmd.Flags().BoolVarP(&sandboxBackgroundFollow, "follow", "f", false, "Follow log output")
+	if err := sandboxBackgroundCmd.MarkPersistentFlagRequired("name"); err != nil {
+		panic(err)
+	}
 
 	// stop flags
 	sandboxStopCmd.Flags().StringVar(&sandboxRunID, "id", "", "Stop specific sandbox by run ID")

--- a/cmd/rwx/sandbox_test.go
+++ b/cmd/rwx/sandbox_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSandboxSyncCommandIsHidden(t *testing.T) {
-	require.True(t, sandboxSyncCmd.Hidden)
-	require.Equal(t, "sync", sandboxSyncCmd.Use)
-	require.NotNil(t, sandboxSyncCmd.Flags().Lookup("id"))
-	require.Nil(t, sandboxSyncCmd.Flags().Lookup("dir"))
-	require.Nil(t, sandboxSyncCmd.Flags().Lookup("init"))
-	require.NoError(t, sandboxSyncCmd.Args(sandboxSyncCmd, nil))
-	require.Error(t, sandboxSyncCmd.Args(sandboxSyncCmd, []string{".rwx/sandbox.yml"}))
+func TestSandboxPushCommandIsHidden(t *testing.T) {
+	require.True(t, sandboxPushCmd.Hidden)
+	require.Equal(t, "push", sandboxPushCmd.Use)
+	require.NotNil(t, sandboxPushCmd.Flags().Lookup("id"))
+	require.Nil(t, sandboxPushCmd.Flags().Lookup("dir"))
+	require.Nil(t, sandboxPushCmd.Flags().Lookup("init"))
+	require.NoError(t, sandboxPushCmd.Args(sandboxPushCmd, nil))
+	require.Error(t, sandboxPushCmd.Args(sandboxPushCmd, []string{".rwx/sandbox.yml"}))
 }
 
 func TestSandboxBackgroundCommandIsHidden(t *testing.T) {
@@ -36,7 +36,7 @@ func TestSandboxBackgroundCommandIsHidden(t *testing.T) {
 
 func TestExperimentalSandboxCommandsRequireOptIn(t *testing.T) {
 	commands := []*cobra.Command{
-		sandboxSyncCmd,
+		sandboxPushCmd,
 		sandboxBackgroundCmd,
 		sandboxBackgroundRestartCmd,
 		sandboxBackgroundStopCmd,

--- a/cmd/rwx/sandbox_test.go
+++ b/cmd/rwx/sandbox_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSandboxSyncCommandIsHidden(t *testing.T) {
+	require.True(t, sandboxSyncCmd.Hidden)
+	require.Equal(t, "sync", sandboxSyncCmd.Use)
+	require.NotNil(t, sandboxSyncCmd.Flags().Lookup("id"))
+	require.Nil(t, sandboxSyncCmd.Flags().Lookup("dir"))
+	require.Nil(t, sandboxSyncCmd.Flags().Lookup("init"))
+	require.NoError(t, sandboxSyncCmd.Args(sandboxSyncCmd, nil))
+	require.Error(t, sandboxSyncCmd.Args(sandboxSyncCmd, []string{".rwx/sandbox.yml"}))
+}
+
+func TestSandboxBackgroundCommandIsHidden(t *testing.T) {
+	require.True(t, sandboxBackgroundCmd.Hidden)
+	require.Equal(t, "background -- <command>", sandboxBackgroundCmd.Use)
+	require.NotNil(t, sandboxBackgroundCmd.PersistentFlags().Lookup("name"))
+	require.NotNil(t, sandboxBackgroundCmd.Flags().Lookup("port"))
+	require.NotNil(t, sandboxBackgroundCmd.Flags().Lookup("local-port"))
+	require.Nil(t, sandboxBackgroundCmd.Flags().Lookup("dir"))
+	require.Nil(t, sandboxBackgroundCmd.Flags().Lookup("init"))
+	require.Equal(t, "restart", sandboxBackgroundRestartCmd.Use)
+	require.True(t, sandboxBackgroundRestartCmd.Hidden)
+	require.Equal(t, "stop", sandboxBackgroundStopCmd.Use)
+	require.True(t, sandboxBackgroundStopCmd.Hidden)
+	require.Equal(t, "logs", sandboxBackgroundLogsCmd.Use)
+	require.True(t, sandboxBackgroundLogsCmd.Hidden)
+	require.NotNil(t, sandboxBackgroundLogsCmd.Flags().Lookup("follow"))
+}

--- a/cmd/rwx/sandbox_test.go
+++ b/cmd/rwx/sandbox_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,4 +32,33 @@ func TestSandboxBackgroundCommandIsHidden(t *testing.T) {
 	require.Equal(t, "logs", sandboxBackgroundLogsCmd.Use)
 	require.True(t, sandboxBackgroundLogsCmd.Hidden)
 	require.NotNil(t, sandboxBackgroundLogsCmd.Flags().Lookup("follow"))
+}
+
+func TestExperimentalSandboxCommandsRequireOptIn(t *testing.T) {
+	commands := []*cobra.Command{
+		sandboxSyncCmd,
+		sandboxBackgroundCmd,
+		sandboxBackgroundRestartCmd,
+		sandboxBackgroundStopCmd,
+		sandboxBackgroundLogsCmd,
+	}
+
+	for _, value := range []string{"", "false", "TRUE", "1"} {
+		t.Run("EXPERIMENTAL="+value, func(t *testing.T) {
+			t.Setenv("EXPERIMENTAL", value)
+			for _, command := range commands {
+				require.EqualError(t, command.PreRunE(command, nil), "this command is experimental; set EXPERIMENTAL=true to use it")
+			}
+		})
+	}
+
+	t.Run("EXPERIMENTAL=true", func(t *testing.T) {
+		t.Setenv("EXPERIMENTAL", "true")
+		originalAccessToken := AccessToken
+		AccessToken = "test-token"
+		t.Cleanup(func() { AccessToken = originalAccessToken })
+		for _, command := range commands {
+			require.NoError(t, command.PreRunE(command, nil))
+		}
+	})
 }

--- a/cmd/rwx/sandbox_test.go
+++ b/cmd/rwx/sandbox_test.go
@@ -44,16 +44,16 @@ func TestExperimentalSandboxCommandsRequireOptIn(t *testing.T) {
 	}
 
 	for _, value := range []string{"", "false", "TRUE", "1"} {
-		t.Run("EXPERIMENTAL="+value, func(t *testing.T) {
-			t.Setenv("EXPERIMENTAL", value)
+		t.Run("RWX_EXPERIMENTAL="+value, func(t *testing.T) {
+			t.Setenv("RWX_EXPERIMENTAL", value)
 			for _, command := range commands {
-				require.EqualError(t, command.PreRunE(command, nil), "this command is experimental; set EXPERIMENTAL=true to use it")
+				require.EqualError(t, command.PreRunE(command, nil), "this command is experimental; set RWX_EXPERIMENTAL=true to use it")
 			}
 		})
 	}
 
-	t.Run("EXPERIMENTAL=true", func(t *testing.T) {
-		t.Setenv("EXPERIMENTAL", "true")
+	t.Run("RWX_EXPERIMENTAL=true", func(t *testing.T) {
+		t.Setenv("RWX_EXPERIMENTAL", "true")
 		originalAccessToken := AccessToken
 		AccessToken = "test-token"
 		t.Cleanup(func() { AccessToken = originalAccessToken })

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -42,6 +42,10 @@ func (c Config) Validate() error {
 		return errors.New("missing SSH client constructor")
 	}
 
+	if c.SSHTunnelManager == nil {
+		return errors.New("missing SSH tunnel manager")
+	}
+
 	if c.GitClient == nil {
 		return errors.New("missing Git client constructor")
 	}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rwx-cloud/rwx/internal/docs"
 	"github.com/rwx-cloud/rwx/internal/docstoken"
 	"github.com/rwx-cloud/rwx/internal/errors"
+	rwxssh "github.com/rwx-cloud/rwx/internal/ssh"
 	"github.com/rwx-cloud/rwx/internal/telemetry"
 	"github.com/rwx-cloud/rwx/internal/versions"
 )
@@ -15,6 +16,7 @@ import (
 type Config struct {
 	APIClient            APIClient
 	SSHClient            SSHClient
+	SSHTunnelManager     rwxssh.TunnelManager
 	GitClient            GitClient
 	DockerCLI            docker.Client
 	DocsClient           docs.Client

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -69,6 +69,7 @@ type SSHClient interface {
 	ExecuteCommand(command string) (int, error)
 	ExecuteCommandWithStdin(command string, stdin io.Reader) (int, error)
 	ExecuteCommandWithOutput(command string) (int, string, error)
+	ExecuteCommandWithSeparateOutput(command string) (int, string, string, error)
 	ExecuteCommandWithStdinAndCombinedOutput(command string, stdin io.Reader) (int, string, error)
 }
 

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rwx-cloud/rwx/internal/errors"
 	"github.com/rwx-cloud/rwx/internal/git"
 	"github.com/rwx-cloud/rwx/internal/skill"
+	rwxssh "github.com/rwx-cloud/rwx/internal/ssh"
 	"github.com/rwx-cloud/rwx/internal/versions"
 )
 
@@ -46,6 +47,9 @@ type Service struct {
 }
 
 func NewService(cfg Config) (Service, error) {
+	if cfg.SSHTunnelManager == nil {
+		cfg.SSHTunnelManager = rwxssh.NewTunnelManager()
+	}
 	if err := cfg.Validate(); err != nil {
 		return Service{}, errors.Wrap(err, "validation failed")
 	}

--- a/internal/cli/service.go
+++ b/internal/cli/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rwx-cloud/rwx/internal/errors"
 	"github.com/rwx-cloud/rwx/internal/git"
 	"github.com/rwx-cloud/rwx/internal/skill"
-	rwxssh "github.com/rwx-cloud/rwx/internal/ssh"
 	"github.com/rwx-cloud/rwx/internal/versions"
 )
 
@@ -47,9 +46,6 @@ type Service struct {
 }
 
 func NewService(cfg Config) (Service, error) {
-	if cfg.SSHTunnelManager == nil {
-		cfg.SSHTunnelManager = rwxssh.NewTunnelManager()
-	}
 	if err := cfg.Validate(); err != nil {
 		return Service{}, errors.Wrap(err, "validation failed")
 	}

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -77,6 +77,7 @@ type BackgroundSandboxConfig struct {
 	Name       string
 	TargetPort int
 	LocalPort  int
+	Scheme     string
 	RunID      string
 	Json       bool
 }
@@ -138,6 +139,7 @@ type SandboxBackgroundResult struct {
 	Status      string
 	TargetPort  int
 	LocalPort   int
+	Scheme      string
 	URL         string
 	PID         int
 	PGID        int
@@ -555,6 +557,17 @@ func (s Service) BackgroundSandbox(cfg BackgroundSandboxConfig) (*SandboxBackgro
 	if cfg.LocalPort != 0 && cfg.TargetPort == 0 {
 		return nil, fmt.Errorf("--local-port requires --port")
 	}
+	if cfg.Scheme != "" && cfg.TargetPort == 0 {
+		return nil, fmt.Errorf("--scheme requires --port")
+	}
+	if cfg.TargetPort != 0 {
+		if cfg.Scheme == "" {
+			cfg.Scheme = "http"
+		}
+		if cfg.Scheme != "http" && cfg.Scheme != "https" {
+			return nil, fmt.Errorf("--scheme must be http or https")
+		}
+	}
 	if len(cfg.Command) == 0 {
 		return nil, fmt.Errorf("background process command is required")
 	}
@@ -584,7 +597,7 @@ func (s Service) BackgroundSandbox(cfg BackgroundSandboxConfig) (*SandboxBackgro
 	}
 	process.Key = cfg.Name
 	process.TargetPort = cfg.TargetPort
-	return s.finishSandboxBackground(sandbox, process, cfg.LocalPort, cfg.Json, "Started")
+	return s.finishSandboxBackground(sandbox, process, cfg.LocalPort, cfg.Scheme, cfg.Json, "Started")
 }
 
 func (s Service) RestartSandboxBackground(cfg SandboxBackgroundConfig) (*SandboxBackgroundResult, error) {
@@ -609,7 +622,7 @@ func (s Service) RestartSandboxBackground(cfg SandboxBackgroundConfig) (*Sandbox
 		return nil, err
 	}
 	process.Key = cfg.Name
-	return s.finishSandboxBackground(sandbox, process, 0, cfg.Json, "Restarted")
+	return s.finishSandboxBackground(sandbox, process, 0, "", cfg.Json, "Restarted")
 }
 
 func (s Service) StopSandboxBackground(cfg SandboxBackgroundConfig) (*SandboxBackgroundResult, error) {
@@ -747,7 +760,7 @@ func (s Service) executeSandboxProcessDirective(directive string, request any, a
 	return process, nil
 }
 
-func (s Service) finishSandboxBackground(sandbox *syncedSandbox, process sandboxProcessResponse, localPort int, jsonMode bool, action string) (*SandboxBackgroundResult, error) {
+func (s Service) finishSandboxBackground(sandbox *syncedSandbox, process sandboxProcessResponse, localPort int, scheme string, jsonMode bool, action string) (*SandboxBackgroundResult, error) {
 	result := sandboxBackgroundResult(sandbox.runID, process)
 	if process.TargetPort != 0 {
 		stateDirectory, err := sandboxTunnelStateDirectory()
@@ -757,13 +770,14 @@ func (s Service) finishSandboxBackground(sandbox *syncedSandbox, process sandbox
 		tunnel, err := s.SSHTunnelManager.Open(rwxssh.TunnelConfig{
 			Key: process.Key, RunID: sandbox.runID, Address: sandbox.connectionInfo.Address,
 			PrivateUserKey: sandbox.connectionInfo.PrivateUserKey, PublicHostKey: sandbox.connectionInfo.PublicHostKey,
-			LocalPort: localPort, TargetPort: process.TargetPort, StateDirectory: stateDirectory,
+			LocalPort: localPort, TargetPort: process.TargetPort, Scheme: scheme, StateDirectory: stateDirectory,
 		})
 		if err != nil {
 			return nil, err
 		}
 		result.LocalPort = tunnel.LocalPort
-		result.URL = fmt.Sprintf("http://127.0.0.1:%d", tunnel.LocalPort)
+		result.Scheme = tunnel.Scheme
+		result.URL = fmt.Sprintf("%s://127.0.0.1:%d", tunnel.Scheme, tunnel.LocalPort)
 
 		deadline := time.Now().Add(30 * time.Second)
 		for !s.SSHTunnelManager.IsReady(tunnel.LocalPort) {
@@ -785,7 +799,11 @@ func (s Service) finishSandboxBackground(sandbox *syncedSandbox, process sandbox
 
 	if !jsonMode {
 		if result.URL != "" {
-			fmt.Fprintln(s.Stdout, result.URL)
+			fmt.Fprintf(s.Stdout, "Preview %q: %s\n\n", process.Key, result.URL)
+			fmt.Fprintln(s.Stdout, "After local edits:")
+			fmt.Fprintln(s.Stdout, "  Hot reload:    rwx sandbox sync")
+			fmt.Fprintf(s.Stdout, "  Hard restart:  rwx sandbox background restart --name %s\n\n", process.Key)
+			fmt.Fprintln(s.Stdout, "rwx sandbox exec -- <command> syncs local changes before it runs.")
 		} else {
 			fmt.Fprintf(s.Stdout, "%s background process %q.\n", action, process.Key)
 		}

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -538,7 +538,7 @@ func (s Service) SyncSandbox(cfg SyncSandboxConfig) (*SyncSandboxResult, error) 
 	defer sandbox.close()
 
 	if !cfg.Json {
-		fmt.Fprintln(s.Stdout, "Synced local changes to sandbox.")
+		fmt.Fprintln(s.Stdout, "Pushed local changes to sandbox.")
 	}
 
 	return &SyncSandboxResult{RunID: sandbox.runID, RunURL: sandbox.runURL}, nil
@@ -811,7 +811,7 @@ func (s Service) finishSandboxBackground(sandbox *syncedSandbox, process sandbox
 		if result.URL != "" {
 			fmt.Fprintf(s.Stdout, "Preview %q: %s\n\n", process.Key, result.URL)
 			fmt.Fprintln(s.Stdout, "After local edits:")
-			fmt.Fprintln(s.Stdout, "  Hot reload:    rwx sandbox sync")
+			fmt.Fprintln(s.Stdout, "  Hot reload:    rwx sandbox push")
 			fmt.Fprintf(s.Stdout, "  Hard restart:  rwx sandbox background restart --name %s\n\n", process.Key)
 			fmt.Fprintln(s.Stdout, "rwx sandbox exec -- <command> syncs local changes before it runs.")
 		} else {
@@ -865,7 +865,7 @@ func (s Service) prepareSandboxOperation(cfg sandboxOperationConfig) (*syncedSan
 	if !cfg.SkipSync {
 		localHeadForSync, err = s.GitClient.GetHeadCommit()
 		if err != nil {
-			return nil, errors.Wrap(err, "sandbox sync requires a git repository with a valid HEAD")
+			return nil, errors.Wrap(err, "sandbox push requires a git repository with a valid HEAD")
 		}
 	}
 
@@ -1856,7 +1856,7 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 
 func (s Service) syncLocalChangesToSandbox(jsonMode bool, isNewSandbox bool, localHead string, connInfo *api.SandboxConnectionInfo) (int, error) {
 	if localHead == "" {
-		return 0, fmt.Errorf("sandbox sync requires a git repository with a valid HEAD")
+		return 0, fmt.Errorf("sandbox push requires a git repository with a valid HEAD")
 	}
 
 	s.warnUnresolvedRejectFiles()

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -743,14 +743,18 @@ func (s Service) executeSandboxProcessDirective(directive string, request any, a
 	if err != nil {
 		return sandboxProcessResponse{}, errors.Wrap(err, "unable to encode sandbox process request")
 	}
-	exitCode, output, err := s.SSHClient.ExecuteCommandWithOutput(directive + " " + string(payload))
+	exitCode, output, stderr, err := s.SSHClient.ExecuteCommandWithSeparateOutput(directive + " " + string(payload))
 	if err != nil {
 		return sandboxProcessResponse{}, errors.Wrapf(err, "failed to %s managed sandbox process", action)
 	}
 	if exitCode == 127 {
-		return sandboxProcessResponse{}, fmt.Errorf("the sandbox agent does not support managed processes yet; update the Mint sandbox agent before using 'rwx sandbox background'")
+		return sandboxProcessResponse{}, fmt.Errorf("background processes are not supported by this sandbox")
 	}
 	if exitCode != 0 {
+		stderr = strings.TrimSpace(stderr)
+		if stderr != "" && !strings.Contains(stderr, "__rwx_sandbox_") {
+			return sandboxProcessResponse{}, fmt.Errorf("sandbox agent failed to %s managed process: %s", action, stderr)
+		}
 		return sandboxProcessResponse{}, fmt.Errorf("sandbox agent failed to %s managed process (exit code %d)", action, exitCode)
 	}
 	var process sandboxProcessResponse
@@ -762,11 +766,17 @@ func (s Service) executeSandboxProcessDirective(directive string, request any, a
 
 func (s Service) finishSandboxBackground(sandbox *syncedSandbox, process sandboxProcessResponse, localPort int, scheme string, jsonMode bool, action string) (*SandboxBackgroundResult, error) {
 	result := sandboxBackgroundResult(sandbox.runID, process)
-	if process.TargetPort != 0 {
-		stateDirectory, err := sandboxTunnelStateDirectory()
-		if err != nil {
-			return nil, err
+	stateDirectory, err := sandboxTunnelStateDirectory()
+	if err != nil {
+		return nil, err
+	}
+	if process.TargetPort == 0 {
+		if err := s.SSHTunnelManager.Close(rwxssh.TunnelCloseConfig{
+			Key: process.Key, RunID: sandbox.runID, StateDirectory: stateDirectory,
+		}); err != nil {
+			return nil, errors.Wrap(err, "failed to close local tunnel")
 		}
+	} else {
 		tunnel, err := s.SSHTunnelManager.Open(rwxssh.TunnelConfig{
 			Key: process.Key, RunID: sandbox.runID, Address: sandbox.connectionInfo.Address,
 			PrivateUserKey: sandbox.connectionInfo.PrivateUserKey, PublicHostKey: sandbox.connectionInfo.PublicHostKey,
@@ -1076,6 +1086,7 @@ func (s Service) prepareSandboxOperation(cfg sandboxOperationConfig) (*syncedSan
 				}
 			}
 			s.waitForSandboxCompletion(runID, scopedToken)
+			s.closeSandboxTunnels(runID)
 			storage.DeleteSession(branch, configFile)
 			if saveErr := storage.Save(); saveErr != nil {
 				fmt.Fprintf(s.Stderr, "Warning: unable to save sandbox sessions: %v\n", saveErr)

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -14,14 +15,20 @@ import (
 	"github.com/rwx-cloud/rwx/internal/api"
 	"github.com/rwx-cloud/rwx/internal/errors"
 	"github.com/rwx-cloud/rwx/internal/git"
+	rwxssh "github.com/rwx-cloud/rwx/internal/ssh"
 
 	"golang.org/x/crypto/ssh"
 )
 
 const (
-	sandboxDirectiveLockRequested = "__rwx_sandbox_lock_requested__"
-	sandboxDirectiveLockReleased  = "__rwx_sandbox_lock_released__"
-	rwxCLISSHUser                 = "rwx-cli"
+	sandboxDirectiveLockRequested  = "__rwx_sandbox_lock_requested__"
+	sandboxDirectiveLockReleased   = "__rwx_sandbox_lock_released__"
+	sandboxDirectiveProcessStart   = "__rwx_sandbox_process_start__"
+	sandboxDirectiveProcessRestart = "__rwx_sandbox_process_restart__"
+	sandboxDirectiveProcessStop    = "__rwx_sandbox_process_stop__"
+	sandboxDirectiveProcessStatus  = "__rwx_sandbox_process_status__"
+	sandboxDirectiveProcessLogs    = "__rwx_sandbox_process_logs__"
+	rwxCLISSHUser                  = "rwx-cli"
 	// Reuse one fixed ref (force-pushed) rather than a unique ref per push so the
 	// sandbox's ref namespace doesn't accumulate dangling refs.
 	sandboxPushRef = "refs/rwx/sync-push"
@@ -59,6 +66,33 @@ type ExecSandboxConfig struct {
 	Reset          bool
 }
 
+type SyncSandboxConfig struct {
+	RunID string
+	Json  bool
+}
+
+type BackgroundSandboxConfig struct {
+	Command    []string
+	Name       string
+	TargetPort int
+	LocalPort  int
+	RunID      string
+	Json       bool
+}
+
+type SandboxBackgroundConfig struct {
+	Name  string
+	RunID string
+	Json  bool
+}
+
+type SandboxBackgroundLogsConfig struct {
+	Name   string
+	RunID  string
+	Json   bool
+	Follow bool
+}
+
 type ListSandboxesConfig struct {
 	Json bool
 }
@@ -90,6 +124,60 @@ type ExecSandboxResult struct {
 	ExitCode    int
 	RunURL      string
 	PulledFiles []string
+}
+
+type SyncSandboxResult struct {
+	RunID  string
+	RunURL string
+}
+
+type SandboxBackgroundResult struct {
+	RunID       string
+	Name        string
+	Status      string
+	TargetPort  int
+	LocalPort   int
+	URL         string
+	PID         int
+	PGID        int
+	StartedAt   string
+	CompletedAt string
+	ExitCode    *int
+	Signal      string
+	StdoutPath  string
+	StderrPath  string
+}
+
+type sandboxOperationConfig struct {
+	ConfigFile           string
+	RunID                string
+	RwxDirectory         string
+	Json                 bool
+	InitParameters       map[string]string
+	Reset                bool
+	RequireExisting      bool
+	SkipSync             bool
+	ShowReconnectionHint bool
+	LockWaitMessage      string
+}
+
+type syncedSandbox struct {
+	cwd                string
+	branch             string
+	runID              string
+	configFile         string
+	runURL             string
+	syncPushMs         int64
+	syncPushPatchBytes int
+	connectionInfo     api.SandboxConnectionInfo
+	release            func()
+}
+
+func (sandbox *syncedSandbox) close() {
+	if sandbox.release != nil {
+		sandbox.release()
+		sandbox.release = nil
+	}
 }
 
 type ListSandboxesResult struct {
@@ -434,17 +522,305 @@ func (s Service) StartSandbox(cfg StartSandboxConfig) (*StartSandboxResult, erro
 	return result, nil
 }
 
-func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) {
-	execStart := time.Now()
+func (s Service) SyncSandbox(cfg SyncSandboxConfig) (*SyncSandboxResult, error) {
+	sandbox, err := s.prepareSandboxOperation(sandboxOperationConfig{
+		RunID:           cfg.RunID,
+		Json:            cfg.Json,
+		RequireExisting: true,
+		LockWaitMessage: "Waiting for another sandbox operation to complete...",
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer sandbox.close()
+
+	if !cfg.Json {
+		fmt.Fprintln(s.Stdout, "Synced local changes to sandbox.")
+	}
+
+	return &SyncSandboxResult{RunID: sandbox.runID, RunURL: sandbox.runURL}, nil
+}
+
+func (s Service) BackgroundSandbox(cfg BackgroundSandboxConfig) (*SandboxBackgroundResult, error) {
+	if strings.TrimSpace(cfg.Name) == "" {
+		return nil, fmt.Errorf("background process name is required")
+	}
+	if cfg.TargetPort < 0 || cfg.TargetPort > 65535 {
+		return nil, fmt.Errorf("background process port must be between 1 and 65535")
+	}
+	if cfg.LocalPort < 0 || cfg.LocalPort > 65535 {
+		return nil, fmt.Errorf("local background process port must be between 1 and 65535")
+	}
+	if cfg.LocalPort != 0 && cfg.TargetPort == 0 {
+		return nil, fmt.Errorf("--local-port requires --port")
+	}
+	if len(cfg.Command) == 0 {
+		return nil, fmt.Errorf("background process command is required")
+	}
+
+	sandbox, err := s.prepareSandboxOperation(sandboxOperationConfig{
+		RunID:           cfg.RunID,
+		Json:            cfg.Json,
+		RequireExisting: true,
+		LockWaitMessage: "Waiting for another sandbox operation to complete...",
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer sandbox.close()
+
+	process, err := s.executeSandboxProcessDirective(sandboxDirectiveProcessStart, struct {
+		Key        string `json:"key"`
+		Command    string `json:"command"`
+		TargetPort int    `json:"targetPort,omitempty"`
+	}{
+		Key:        cfg.Name,
+		Command:    shellescape.QuoteCommand(cfg.Command),
+		TargetPort: cfg.TargetPort,
+	}, "start")
+	if err != nil {
+		return nil, err
+	}
+	process.Key = cfg.Name
+	process.TargetPort = cfg.TargetPort
+	return s.finishSandboxBackground(sandbox, process, cfg.LocalPort, cfg.Json, "Started")
+}
+
+func (s Service) RestartSandboxBackground(cfg SandboxBackgroundConfig) (*SandboxBackgroundResult, error) {
+	if strings.TrimSpace(cfg.Name) == "" {
+		return nil, fmt.Errorf("background process name is required")
+	}
+	sandbox, err := s.prepareSandboxOperation(sandboxOperationConfig{
+		RunID:           cfg.RunID,
+		Json:            cfg.Json,
+		RequireExisting: true,
+		LockWaitMessage: "Waiting for another sandbox operation to complete...",
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer sandbox.close()
+
+	process, err := s.executeSandboxProcessDirective(sandboxDirectiveProcessRestart, struct {
+		Key string `json:"key"`
+	}{Key: cfg.Name}, "restart")
+	if err != nil {
+		return nil, err
+	}
+	process.Key = cfg.Name
+	return s.finishSandboxBackground(sandbox, process, 0, cfg.Json, "Restarted")
+}
+
+func (s Service) StopSandboxBackground(cfg SandboxBackgroundConfig) (*SandboxBackgroundResult, error) {
+	if strings.TrimSpace(cfg.Name) == "" {
+		return nil, fmt.Errorf("background process name is required")
+	}
+	sandbox, err := s.prepareSandboxOperation(sandboxOperationConfig{
+		RunID:           cfg.RunID,
+		Json:            cfg.Json,
+		RequireExisting: true,
+		SkipSync:        true,
+		LockWaitMessage: "Waiting for another sandbox operation to complete...",
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer sandbox.close()
+
+	stateDirectory, stateErr := sandboxTunnelStateDirectory()
+	if stateErr == nil {
+		stateErr = s.SSHTunnelManager.Close(rwxssh.TunnelCloseConfig{
+			Key: cfg.Name, RunID: sandbox.runID, StateDirectory: stateDirectory,
+		})
+	}
+	process, processErr := s.executeSandboxProcessDirective(sandboxDirectiveProcessStop, struct {
+		Key string `json:"key"`
+	}{Key: cfg.Name}, "stop")
+	if processErr != nil && stateErr != nil {
+		return nil, fmt.Errorf("%v; also failed to close local tunnel: %v", processErr, stateErr)
+	}
+	if processErr != nil {
+		return nil, processErr
+	}
+	if stateErr != nil {
+		return nil, errors.Wrap(stateErr, "failed to close local tunnel")
+	}
+
+	result := sandboxBackgroundResult(sandbox.runID, process)
+	if !cfg.Json {
+		fmt.Fprintf(s.Stdout, "Stopped background process %q.\n", cfg.Name)
+	}
+	return result, nil
+}
+
+func (s Service) LogsSandboxBackground(cfg SandboxBackgroundLogsConfig) (*SandboxBackgroundResult, error) {
+	if strings.TrimSpace(cfg.Name) == "" {
+		return nil, fmt.Errorf("background process name is required")
+	}
+	sandbox, err := s.prepareSandboxOperation(sandboxOperationConfig{
+		RunID:           cfg.RunID,
+		Json:            cfg.Json,
+		RequireExisting: true,
+		SkipSync:        true,
+		LockWaitMessage: "Waiting for another sandbox operation to complete...",
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer sandbox.close()
+
+	process, err := s.executeSandboxProcessDirective(sandboxDirectiveProcessLogs, struct {
+		Key string `json:"key"`
+	}{Key: cfg.Name}, "get logs for")
+	if err != nil {
+		return nil, err
+	}
+	result := sandboxBackgroundResult(sandbox.runID, process)
+	if cfg.Json {
+		return result, nil
+	}
+
+	sandbox.close()
+	if err := s.connectSSH(&sandbox.connectionInfo); err != nil {
+		return nil, errors.Wrap(err, "failed to reconnect for sandbox process logs")
+	}
+	defer s.SSHClient.Close()
+	if cfg.Follow {
+		command := fmt.Sprintf("tail -n +1 -F -- %s %s", quoteShellArg(process.StdoutPath), quoteShellArg(process.StderrPath))
+		exitCode, err := s.SSHClient.ExecuteCommand(command)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to follow sandbox process logs")
+		}
+		if exitCode != 0 {
+			return nil, fmt.Errorf("failed to follow sandbox process logs (exit code %d)", exitCode)
+		}
+		return result, nil
+	}
+	command := fmt.Sprintf(
+		"printf '%%s\\n' '--- stdout ---'; tail -n +1 -- %s; printf '%%s\\n' '--- stderr ---'; tail -n +1 -- %s",
+		quoteShellArg(process.StdoutPath), quoteShellArg(process.StderrPath),
+	)
+	exitCode, err := s.SSHClient.ExecuteCommand(command)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read sandbox process logs")
+	}
+	if exitCode != 0 {
+		return nil, fmt.Errorf("failed to read sandbox process logs (exit code %d)", exitCode)
+	}
+	return result, nil
+}
+
+type sandboxProcessResponse struct {
+	Key         string `json:"key"`
+	Status      string `json:"status"`
+	TargetPort  int    `json:"targetPort"`
+	PID         int    `json:"pid"`
+	PGID        int    `json:"pgid"`
+	StartedAt   string `json:"startedAt"`
+	CompletedAt string `json:"completedAt"`
+	ExitCode    *int   `json:"exitCode"`
+	Signal      string `json:"signal"`
+	StdoutPath  string `json:"stdoutPath"`
+	StderrPath  string `json:"stderrPath"`
+}
+
+func (s Service) executeSandboxProcessDirective(directive string, request any, action string) (sandboxProcessResponse, error) {
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return sandboxProcessResponse{}, errors.Wrap(err, "unable to encode sandbox process request")
+	}
+	exitCode, output, err := s.SSHClient.ExecuteCommandWithOutput(directive + " " + string(payload))
+	if err != nil {
+		return sandboxProcessResponse{}, errors.Wrapf(err, "failed to %s managed sandbox process", action)
+	}
+	if exitCode == 127 {
+		return sandboxProcessResponse{}, fmt.Errorf("the sandbox agent does not support managed processes yet; update the Mint sandbox agent before using 'rwx sandbox background'")
+	}
+	if exitCode != 0 {
+		return sandboxProcessResponse{}, fmt.Errorf("sandbox agent failed to %s managed process (exit code %d)", action, exitCode)
+	}
+	var process sandboxProcessResponse
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &process); err != nil {
+		return sandboxProcessResponse{}, errors.Wrap(err, "unable to decode sandbox process response")
+	}
+	return process, nil
+}
+
+func (s Service) finishSandboxBackground(sandbox *syncedSandbox, process sandboxProcessResponse, localPort int, jsonMode bool, action string) (*SandboxBackgroundResult, error) {
+	result := sandboxBackgroundResult(sandbox.runID, process)
+	if process.TargetPort != 0 {
+		stateDirectory, err := sandboxTunnelStateDirectory()
+		if err != nil {
+			return nil, err
+		}
+		tunnel, err := s.SSHTunnelManager.Open(rwxssh.TunnelConfig{
+			Key: process.Key, RunID: sandbox.runID, Address: sandbox.connectionInfo.Address,
+			PrivateUserKey: sandbox.connectionInfo.PrivateUserKey, PublicHostKey: sandbox.connectionInfo.PublicHostKey,
+			LocalPort: localPort, TargetPort: process.TargetPort, StateDirectory: stateDirectory,
+		})
+		if err != nil {
+			return nil, err
+		}
+		result.LocalPort = tunnel.LocalPort
+		result.URL = fmt.Sprintf("http://127.0.0.1:%d", tunnel.LocalPort)
+
+		deadline := time.Now().Add(30 * time.Second)
+		for !s.SSHTunnelManager.IsReady(tunnel.LocalPort) {
+			status, statusErr := s.executeSandboxProcessDirective(sandboxDirectiveProcessStatus, struct {
+				Key string `json:"key"`
+			}{Key: process.Key}, "get status for")
+			if statusErr != nil {
+				return nil, statusErr
+			}
+			if status.Status != "running" {
+				return nil, fmt.Errorf("background process %q stopped before port %d became ready (status: %s; stdout: %s; stderr: %s)", process.Key, process.TargetPort, status.Status, status.StdoutPath, status.StderrPath)
+			}
+			if time.Now().After(deadline) {
+				return nil, fmt.Errorf("timed out waiting for background process %q on %s; the process and tunnel are still running", process.Key, result.URL)
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+
+	if !jsonMode {
+		if result.URL != "" {
+			fmt.Fprintln(s.Stdout, result.URL)
+		} else {
+			fmt.Fprintf(s.Stdout, "%s background process %q.\n", action, process.Key)
+		}
+	}
+	return result, nil
+}
+
+func sandboxBackgroundResult(runID string, process sandboxProcessResponse) *SandboxBackgroundResult {
+	return &SandboxBackgroundResult{
+		RunID: runID, Name: process.Key, Status: process.Status, TargetPort: process.TargetPort,
+		PID: process.PID, PGID: process.PGID, StartedAt: process.StartedAt, CompletedAt: process.CompletedAt,
+		ExitCode: process.ExitCode, Signal: process.Signal, StdoutPath: process.StdoutPath, StderrPath: process.StderrPath,
+	}
+}
+
+func sandboxTunnelStateDirectory() (string, error) {
+	storagePath, err := sandboxStoragePath()
+	if err != nil {
+		return "", errors.Wrap(err, "unable to determine background tunnel state directory")
+	}
+	return filepath.Join(filepath.Dir(storagePath), "previews"), nil
+}
+
+func (s Service) prepareSandboxOperation(cfg sandboxOperationConfig) (*syncedSandbox, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get current directory")
 	}
 	branch := GetCurrentGitBranch(cwd)
 
-	localHeadForSync, headErr := s.GitClient.GetHeadCommit()
-	if headErr != nil {
-		return nil, errors.Wrap(headErr, "sandbox sync requires a git repository with a valid HEAD")
+	var localHeadForSync string
+	if !cfg.SkipSync {
+		localHeadForSync, err = s.GitClient.GetHeadCommit()
+		if err != nil {
+			return nil, errors.Wrap(err, "sandbox sync requires a git repository with a valid HEAD")
+		}
 	}
 
 	var runID string
@@ -480,7 +856,7 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 	} else {
 		// Serialize sandbox resolution across concurrent CLI processes.
 		// The lock is released as soon as a run ID is determined so that
-		// the actual SSH exec can proceed concurrently (serialized by the
+		// the actual SSH operation can proceed concurrently (serialized by the
 		// agent-side lock instead).
 		lockFile, lockErr := s.lockSandboxStorageWithInfo(cfg.Json)
 		if lockErr != nil {
@@ -567,6 +943,9 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 				found = true
 			} else if len(activeSessions) > 1 {
 				UnlockSandboxStorage(lockFile)
+				if cfg.RequireExisting {
+					return nil, fmt.Errorf("Multiple active sandboxes found for branch %s.\nUse --id to select one.", branch)
+				}
 				return nil, fmt.Errorf("Multiple active sandboxes found for branch %s.\nSpecify a config file to select one, or use --id to specify a run ID.", branch)
 			}
 		}
@@ -639,6 +1018,11 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 			}
 		}
 
+		if !found && cfg.RequireExisting {
+			UnlockSandboxStorage(lockFile)
+			return nil, fmt.Errorf("No active sandbox found for branch %s.\nStart one with 'rwx sandbox start' or use --id to select an existing run.", branch)
+		}
+
 		if found && cfg.Reset {
 			connInfo, connErr := s.APIClient.GetSandboxConnectionInfo(runID, scopedToken)
 			if connErr == nil && connInfo.Sandboxable {
@@ -694,13 +1078,13 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 				}
 			}
 		} else {
-			// Resolution complete — release the file lock so concurrent execs
+			// Resolution complete — release the file lock so concurrent operations
 			// can proceed. The agent-side lock serializes from here.
 			UnlockSandboxStorage(lockFile)
 		}
 	}
 
-	if !isNewSandbox && execCount >= 1 && !resetNagShown {
+	if cfg.ShowReconnectionHint && !isNewSandbox && execCount >= 1 && !resetNagShown {
 		fmt.Fprintf(s.Stderr, "Reconnecting to existing sandbox. To re-run setup tasks, use: rwx sandbox exec --reset -- <command>\n")
 		if nagLock, nagLockErr := s.lockSandboxStorageWithInfo(cfg.Json); nagLockErr == nil {
 			if nagStorage, nagLoadErr := LoadSandboxStorage(); nagLoadErr == nil {
@@ -741,11 +1125,10 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 		}
 		return nil, fmt.Errorf("Failed to connect to sandbox '%s': %v\nThe sandbox may have timed out. Run 'rwx sandbox reset %s' to restart.", runID, err, configFile)
 	}
-	defer s.SSHClient.Close()
 
-	// Acquire the distributed lock so concurrent exec calls on the same
+	// Acquire the distributed lock so concurrent operations on the same
 	// sandbox are serialized by the agent. Blocks until the lock is granted.
-	// Show a spinner if another exec is holding the lock.
+	// Show a spinner if another operation is holding the lock.
 	lockDone := make(chan struct{})
 	if !cfg.Json {
 		go func() {
@@ -755,7 +1138,7 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 			case <-lockDone:
 				return
 			case <-t.C:
-				stopSpinner := Spin("Waiting for another sandbox exec to complete...", s.StderrIsTTY, s.Stderr)
+				stopSpinner := Spin(cfg.LockWaitMessage, s.StderrIsTTY, s.Stderr)
 				<-lockDone
 				stopSpinner()
 			}
@@ -764,19 +1147,32 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 	_, lockErr := s.SSHClient.ExecuteCommand(sandboxDirectiveLockRequested)
 	close(lockDone)
 	if lockErr != nil {
+		s.SSHClient.Close()
 		return nil, errors.Wrap(lockErr, "failed to acquire sandbox lock")
 	}
-	defer func() {
-		_, _ = s.SSHClient.ExecuteCommand(sandboxDirectiveLockReleased)
-	}()
 
-	// Sync local changes to sandbox
-	var syncPushMs int64
-	var syncPushPatchBytes int
+	result := &syncedSandbox{
+		cwd:            cwd,
+		branch:         branch,
+		runID:          runID,
+		configFile:     configFile,
+		runURL:         s.sandboxRunURL(&SandboxSession{RunURL: sessionRunURL}),
+		connectionInfo: *connInfo,
+		release: func() {
+			_, _ = s.SSHClient.ExecuteCommand(sandboxDirectiveLockReleased)
+			s.SSHClient.Close()
+		},
+	}
+
+	if cfg.SkipSync {
+		return result, nil
+	}
+
+	// Sync local changes to sandbox.
 	syncPushStart := time.Now()
-	patchBytes, err := s.prepareSandboxForExec(cfg.Json, isNewSandbox, localHeadForSync, connInfo)
-	syncPushMs = time.Since(syncPushStart).Milliseconds()
-	syncPushPatchBytes = patchBytes
+	patchBytes, err := s.syncLocalChangesToSandbox(cfg.Json, isNewSandbox, localHeadForSync, connInfo)
+	result.syncPushMs = time.Since(syncPushStart).Milliseconds()
+	result.syncPushPatchBytes = patchBytes
 	if err != nil {
 		if errors.Is(err, errors.ErrSandboxNoGitDir) {
 			// Stop the sandbox so the user gets a fresh one on retry
@@ -797,8 +1193,29 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 				fmt.Fprintf(s.Stderr, "Warning: failed to lock sandbox storage: %v\n", lockErr)
 			}
 		}
+		result.close()
 		return nil, errors.Wrap(err, "failed to sync changes to sandbox")
 	}
+
+	return result, nil
+}
+
+func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) {
+	execStart := time.Now()
+	sandbox, err := s.prepareSandboxOperation(sandboxOperationConfig{
+		ConfigFile:           cfg.ConfigFile,
+		RunID:                cfg.RunID,
+		RwxDirectory:         cfg.RwxDirectory,
+		Json:                 cfg.Json,
+		InitParameters:       cfg.InitParameters,
+		Reset:                cfg.Reset,
+		ShowReconnectionHint: true,
+		LockWaitMessage:      "Waiting for another sandbox exec to complete...",
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer sandbox.close()
 
 	// Execute command — shell-quote each argument so the remote shell
 	// preserves the original grouping (e.g. bash -c "cat README.md").
@@ -822,11 +1239,11 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 	var syncPullSuccess bool
 	var syncPullRejCount int
 	pullStart := time.Now()
-	pulled, pullPatchBytes, pullErr := s.pullChangesFromSandbox(cwd, cfg.Json)
+	pulled, pullPatchBytes, pullErr := s.pullChangesFromSandbox(sandbox.cwd, cfg.Json)
 	syncPullMs = time.Since(pullStart).Milliseconds()
 	syncPullPatchBytes = pullPatchBytes
 	if pullErr != nil {
-		syncPullRejCount = len(findRejFiles(cwd, pulled))
+		syncPullRejCount = len(findRejFiles(sandbox.cwd, pulled))
 		s.recordTelemetry("sandbox.sync_pull", map[string]any{
 			"patch_bytes":    pullPatchBytes,
 			"duration_ms":    syncPullMs,
@@ -852,10 +1269,10 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 	execNow := time.Now().UTC()
 	if lockFile, lockErr := s.lockSandboxStorageWithInfo(cfg.Json); lockErr == nil {
 		if storage, loadErr := LoadSandboxStorage(); loadErr == nil {
-			if session, ok := storage.GetSession(branch, configFile); ok {
+			if session, ok := storage.GetSession(sandbox.branch, sandbox.configFile); ok {
 				session.LastExecAt = &execNow
 				session.ExecCount++
-				storage.SetSession(branch, configFile, *session)
+				storage.SetSession(sandbox.branch, sandbox.configFile, *session)
 				_ = storage.Save()
 			}
 		}
@@ -865,14 +1282,13 @@ func (s Service) ExecSandbox(cfg ExecSandboxConfig) (*ExecSandboxResult, error) 
 	s.recordTelemetry("sandbox.exec", map[string]any{
 		"duration_ms":      time.Since(execStart).Milliseconds(),
 		"exit_code":        exitCode,
-		"sync_push_ms":     syncPushMs,
+		"sync_push_ms":     sandbox.syncPushMs,
 		"sync_pull_ms":     syncPullMs,
-		"push_patch_bytes": syncPushPatchBytes,
+		"push_patch_bytes": sandbox.syncPushPatchBytes,
 		"pull_patch_bytes": syncPullPatchBytes,
 	})
 
-	runURL := s.sandboxRunURL(&SandboxSession{RunURL: sessionRunURL})
-	return &ExecSandboxResult{RunID: runID, ExitCode: exitCode, RunURL: runURL, PulledFiles: pulledFiles}, nil
+	return &ExecSandboxResult{RunID: sandbox.runID, ExitCode: exitCode, RunURL: sandbox.runURL, PulledFiles: pulledFiles}, nil
 }
 
 func (s Service) ListSandboxes(cfg ListSandboxesConfig) (*ListSandboxesResult, error) {
@@ -1090,6 +1506,7 @@ func (s Service) StopSandbox(cfg StopSandboxConfig) (*StopSandboxResult, error) 
 		if wasRunning {
 			s.waitForSandboxCompletion(session.RunID, session.ScopedToken)
 		}
+		s.closeSandboxTunnels(session.RunID)
 
 		// Remove from storage
 		delete(storage.Sandboxes, keys[i])
@@ -1158,6 +1575,16 @@ func (s Service) waitForSandboxCompletion(runID, scopedToken string) {
 	fmt.Fprintf(s.Stderr, "Warning: timed out waiting for sandbox %s to fully stop\n", runID)
 }
 
+func (s Service) closeSandboxTunnels(runID string) {
+	stateDirectory, err := sandboxTunnelStateDirectory()
+	if err == nil {
+		err = s.SSHTunnelManager.CloseAll(runID, stateDirectory)
+	}
+	if err != nil {
+		fmt.Fprintf(s.Stderr, "Warning: failed to close local tunnels for sandbox %s: %v\n", runID, err)
+	}
+}
+
 func (s Service) ResetSandbox(cfg ResetSandboxConfig) (*ResetSandboxResult, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -1215,6 +1642,7 @@ func (s Service) ResetSandbox(cfg ResetSandboxConfig) (*ResetSandboxResult, erro
 			if cancelMethod != "" {
 				s.waitForSandboxCompletion(session.RunID, session.ScopedToken)
 			}
+			s.closeSandboxTunnels(session.RunID)
 
 			// Remove old session
 			storage.DeleteSession(branch, cfg.ConfigFile)
@@ -1379,7 +1807,7 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 	return files, patchBytes, nil
 }
 
-func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHead string, connInfo *api.SandboxConnectionInfo) (int, error) {
+func (s Service) syncLocalChangesToSandbox(jsonMode bool, isNewSandbox bool, localHead string, connInfo *api.SandboxConnectionInfo) (int, error) {
 	if localHead == "" {
 		return 0, fmt.Errorf("sandbox sync requires a git repository with a valid HEAD")
 	}
@@ -1442,9 +1870,9 @@ func (s Service) prepareSandboxForExec(jsonMode bool, isNewSandbox bool, localHe
 		return patchBytes, syncPushErr
 	}
 	// A reused sandbox may still contain untracked files from the previous exec.
-	// Remove them before applying local dirty state so the command starts from a
-	// known baseline. A new sandbox may contain files prepared by its setup tasks,
-	// so preserve those on its first exec.
+	// Remove them before applying local dirty state so every operation starts from
+	// the same known baseline. A new sandbox may contain setup-created files, so
+	// preserve those on its first operation.
 	if !isNewSandbox {
 		exitCode, cleanErr := s.SSHClient.ExecuteCommand(sandboxWorktreeRootCommand("/usr/bin/git clean -fd >/dev/null 2>&1"))
 		if cleanErr != nil {

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -798,7 +798,14 @@ func (s Service) finishSandboxBackground(sandbox *syncedSandbox, process sandbox
 				return nil, statusErr
 			}
 			if status.Status != "running" {
-				return nil, fmt.Errorf("background process %q stopped before port %d became ready (status: %s; stdout: %s; stderr: %s)", process.Key, process.TargetPort, status.Status, status.StdoutPath, status.StderrPath)
+				processErr := fmt.Errorf("background process %q stopped before port %d became ready (status: %s; stdout: %s; stderr: %s)", process.Key, process.TargetPort, status.Status, status.StdoutPath, status.StderrPath)
+				closeErr := s.SSHTunnelManager.Close(rwxssh.TunnelCloseConfig{
+					Key: process.Key, RunID: sandbox.runID, StateDirectory: stateDirectory,
+				})
+				if closeErr != nil {
+					return nil, fmt.Errorf("%w; additionally failed to close local tunnel: %v", processErr, closeErr)
+				}
+				return nil, processErr
 			}
 			if time.Now().After(deadline) {
 				return nil, fmt.Errorf("timed out waiting for background process %q on %s; the process and tunnel are still running", process.Key, result.URL)

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -28,6 +28,7 @@ const (
 	sandboxDirectiveProcessStop    = "__rwx_sandbox_process_stop__"
 	sandboxDirectiveProcessStatus  = "__rwx_sandbox_process_status__"
 	sandboxDirectiveProcessLogs    = "__rwx_sandbox_process_logs__"
+	sandboxBackgroundNameSizeLimit = 255
 	rwxCLISSHUser                  = "rwx-cli"
 	// Reuse one fixed ref (force-pushed) rather than a unique ref per push so the
 	// sandbox's ref namespace doesn't accumulate dangling refs.
@@ -542,8 +543,8 @@ func (s Service) SyncSandbox(cfg SyncSandboxConfig) (*SyncSandboxResult, error) 
 }
 
 func (s Service) BackgroundSandbox(cfg BackgroundSandboxConfig) (*SandboxBackgroundResult, error) {
-	if strings.TrimSpace(cfg.Name) == "" {
-		return nil, fmt.Errorf("background process name is required")
+	if err := validateSandboxBackgroundName(cfg.Name); err != nil {
+		return nil, err
 	}
 	if cfg.TargetPort < 0 || cfg.TargetPort > 65535 {
 		return nil, fmt.Errorf("background process port must be between 1 and 65535")
@@ -587,8 +588,8 @@ func (s Service) BackgroundSandbox(cfg BackgroundSandboxConfig) (*SandboxBackgro
 }
 
 func (s Service) RestartSandboxBackground(cfg SandboxBackgroundConfig) (*SandboxBackgroundResult, error) {
-	if strings.TrimSpace(cfg.Name) == "" {
-		return nil, fmt.Errorf("background process name is required")
+	if err := validateSandboxBackgroundName(cfg.Name); err != nil {
+		return nil, err
 	}
 	sandbox, err := s.prepareSandboxOperation(sandboxOperationConfig{
 		RunID:           cfg.RunID,
@@ -612,8 +613,8 @@ func (s Service) RestartSandboxBackground(cfg SandboxBackgroundConfig) (*Sandbox
 }
 
 func (s Service) StopSandboxBackground(cfg SandboxBackgroundConfig) (*SandboxBackgroundResult, error) {
-	if strings.TrimSpace(cfg.Name) == "" {
-		return nil, fmt.Errorf("background process name is required")
+	if err := validateSandboxBackgroundName(cfg.Name); err != nil {
+		return nil, err
 	}
 	sandbox, err := s.prepareSandboxOperation(sandboxOperationConfig{
 		RunID:           cfg.RunID,
@@ -654,8 +655,8 @@ func (s Service) StopSandboxBackground(cfg SandboxBackgroundConfig) (*SandboxBac
 }
 
 func (s Service) LogsSandboxBackground(cfg SandboxBackgroundLogsConfig) (*SandboxBackgroundResult, error) {
-	if strings.TrimSpace(cfg.Name) == "" {
-		return nil, fmt.Errorf("background process name is required")
+	if err := validateSandboxBackgroundName(cfg.Name); err != nil {
+		return nil, err
 	}
 	sandbox, err := s.prepareSandboxOperation(sandboxOperationConfig{
 		RunID:           cfg.RunID,
@@ -798,6 +799,23 @@ func sandboxBackgroundResult(runID string, process sandboxProcessResponse) *Sand
 		PID: process.PID, PGID: process.PGID, StartedAt: process.StartedAt, CompletedAt: process.CompletedAt,
 		ExitCode: process.ExitCode, Signal: process.Signal, StdoutPath: process.StdoutPath, StderrPath: process.StderrPath,
 	}
+}
+
+func validateSandboxBackgroundName(name string) error {
+	if name == "" {
+		return fmt.Errorf("background process name is required")
+	}
+	if len(name) > sandboxBackgroundNameSizeLimit {
+		return fmt.Errorf("background process name must be at most %d bytes", sandboxBackgroundNameSizeLimit)
+	}
+	for _, char := range name {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') || char == '-' || char == '_' {
+			continue
+		}
+		return fmt.Errorf("background process name may contain only letters, numbers, underscores, and hyphens")
+	}
+	return nil
 }
 
 func sandboxTunnelStateDirectory() (string, error) {

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1239,9 +1239,14 @@ func TestService_BackgroundSandbox(t *testing.T) {
 
 	t.Run("starts without a tunnel when no port is requested", func(t *testing.T) {
 		setup, commands := setupBackground(t)
+		var closeConfig rwxssh.TunnelCloseConfig
 		setup.mockTunnel.MockOpen = func(rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
 			require.Fail(t, "a portless process must not open a tunnel")
 			return rwxssh.TunnelResult{}, nil
+		}
+		setup.mockTunnel.MockClose = func(cfg rwxssh.TunnelCloseConfig) error {
+			closeConfig = cfg
+			return nil
 		}
 
 		result, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{
@@ -1253,6 +1258,8 @@ func TestService_BackgroundSandbox(t *testing.T) {
 		require.NoError(t, err)
 		require.Zero(t, result.TargetPort)
 		require.Empty(t, result.URL)
+		require.Equal(t, "worker", closeConfig.Key)
+		require.Equal(t, "run-background", closeConfig.RunID)
 		require.Equal(t, "Started background process \"worker\".\n", setup.mockStdout.String())
 		processIndex := slices.IndexFunc(*commands, func(command string) bool {
 			return strings.HasPrefix(command, "__rwx_sandbox_process_start__ ")
@@ -1384,11 +1391,12 @@ rwx sandbox exec -- <command> syncs local changes before it runs.
 
 	t.Run("does not open a tunnel when the agent lacks process directives", func(t *testing.T) {
 		setup, _ := setupBackground(t)
-		setup.mockSSH.MockExecuteCommandWithOutput = func(command string) (int, string, error) {
+		setup.mockSSH.MockExecuteCommandWithSeparateOutput = func(command string) (int, string, string, error) {
 			if strings.HasPrefix(command, "__rwx_sandbox_process_start__ ") {
-				return 127, "", nil
+				return 127, "", "sh: " + command + ": command not found", nil
 			}
-			return 0, "", nil
+			exitCode, err := setup.mockSSH.ExecuteCommand(command)
+			return exitCode, "", "", err
 		}
 		setup.mockTunnel.MockOpen = func(rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
 			require.Fail(t, "tunnel must not open when process directives are unavailable")
@@ -1404,7 +1412,27 @@ rwx sandbox exec -- <command> syncs local changes before it runs.
 		})
 
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "sandbox agent does not support managed processes yet")
+		require.EqualError(t, err, "background processes are not supported by this sandbox")
+		require.NotContains(t, err.Error(), "__rwx_sandbox_")
+		require.NotContains(t, setup.mockStderr.String(), "__rwx_sandbox_")
+	})
+
+	t.Run("returns managed process diagnostics without exposing directives", func(t *testing.T) {
+		setup, _ := setupBackground(t)
+		setup.mockSSH.MockExecuteCommandWithSeparateOutput = func(command string) (int, string, string, error) {
+			if strings.HasPrefix(command, "__rwx_sandbox_process_restart__ ") {
+				return 1, "", `sandbox process "web" has no stored definition`, nil
+			}
+			exitCode, err := setup.mockSSH.ExecuteCommand(command)
+			return exitCode, "", "", err
+		}
+
+		_, err := setup.service.RestartSandboxBackground(cli.SandboxBackgroundConfig{
+			Name: "web", RunID: "run-background", Json: true,
+		})
+
+		require.EqualError(t, err, `sandbox agent failed to restart managed process: sandbox process "web" has no stored definition`)
+		require.NotContains(t, err.Error(), "__rwx_sandbox_")
 	})
 
 	t.Run("requires an already-running sandbox", func(t *testing.T) {
@@ -5352,6 +5380,11 @@ func TestService_ExecSandbox_Reset(t *testing.T) {
 		}
 
 		sshEndSent := false
+		closedTunnelRunID := ""
+		setup.mockTunnel.MockCloseAll = func(runID, stateDirectory string) error {
+			closedTunnelRunID = runID
+			return nil
+		}
 		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error { return nil }
 		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
 			if cmd == "__rwx_sandbox_end__" {
@@ -5372,6 +5405,7 @@ func TestService_ExecSandbox_Reset(t *testing.T) {
 
 		require.NoError(t, err)
 		require.True(t, sshEndSent, "expected __rwx_sandbox_end__ to be sent to old sandbox")
+		require.Equal(t, "run-existing", closedTunnelRunID)
 		require.Equal(t, "run-new", result.RunID)
 
 		storage, loadErr := cli.LoadSandboxStorage()

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rwx-cloud/rwx/internal/cli"
 	"github.com/rwx-cloud/rwx/internal/errors"
 	"github.com/rwx-cloud/rwx/internal/git"
+	rwxssh "github.com/rwx-cloud/rwx/internal/ssh"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 )
@@ -1004,6 +1005,340 @@ func TestService_ExecSandbox(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "The sandbox may have timed out")
 		require.NotContains(t, err.Error(), "firewall")
+	})
+}
+
+func TestService_SyncSandbox(t *testing.T) {
+	t.Run("requires an already-running sandbox", func(t *testing.T) {
+		setup := setupTest(t)
+		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
+			return &api.ListSandboxRunsResult{}, nil
+		}
+
+		_, err := setup.service.SyncSandbox(cli.SyncSandboxConfig{Json: true})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "No active sandbox found")
+		require.Contains(t, err.Error(), "rwx sandbox start")
+	})
+
+	t.Run("reuses exec preparation without running a command or pulling changes", func(t *testing.T) {
+		setup := setupTest(t)
+
+		runID := "run-sync"
+		address := "192.168.1.1:22"
+		localHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		localPatch := []byte("diff --git a/file.txt b/file.txt\n")
+		setup.mockGit.MockGetHead = localHead
+		setup.mockGit.MockGenerateDirtyPatches = func() (git.DirtyPatches, error) {
+			return git.DirtyPatches{Unstaged: localPatch, Files: []string{"file.txt"}}, nil
+		}
+
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			require.Equal(t, runID, id)
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        address,
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error {
+			require.Equal(t, address, addr)
+			return nil
+		}
+
+		var commands []string
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
+			commands = append(commands, cmd)
+			return 0, nil
+		}
+		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
+			commands = append(commands, cmd)
+			return 0, "", nil
+		}
+		setup.mockSSH.MockExecuteCommandWithStdinAndCombinedOutput = func(command string, stdin io.Reader) (int, string, error) {
+			commands = append(commands, command)
+			patch, err := io.ReadAll(stdin)
+			require.NoError(t, err)
+			require.Equal(t, localPatch, patch)
+			return 0, "", nil
+		}
+
+		result, err := setup.service.SyncSandbox(cli.SyncSandboxConfig{
+			RunID: runID,
+			Json:  true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, runID, result.RunID)
+		require.Empty(t, setup.mockStdout.String())
+		require.Equal(t, "__rwx_sandbox_lock_requested__", commands[0])
+		require.Contains(t, commands, "__rwx_sandbox_lock_released__")
+
+		checkoutIndex := sandboxCommandIndex(commands, "checkout -f")
+		cleanIndex := sandboxCommandIndex(commands, "/usr/bin/git clean -fd >/dev/null")
+		applyIndex := sandboxCommandIndex(commands, "/usr/bin/git apply --allow-empty -")
+		require.NotEqual(t, -1, checkoutIndex)
+		require.NotEqual(t, -1, cleanIndex)
+		require.NotEqual(t, -1, applyIndex)
+		require.Less(t, checkoutIndex, cleanIndex)
+		require.Less(t, cleanIndex, applyIndex)
+
+		for _, cmd := range commands {
+			require.NotContains(t, cmd, "git diff --binary --full-index", "sync should not pull sandbox changes locally")
+		}
+
+		require.Nil(t, findEvent(setup.drainEvents(), "sandbox.exec"))
+	})
+
+	t.Run("prints success without running a foreground command", func(t *testing.T) {
+		setup := setupTest(t)
+
+		runID := "run-sync-output"
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error { return nil }
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) { return 0, nil }
+		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) { return 0, "", nil }
+
+		_, err := setup.service.SyncSandbox(cli.SyncSandboxConfig{RunID: runID})
+
+		require.NoError(t, err)
+		require.Equal(t, "Synced local changes to sandbox.\n", setup.mockStdout.String())
+	})
+}
+
+func TestService_BackgroundSandbox(t *testing.T) {
+	setupBackground := func(t *testing.T) (*testSetup, *[]string) {
+		t.Helper()
+		setup := setupTest(t)
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(string, ssh.ClientConfig) error { return nil }
+		commands := []string{}
+		setup.mockSSH.MockExecuteCommand = func(command string) (int, error) {
+			commands = append(commands, command)
+			return 0, nil
+		}
+		setup.mockSSH.MockExecuteCommandWithOutput = func(command string) (int, string, error) {
+			commands = append(commands, command)
+			if strings.HasPrefix(command, "__rwx_sandbox_process_start__ ") {
+				return 0, `{"key":"web","status":"running","targetPort":3100,"pid":243,"pgid":243}`, nil
+			}
+			return 0, "", nil
+		}
+		return setup, &commands
+	}
+
+	t.Run("syncs, starts a managed process, and opens a local tunnel", func(t *testing.T) {
+		setup, commands := setupBackground(t)
+		var tunnelConfig rwxssh.TunnelConfig
+		setup.mockTunnel.MockOpen = func(cfg rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
+			tunnelConfig = cfg
+			return rwxssh.TunnelResult{LocalPort: 8310}, nil
+		}
+
+		result, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{
+			Command: []string{
+				"/bin/sh",
+				"-lc",
+				`mkdir -p /tmp/rwx-preview && printf "ok\n" > /tmp/rwx-preview/index.html && python3 -m http.server 3100`,
+			},
+			Name:       "web",
+			TargetPort: 3100,
+			LocalPort:  8310,
+			RunID:      "run-preview",
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "run-preview", result.RunID)
+		require.Equal(t, "web", result.Name)
+		require.Equal(t, 8310, result.LocalPort)
+		require.Equal(t, "http://127.0.0.1:8310", result.URL)
+		require.Equal(t, "web", tunnelConfig.Key)
+		require.Equal(t, "run-preview", tunnelConfig.RunID)
+		require.Equal(t, "192.168.1.1:22", tunnelConfig.Address)
+		require.Equal(t, 8310, tunnelConfig.LocalPort)
+		require.Equal(t, 3100, tunnelConfig.TargetPort)
+
+		processIndex := slices.IndexFunc(*commands, func(command string) bool {
+			return strings.HasPrefix(command, "__rwx_sandbox_process_start__ ")
+		})
+		require.NotEqual(t, -1, processIndex)
+		var processRequest struct {
+			Key        string `json:"key"`
+			Command    string `json:"command"`
+			TargetPort int    `json:"targetPort"`
+		}
+		payload := strings.TrimPrefix((*commands)[processIndex], "__rwx_sandbox_process_start__ ")
+		require.NoError(t, json.Unmarshal([]byte(payload), &processRequest))
+		require.Equal(t, "web", processRequest.Key)
+		require.Equal(t, 3100, processRequest.TargetPort)
+		require.Contains(t, processRequest.Command, "python3 -m http.server 3100")
+		checkoutIndex := sandboxCommandIndex(*commands, "checkout -f")
+		require.NotEqual(t, -1, checkoutIndex)
+		require.Less(t, checkoutIndex, processIndex)
+		require.Equal(t, "__rwx_sandbox_lock_requested__", (*commands)[0])
+		require.Equal(t, "__rwx_sandbox_lock_released__", (*commands)[len(*commands)-1])
+		for _, command := range *commands {
+			require.NotContains(t, command, "__rwx_sandbox_preview_")
+			require.False(t, isSandboxPullDiffCommand(command), "preview must not pull changes back")
+		}
+	})
+
+	t.Run("starts without a tunnel when no port is requested", func(t *testing.T) {
+		setup, commands := setupBackground(t)
+		setup.mockTunnel.MockOpen = func(rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
+			require.Fail(t, "a portless process must not open a tunnel")
+			return rwxssh.TunnelResult{}, nil
+		}
+
+		result, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{
+			Command: []string{"bin/worker"},
+			Name:    "worker",
+			RunID:   "run-background",
+		})
+
+		require.NoError(t, err)
+		require.Zero(t, result.TargetPort)
+		require.Empty(t, result.URL)
+		require.Equal(t, "Started background process \"worker\".\n", setup.mockStdout.String())
+		processIndex := slices.IndexFunc(*commands, func(command string) bool {
+			return strings.HasPrefix(command, "__rwx_sandbox_process_start__ ")
+		})
+		require.NotEqual(t, -1, processIndex)
+		var request map[string]any
+		require.NoError(t, json.Unmarshal([]byte(strings.TrimPrefix((*commands)[processIndex], "__rwx_sandbox_process_start__ ")), &request))
+		require.Equal(t, "worker", request["key"])
+		_, hasTargetPort := request["targetPort"]
+		require.False(t, hasTargetPort)
+	})
+
+	t.Run("rejects a local port without a sandbox port", func(t *testing.T) {
+		setup := setupTest(t)
+		_, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{
+			Command:   []string{"bin/worker"},
+			Name:      "worker",
+			LocalPort: 8310,
+		})
+		require.EqualError(t, err, "--local-port requires --port")
+	})
+
+	t.Run("syncs before restarting and reopens its tunnel", func(t *testing.T) {
+		setup, commands := setupBackground(t)
+		setup.mockSSH.MockExecuteCommandWithOutput = func(command string) (int, string, error) {
+			*commands = append(*commands, command)
+			if strings.HasPrefix(command, "__rwx_sandbox_process_restart__ ") {
+				return 0, `{"key":"web","status":"running","targetPort":3100}`, nil
+			}
+			return 0, "", nil
+		}
+		var tunnelConfig rwxssh.TunnelConfig
+		setup.mockTunnel.MockOpen = func(cfg rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
+			tunnelConfig = cfg
+			return rwxssh.TunnelResult{LocalPort: 8310}, nil
+		}
+
+		result, err := setup.service.RestartSandboxBackground(cli.SandboxBackgroundConfig{
+			Name: "web", RunID: "run-background", Json: true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "http://127.0.0.1:8310", result.URL)
+		require.Equal(t, 0, tunnelConfig.LocalPort, "restart should let the tunnel manager reuse its saved local port")
+		checkoutIndex := sandboxCommandIndex(*commands, "checkout -f")
+		restartIndex := slices.IndexFunc(*commands, func(command string) bool {
+			return strings.HasPrefix(command, "__rwx_sandbox_process_restart__ ")
+		})
+		require.NotEqual(t, -1, checkoutIndex)
+		require.NotEqual(t, -1, restartIndex)
+		require.Less(t, checkoutIndex, restartIndex)
+	})
+
+	t.Run("stop closes the matching tunnel without syncing", func(t *testing.T) {
+		setup, commands := setupBackground(t)
+		setup.mockGit.MockGetHeadError = fmt.Errorf("git should not be consulted")
+		setup.mockSSH.MockExecuteCommandWithOutput = func(command string) (int, string, error) {
+			*commands = append(*commands, command)
+			return 0, `{"key":"web","status":"stopped"}`, nil
+		}
+		var closeConfig rwxssh.TunnelCloseConfig
+		setup.mockTunnel.MockClose = func(cfg rwxssh.TunnelCloseConfig) error {
+			closeConfig = cfg
+			return nil
+		}
+
+		result, err := setup.service.StopSandboxBackground(cli.SandboxBackgroundConfig{
+			Name: "web", RunID: "run-background", Json: true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "stopped", result.Status)
+		require.Equal(t, "web", closeConfig.Key)
+		require.Equal(t, "run-background", closeConfig.RunID)
+		require.True(t, slices.ContainsFunc(*commands, func(command string) bool {
+			return strings.HasPrefix(command, "__rwx_sandbox_process_stop__ ")
+		}))
+		for _, command := range *commands {
+			require.NotContains(t, command, "checkout -f")
+		}
+	})
+
+	t.Run("does not open a tunnel when the agent lacks process directives", func(t *testing.T) {
+		setup, _ := setupBackground(t)
+		setup.mockSSH.MockExecuteCommandWithOutput = func(command string) (int, string, error) {
+			if strings.HasPrefix(command, "__rwx_sandbox_process_start__ ") {
+				return 127, "", nil
+			}
+			return 0, "", nil
+		}
+		setup.mockTunnel.MockOpen = func(rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
+			require.Fail(t, "tunnel must not open when process directives are unavailable")
+			return rwxssh.TunnelResult{}, nil
+		}
+
+		_, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{
+			Command:    []string{"bin/server"},
+			Name:       "web",
+			TargetPort: 3000,
+			RunID:      "run-preview-old-agent",
+			Json:       true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "sandbox agent does not support managed processes yet")
+	})
+
+	t.Run("requires an already-running sandbox", func(t *testing.T) {
+		setup := setupTest(t)
+		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
+			return &api.ListSandboxRunsResult{}, nil
+		}
+
+		_, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{
+			Command:    []string{"bin/server"},
+			Name:       "web",
+			TargetPort: 3000,
+			Json:       true,
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "No active sandbox found")
+		require.Contains(t, err.Error(), "rwx sandbox start")
 	})
 }
 

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1111,7 +1111,7 @@ func TestService_SyncSandbox(t *testing.T) {
 		_, err := setup.service.SyncSandbox(cli.SyncSandboxConfig{RunID: runID})
 
 		require.NoError(t, err)
-		require.Equal(t, "Synced local changes to sandbox.\n", setup.mockStdout.String())
+		require.Equal(t, "Pushed local changes to sandbox.\n", setup.mockStdout.String())
 	})
 }
 
@@ -1290,7 +1290,7 @@ func TestService_BackgroundSandbox(t *testing.T) {
 		require.Equal(t, `Preview "web": https://127.0.0.1:8310
 
 After local edits:
-  Hot reload:    rwx sandbox sync
+  Hot reload:    rwx sandbox push
   Hard restart:  rwx sandbox background restart --name web
 
 rwx sandbox exec -- <command> syncs local changes before it runs.
@@ -1485,7 +1485,7 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		})
 
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "sandbox sync requires a git repository with a valid HEAD")
+		require.Contains(t, err.Error(), "sandbox push requires a git repository with a valid HEAD")
 		require.Contains(t, err.Error(), "not a git repository")
 	})
 

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1360,6 +1360,40 @@ rwx sandbox exec -- <command> syncs local changes before it runs.
 		require.Less(t, checkoutIndex, restartIndex)
 	})
 
+	t.Run("closes the tunnel when the process stops before becoming ready", func(t *testing.T) {
+		setup, _ := setupBackground(t)
+		setup.mockSSH.MockExecuteCommandWithSeparateOutput = func(command string) (int, string, string, error) {
+			switch {
+			case strings.HasPrefix(command, "__rwx_sandbox_process_start__ "):
+				return 0, `{"key":"web","status":"running","targetPort":3100}`, "", nil
+			case strings.HasPrefix(command, "__rwx_sandbox_process_status__ "):
+				return 0, `{"key":"web","status":"stopped","targetPort":3100,"stdoutPath":"/tmp/web.stdout","stderrPath":"/tmp/web.stderr"}`, "", nil
+			default:
+				return 0, "", "", nil
+			}
+		}
+		setup.mockTunnel.MockOpen = func(rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
+			return rwxssh.TunnelResult{LocalPort: 8310, Scheme: "http"}, nil
+		}
+		setup.mockTunnel.MockIsReady = func(int) bool { return false }
+		var closeConfig rwxssh.TunnelCloseConfig
+		setup.mockTunnel.MockClose = func(cfg rwxssh.TunnelCloseConfig) error {
+			closeConfig = cfg
+			return fmt.Errorf("control exit failed")
+		}
+
+		_, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{
+			Command: []string{"bin/server"}, Name: "web", TargetPort: 3100, RunID: "run-background", Json: true,
+		})
+
+		require.ErrorContains(t, err, `background process "web" stopped before port 3100 became ready`)
+		require.ErrorContains(t, err, "stdout: /tmp/web.stdout; stderr: /tmp/web.stderr")
+		require.ErrorContains(t, err, "additionally failed to close local tunnel: control exit failed")
+		require.Equal(t, "web", closeConfig.Key)
+		require.Equal(t, "run-background", closeConfig.RunID)
+		require.NotEmpty(t, closeConfig.StateDirectory)
+	})
+
 	t.Run("stop closes the matching tunnel without syncing", func(t *testing.T) {
 		setup, commands := setupBackground(t)
 		setup.mockGit.MockGetHeadError = fmt.Errorf("git should not be consulted")

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1183,7 +1183,7 @@ func TestService_BackgroundSandbox(t *testing.T) {
 		var tunnelConfig rwxssh.TunnelConfig
 		setup.mockTunnel.MockOpen = func(cfg rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
 			tunnelConfig = cfg
-			return rwxssh.TunnelResult{LocalPort: 8310}, nil
+			return rwxssh.TunnelResult{LocalPort: 8310, Scheme: cfg.Scheme}, nil
 		}
 
 		result, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{
@@ -1209,6 +1209,8 @@ func TestService_BackgroundSandbox(t *testing.T) {
 		require.Equal(t, "192.168.1.1:22", tunnelConfig.Address)
 		require.Equal(t, 8310, tunnelConfig.LocalPort)
 		require.Equal(t, 3100, tunnelConfig.TargetPort)
+		require.Equal(t, "http", tunnelConfig.Scheme)
+		require.Equal(t, "http", result.Scheme)
 
 		processIndex := slices.IndexFunc(*commands, func(command string) bool {
 			return strings.HasPrefix(command, "__rwx_sandbox_process_start__ ")
@@ -1263,6 +1265,31 @@ func TestService_BackgroundSandbox(t *testing.T) {
 		require.False(t, hasTargetPort)
 	})
 
+	t.Run("prints preview URL and update commands in text mode", func(t *testing.T) {
+		setup, _ := setupBackground(t)
+		setup.mockTunnel.MockOpen = func(rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
+			return rwxssh.TunnelResult{LocalPort: 8310, Scheme: "https"}, nil
+		}
+
+		_, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{
+			Command:    []string{"bin/server"},
+			Name:       "web",
+			TargetPort: 3100,
+			Scheme:     "https",
+			RunID:      "run-preview",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, `Preview "web": https://127.0.0.1:8310
+
+After local edits:
+  Hot reload:    rwx sandbox sync
+  Hard restart:  rwx sandbox background restart --name web
+
+rwx sandbox exec -- <command> syncs local changes before it runs.
+`, setup.mockStdout.String())
+	})
+
 	t.Run("rejects a local port without a sandbox port", func(t *testing.T) {
 		setup := setupTest(t)
 		_, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{
@@ -1271,6 +1298,27 @@ func TestService_BackgroundSandbox(t *testing.T) {
 			LocalPort: 8310,
 		})
 		require.EqualError(t, err, "--local-port requires --port")
+	})
+
+	t.Run("rejects a scheme without a sandbox port", func(t *testing.T) {
+		setup := setupTest(t)
+		_, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{
+			Command: []string{"bin/worker"},
+			Name:    "worker",
+			Scheme:  "https",
+		})
+		require.EqualError(t, err, "--scheme requires --port")
+	})
+
+	t.Run("rejects an unsupported URL scheme", func(t *testing.T) {
+		setup := setupTest(t)
+		_, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{
+			Command:    []string{"bin/server"},
+			Name:       "web",
+			TargetPort: 3100,
+			Scheme:     "ftp",
+		})
+		require.EqualError(t, err, "--scheme must be http or https")
 	})
 
 	t.Run("syncs before restarting and reopens its tunnel", func(t *testing.T) {
@@ -1285,7 +1333,7 @@ func TestService_BackgroundSandbox(t *testing.T) {
 		var tunnelConfig rwxssh.TunnelConfig
 		setup.mockTunnel.MockOpen = func(cfg rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
 			tunnelConfig = cfg
-			return rwxssh.TunnelResult{LocalPort: 8310}, nil
+			return rwxssh.TunnelResult{LocalPort: 8310, Scheme: "https"}, nil
 		}
 
 		result, err := setup.service.RestartSandboxBackground(cli.SandboxBackgroundConfig{
@@ -1293,7 +1341,8 @@ func TestService_BackgroundSandbox(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, "http://127.0.0.1:8310", result.URL)
+		require.Equal(t, "https://127.0.0.1:8310", result.URL)
+		require.Equal(t, "https", result.Scheme)
 		require.Equal(t, 0, tunnelConfig.LocalPort, "restart should let the tunnel manager reuse its saved local port")
 		checkoutIndex := sandboxCommandIndex(*commands, "checkout -f")
 		restartIndex := slices.IndexFunc(*commands, func(command string) bool {

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -3761,15 +3761,16 @@ func TestService_ExecSandbox_ConcurrentAutoCreate(t *testing.T) {
 		stdout2 := &strings.Builder{}
 		stderr2 := &strings.Builder{}
 		service2, err := cli.NewService(cli.Config{
-			APIClient:   setup.mockAPI,
-			SSHClient:   setup.mockSSH,
-			GitClient:   setup.mockGit,
-			DockerCLI:   setup.mockDocker,
-			Stdin:       &bytes.Buffer{},
-			Stdout:      stdout2,
-			StdoutIsTTY: false,
-			Stderr:      stderr2,
-			StderrIsTTY: false,
+			APIClient:        setup.mockAPI,
+			SSHClient:        setup.mockSSH,
+			SSHTunnelManager: setup.mockTunnel,
+			GitClient:        setup.mockGit,
+			DockerCLI:        setup.mockDocker,
+			Stdin:            &bytes.Buffer{},
+			Stdout:           stdout2,
+			StdoutIsTTY:      false,
+			Stderr:           stderr2,
+			StderrIsTTY:      false,
 		})
 		require.NoError(t, err)
 

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1143,6 +1143,41 @@ func TestService_BackgroundSandbox(t *testing.T) {
 		return setup, &commands
 	}
 
+	t.Run("validates names before contacting the sandbox", func(t *testing.T) {
+		setup := setupTest(t)
+		invalidName := "../web"
+		for action, run := range map[string]func() error{
+			"start": func() error {
+				_, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{Name: invalidName, Command: []string{"bin/server"}})
+				return err
+			},
+			"restart": func() error {
+				_, err := setup.service.RestartSandboxBackground(cli.SandboxBackgroundConfig{Name: invalidName})
+				return err
+			},
+			"stop": func() error {
+				_, err := setup.service.StopSandboxBackground(cli.SandboxBackgroundConfig{Name: invalidName})
+				return err
+			},
+			"logs": func() error {
+				_, err := setup.service.LogsSandboxBackground(cli.SandboxBackgroundLogsConfig{Name: invalidName})
+				return err
+			},
+		} {
+			t.Run(action, func(t *testing.T) {
+				require.EqualError(t, run(), "background process name may contain only letters, numbers, underscores, and hyphens")
+			})
+		}
+
+		_, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{Command: []string{"bin/server"}})
+		require.EqualError(t, err, "background process name is required")
+
+		_, err = setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{
+			Name: strings.Repeat("a", 256), Command: []string{"bin/server"},
+		})
+		require.EqualError(t, err, "background process name must be at most 255 bytes")
+	})
+
 	t.Run("syncs, starts a managed process, and opens a local tunnel", func(t *testing.T) {
 		setup, commands := setupBackground(t)
 		var tunnelConfig rwxssh.TunnelConfig

--- a/internal/cli/service_test.go
+++ b/internal/cli/service_test.go
@@ -40,6 +40,7 @@ func setupSkillTest(t *testing.T) *testSetup {
 
 	setup.mockAPI = new(mocks.API)
 	setup.mockSSH = new(mocks.SSH)
+	setup.mockTunnel = new(mocks.SSHTunnelManager)
 	setup.mockGit = &mocks.Git{
 		MockIsInstalled:      true,
 		MockIsInsideWorkTree: true,
@@ -53,6 +54,7 @@ func setupSkillTest(t *testing.T) *testSetup {
 	setup.config = cli.Config{
 		APIClient:          setup.mockAPI,
 		SSHClient:          setup.mockSSH,
+		SSHTunnelManager:   setup.mockTunnel,
 		GitClient:          setup.mockGit,
 		DockerCLI:          setup.mockDocker,
 		TelemetryCollector: setup.collector,

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -68,6 +68,14 @@ func setupTest(t *testing.T) *testSetup {
 	setup.mockSSH.MockExecuteCommandWithOutput = func(command string) (int, string, error) {
 		return 0, "", nil
 	}
+	setup.mockSSH.MockExecuteCommandWithSeparateOutput = func(command string) (int, string, string, error) {
+		if strings.HasPrefix(command, "__rwx_sandbox_process_") {
+			exitCode, stdout, err := setup.mockSSH.ExecuteCommandWithOutput(command)
+			return exitCode, stdout, "", err
+		}
+		exitCode, err := setup.mockSSH.ExecuteCommand(command)
+		return exitCode, "", "", err
+	}
 	setup.mockGit = &mocks.Git{
 		MockIsInstalled:      true,
 		MockIsInsideWorkTree: true,

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -19,6 +19,7 @@ type testSetup struct {
 	collector  *telemetry.Collector
 	mockAPI    *mocks.API
 	mockSSH    *mocks.SSH
+	mockTunnel *mocks.SSHTunnelManager
 	mockGit    *mocks.Git
 	mockDocker *mocks.DockerClient
 	mockStdin  *bytes.Buffer
@@ -63,6 +64,7 @@ func setupTest(t *testing.T) *testSetup {
 	require.NoError(t, os.Mkdir(filepath.Join(setup.tmp, ".rwx"), 0o755))
 	setup.mockAPI = new(mocks.API)
 	setup.mockSSH = new(mocks.SSH)
+	setup.mockTunnel = new(mocks.SSHTunnelManager)
 	setup.mockSSH.MockExecuteCommandWithOutput = func(command string) (int, string, error) {
 		return 0, "", nil
 	}
@@ -80,6 +82,7 @@ func setupTest(t *testing.T) *testSetup {
 	setup.config = cli.Config{
 		APIClient:          setup.mockAPI,
 		SSHClient:          setup.mockSSH,
+		SSHTunnelManager:   setup.mockTunnel,
 		GitClient:          setup.mockGit,
 		DockerCLI:          setup.mockDocker,
 		TelemetryCollector: setup.collector,

--- a/internal/mocks/ssh.go
+++ b/internal/mocks/ssh.go
@@ -14,6 +14,7 @@ type SSH struct {
 	MockExecuteCommand                           func(command string) (int, error)
 	MockExecuteCommandWithStdin                  func(command string, stdin io.Reader) (int, error)
 	MockExecuteCommandWithOutput                 func(command string) (int, string, error)
+	MockExecuteCommandWithSeparateOutput         func(command string) (int, string, string, error)
 	MockExecuteCommandWithStdinAndCombinedOutput func(command string, stdin io.Reader) (int, string, error)
 }
 
@@ -59,6 +60,14 @@ func (s *SSH) ExecuteCommandWithOutput(command string) (int, string, error) {
 	}
 
 	return -1, "", errors.New("MockExecuteCommandWithOutput was not configured")
+}
+
+func (s *SSH) ExecuteCommandWithSeparateOutput(command string) (int, string, string, error) {
+	if s.MockExecuteCommandWithSeparateOutput != nil {
+		return s.MockExecuteCommandWithSeparateOutput(command)
+	}
+
+	return -1, "", "", errors.New("MockExecuteCommandWithSeparateOutput was not configured")
 }
 
 func (s *SSH) ExecuteCommandWithStdinAndCombinedOutput(command string, stdin io.Reader) (int, string, error) {

--- a/internal/mocks/ssh_tunnel.go
+++ b/internal/mocks/ssh_tunnel.go
@@ -1,0 +1,41 @@
+package mocks
+
+import (
+	"github.com/rwx-cloud/rwx/internal/errors"
+	rwxssh "github.com/rwx-cloud/rwx/internal/ssh"
+)
+
+type SSHTunnelManager struct {
+	MockOpen     func(rwxssh.TunnelConfig) (rwxssh.TunnelResult, error)
+	MockClose    func(rwxssh.TunnelCloseConfig) error
+	MockCloseAll func(string, string) error
+	MockIsReady  func(int) bool
+}
+
+func (m *SSHTunnelManager) Open(cfg rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
+	if m.MockOpen != nil {
+		return m.MockOpen(cfg)
+	}
+	return rwxssh.TunnelResult{}, errors.New("MockOpen was not configured")
+}
+
+func (m *SSHTunnelManager) Close(cfg rwxssh.TunnelCloseConfig) error {
+	if m.MockClose != nil {
+		return m.MockClose(cfg)
+	}
+	return nil
+}
+
+func (m *SSHTunnelManager) CloseAll(runID, stateDirectory string) error {
+	if m.MockCloseAll != nil {
+		return m.MockCloseAll(runID, stateDirectory)
+	}
+	return nil
+}
+
+func (m *SSHTunnelManager) IsReady(localPort int) bool {
+	if m.MockIsReady != nil {
+		return m.MockIsReady(localPort)
+	}
+	return true
+}

--- a/internal/ssh/client.go
+++ b/internal/ssh/client.go
@@ -157,6 +157,35 @@ func (c *Client) ExecuteCommandWithOutput(command string) (int, string, error) {
 	return 0, stdout.String(), nil
 }
 
+// ExecuteCommandWithSeparateOutput runs a command non-interactively over SSH
+// and captures stdout and stderr independently.
+//
+// Return values:
+//   - (0, stdout, stderr, nil)   = command succeeded with exit code 0
+//   - (N, stdout, stderr, nil)   = command completed with non-zero exit code N
+//   - (-1, "", "", err)        = SSH/connection error (command may not have run)
+func (c *Client) ExecuteCommandWithSeparateOutput(command string) (int, string, string, error) {
+	session, err := c.Client.NewSession()
+	if err != nil {
+		return -1, "", "", errors.Wrap(err, "unable to create SSH session")
+	}
+	defer session.Close()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	session.Stdout = &stdout
+	session.Stderr = &stderr
+
+	err = session.Run(command)
+	if err != nil {
+		if exitErr, ok := err.(*ssh.ExitError); ok {
+			return exitErr.ExitStatus(), stdout.String(), stderr.String(), nil
+		}
+		return -1, "", "", errors.Wrap(err, "SSH command execution failed")
+	}
+	return 0, stdout.String(), stderr.String(), nil
+}
+
 // ExecuteCommandWithStdinAndCombinedOutput runs a command non-interactively over SSH,
 // piping data to stdin, and captures both stdout and stderr.
 //

--- a/internal/ssh/tunnel.go
+++ b/internal/ssh/tunnel.go
@@ -22,12 +22,14 @@ type TunnelConfig struct {
 	PublicHostKey     string
 	LocalPort         int
 	TargetPort        int
+	Scheme            string
 	StateDirectory    string
 	RemoteDestination string
 }
 
 type TunnelResult struct {
 	LocalPort int
+	Scheme    string
 }
 
 type TunnelCloseConfig struct {
@@ -52,6 +54,7 @@ type tunnelState struct {
 	RunID      string `json:"runId"`
 	LocalPort  int    `json:"localPort"`
 	TargetPort int    `json:"targetPort"`
+	Scheme     string `json:"scheme"`
 	SocketPath string `json:"socketPath"`
 }
 
@@ -102,6 +105,17 @@ func (m tunnelManager) Open(cfg TunnelConfig) (TunnelResult, error) {
 	}
 	if state.SocketPath != "" {
 		_ = exec.Command(m.binary, "-F", "/dev/null", "-S", state.SocketPath, "-O", "exit", "rwx-preview").Run()
+	}
+
+	scheme := cfg.Scheme
+	if scheme == "" && state.Key == cfg.Key && state.RunID == cfg.RunID {
+		scheme = state.Scheme
+	}
+	if scheme == "" {
+		scheme = "http"
+	}
+	if scheme != "http" && scheme != "https" {
+		return TunnelResult{}, fmt.Errorf("scheme must be http or https")
 	}
 
 	localPort := cfg.LocalPort
@@ -191,6 +205,7 @@ func (m tunnelManager) Open(cfg TunnelConfig) (TunnelResult, error) {
 		RunID:      cfg.RunID,
 		LocalPort:  localPort,
 		TargetPort: cfg.TargetPort,
+		Scheme:     scheme,
 		SocketPath: socketPath,
 	}
 	data, err := json.MarshalIndent(state, "", "  ")
@@ -203,7 +218,7 @@ func (m tunnelManager) Open(cfg TunnelConfig) (TunnelResult, error) {
 		return TunnelResult{}, fmt.Errorf("unable to save background tunnel state: %w", err)
 	}
 
-	return TunnelResult{LocalPort: localPort}, nil
+	return TunnelResult{LocalPort: localPort, Scheme: scheme}, nil
 }
 
 func (m tunnelManager) Close(cfg TunnelCloseConfig) error {

--- a/internal/ssh/tunnel.go
+++ b/internal/ssh/tunnel.go
@@ -1,0 +1,282 @@
+package ssh
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type TunnelConfig struct {
+	Key               string
+	RunID             string
+	Address           string
+	PrivateUserKey    string
+	PublicHostKey     string
+	LocalPort         int
+	TargetPort        int
+	StateDirectory    string
+	RemoteDestination string
+}
+
+type TunnelResult struct {
+	LocalPort int
+}
+
+type TunnelCloseConfig struct {
+	Key            string
+	RunID          string
+	StateDirectory string
+}
+
+type TunnelManager interface {
+	Open(TunnelConfig) (TunnelResult, error)
+	Close(TunnelCloseConfig) error
+	CloseAll(runID, stateDirectory string) error
+	IsReady(localPort int) bool
+}
+
+type tunnelManager struct {
+	binary string
+}
+
+type tunnelState struct {
+	Key        string `json:"key"`
+	RunID      string `json:"runId"`
+	LocalPort  int    `json:"localPort"`
+	TargetPort int    `json:"targetPort"`
+	SocketPath string `json:"socketPath"`
+}
+
+func NewTunnelManager() TunnelManager {
+	return tunnelManager{binary: "ssh"}
+}
+
+func (m tunnelManager) IsReady(localPort int) bool {
+	connection, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", localPort), 250*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	defer connection.Close()
+	if err := connection.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
+		return false
+	}
+	buffer := make([]byte, 1)
+	bytesRead, err := connection.Read(buffer)
+	if bytesRead > 0 {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+func (m tunnelManager) Open(cfg TunnelConfig) (TunnelResult, error) {
+	if cfg.Key == "" {
+		return TunnelResult{}, fmt.Errorf("background process key is required")
+	}
+	if cfg.TargetPort < 1 || cfg.TargetPort > 65535 {
+		return TunnelResult{}, fmt.Errorf("target port must be between 1 and 65535")
+	}
+	if cfg.LocalPort < 0 || cfg.LocalPort > 65535 {
+		return TunnelResult{}, fmt.Errorf("local port must be between 1 and 65535")
+	}
+
+	hash := sha256.Sum256([]byte(cfg.StateDirectory + "\x00" + cfg.Key))
+	keyHash := hex.EncodeToString(hash[:8])
+	previewDir := filepath.Join(cfg.StateDirectory, keyHash)
+	if err := os.MkdirAll(previewDir, 0o700); err != nil {
+		return TunnelResult{}, fmt.Errorf("unable to create background tunnel state: %w", err)
+	}
+
+	statePath := filepath.Join(previewDir, "state.json")
+	state := tunnelState{}
+	if data, err := os.ReadFile(statePath); err == nil {
+		_ = json.Unmarshal(data, &state)
+	}
+	if state.SocketPath != "" {
+		_ = exec.Command(m.binary, "-F", "/dev/null", "-S", state.SocketPath, "-O", "exit", "rwx-preview").Run()
+	}
+
+	localPort := cfg.LocalPort
+	if localPort == 0 && state.Key == cfg.Key && state.RunID == cfg.RunID {
+		localPort = state.LocalPort
+	}
+	if localPort != 0 && cfg.LocalPort == 0 {
+		listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", localPort))
+		if err != nil {
+			localPort = 0
+		} else {
+			_ = listener.Close()
+		}
+	}
+	if localPort == 0 {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return TunnelResult{}, fmt.Errorf("unable to allocate local background process port: %w", err)
+		}
+		localPort = listener.Addr().(*net.TCPAddr).Port
+		if err := listener.Close(); err != nil {
+			return TunnelResult{}, fmt.Errorf("unable to release allocated background process port: %w", err)
+		}
+	}
+
+	host, port, err := net.SplitHostPort(cfg.Address)
+	if err != nil {
+		return TunnelResult{}, fmt.Errorf("unable to parse sandbox SSH address: %w", err)
+	}
+	keyFile, err := os.CreateTemp("", "rwx-preview-key-*")
+	if err != nil {
+		return TunnelResult{}, err
+	}
+	keyPath := keyFile.Name()
+	_ = keyFile.Close()
+	defer os.Remove(keyPath)
+	if err := os.WriteFile(keyPath, []byte(cfg.PrivateUserKey), 0o600); err != nil {
+		return TunnelResult{}, err
+	}
+
+	knownHostsFile, err := os.CreateTemp("", "rwx-preview-known-hosts-*")
+	if err != nil {
+		return TunnelResult{}, err
+	}
+	knownHostsPath := knownHostsFile.Name()
+	_ = knownHostsFile.Close()
+	defer os.Remove(knownHostsPath)
+
+	alias := "rwx-preview-" + keyHash
+	if err := os.WriteFile(knownHostsPath, []byte(fmt.Sprintf("%s %s\n", alias, strings.TrimSpace(cfg.PublicHostKey))), 0o600); err != nil {
+		return TunnelResult{}, err
+	}
+
+	socketPath := filepath.Join(os.TempDir(), "rwx-preview-"+keyHash+".sock")
+	_ = os.Remove(socketPath)
+	remoteDestination := cfg.RemoteDestination
+	if remoteDestination == "" {
+		remoteDestination = "127.0.0.1"
+	}
+	forward := fmt.Sprintf("127.0.0.1:%d:%s:%d", localPort, remoteDestination, cfg.TargetPort)
+	args := []string{
+		"-F", "/dev/null",
+		"-f", "-N", "-M",
+		"-S", socketPath,
+		"-i", keyPath,
+		"-o", "BatchMode=yes",
+		"-o", "IdentitiesOnly=yes",
+		"-o", "ExitOnForwardFailure=yes",
+		"-o", "StrictHostKeyChecking=yes",
+		"-o", "UserKnownHostsFile=" + knownHostsPath,
+		"-o", "HostKeyAlias=" + alias,
+		"-o", "HostName=" + host,
+		"-p", port,
+		"-L", forward,
+		"rwx-cli@" + alias,
+	}
+	if output, err := exec.Command(m.binary, args...).CombinedOutput(); err != nil {
+		message := strings.TrimSpace(string(output))
+		if message != "" {
+			return TunnelResult{}, fmt.Errorf("unable to open SSH background process tunnel: %s", message)
+		}
+		return TunnelResult{}, fmt.Errorf("unable to open SSH background process tunnel: %w", err)
+	}
+
+	state = tunnelState{
+		Key:        cfg.Key,
+		RunID:      cfg.RunID,
+		LocalPort:  localPort,
+		TargetPort: cfg.TargetPort,
+		SocketPath: socketPath,
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return TunnelResult{}, err
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(statePath, data, 0o600); err != nil {
+		_ = exec.Command(m.binary, "-F", "/dev/null", "-S", socketPath, "-O", "exit", "rwx-preview").Run()
+		return TunnelResult{}, fmt.Errorf("unable to save background tunnel state: %w", err)
+	}
+
+	return TunnelResult{LocalPort: localPort}, nil
+}
+
+func (m tunnelManager) Close(cfg TunnelCloseConfig) error {
+	if cfg.Key == "" {
+		return fmt.Errorf("background process key is required")
+	}
+
+	hash := sha256.Sum256([]byte(cfg.StateDirectory + "\x00" + cfg.Key))
+	stateDirectory := filepath.Join(cfg.StateDirectory, hex.EncodeToString(hash[:8]))
+	statePath := filepath.Join(stateDirectory, "state.json")
+	data, err := os.ReadFile(statePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("unable to read background tunnel state: %w", err)
+	}
+
+	var state tunnelState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Errorf("unable to decode background tunnel state: %w", err)
+	}
+	if state.Key != cfg.Key || state.RunID != cfg.RunID {
+		return nil
+	}
+
+	if state.SocketPath != "" {
+		_ = exec.Command(m.binary, "-F", "/dev/null", "-S", state.SocketPath, "-O", "exit", "rwx-preview").Run()
+		_ = os.Remove(state.SocketPath)
+	}
+	if err := os.Remove(statePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("unable to remove background tunnel state: %w", err)
+	}
+	_ = os.Remove(stateDirectory)
+	return nil
+}
+
+func (m tunnelManager) CloseAll(runID, stateDirectory string) error {
+	entries, err := os.ReadDir(stateDirectory)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("unable to list background tunnel state: %w", err)
+	}
+
+	var closeErrors []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		statePath := filepath.Join(stateDirectory, entry.Name(), "state.json")
+		data, readErr := os.ReadFile(statePath)
+		if readErr != nil {
+			if !errors.Is(readErr, os.ErrNotExist) {
+				closeErrors = append(closeErrors, readErr.Error())
+			}
+			continue
+		}
+		var state tunnelState
+		if decodeErr := json.Unmarshal(data, &state); decodeErr != nil {
+			closeErrors = append(closeErrors, decodeErr.Error())
+			continue
+		}
+		if state.RunID != runID {
+			continue
+		}
+		if closeErr := m.Close(TunnelCloseConfig{Key: state.Key, RunID: runID, StateDirectory: stateDirectory}); closeErr != nil {
+			closeErrors = append(closeErrors, closeErr.Error())
+		}
+	}
+	if len(closeErrors) > 0 {
+		return fmt.Errorf("unable to close all background tunnels: %s", strings.Join(closeErrors, "; "))
+	}
+	return nil
+}

--- a/internal/ssh/tunnel.go
+++ b/internal/ssh/tunnel.go
@@ -91,7 +91,7 @@ func (m tunnelManager) Open(cfg TunnelConfig) (TunnelResult, error) {
 		return TunnelResult{}, fmt.Errorf("local port must be between 1 and 65535")
 	}
 
-	hash := sha256.Sum256([]byte(cfg.StateDirectory + "\x00" + cfg.Key))
+	hash := sha256.Sum256([]byte(cfg.StateDirectory + "\x00" + cfg.RunID + "\x00" + cfg.Key))
 	keyHash := hex.EncodeToString(hash[:8])
 	previewDir := filepath.Join(cfg.StateDirectory, keyHash)
 	if err := os.MkdirAll(previewDir, 0o700); err != nil {
@@ -226,7 +226,7 @@ func (m tunnelManager) Close(cfg TunnelCloseConfig) error {
 		return fmt.Errorf("background process key is required")
 	}
 
-	hash := sha256.Sum256([]byte(cfg.StateDirectory + "\x00" + cfg.Key))
+	hash := sha256.Sum256([]byte(cfg.StateDirectory + "\x00" + cfg.RunID + "\x00" + cfg.Key))
 	stateDirectory := filepath.Join(cfg.StateDirectory, hex.EncodeToString(hash[:8]))
 	statePath := filepath.Join(stateDirectory, "state.json")
 	data, err := os.ReadFile(statePath)

--- a/internal/ssh/tunnel.go
+++ b/internal/ssh/tunnel.go
@@ -103,9 +103,6 @@ func (m tunnelManager) Open(cfg TunnelConfig) (TunnelResult, error) {
 	if data, err := os.ReadFile(statePath); err == nil {
 		_ = json.Unmarshal(data, &state)
 	}
-	if state.SocketPath != "" {
-		_ = exec.Command(m.binary, "-F", "/dev/null", "-S", state.SocketPath, "-O", "exit", "rwx-preview").Run()
-	}
 
 	scheme := cfg.Scheme
 	if scheme == "" && state.Key == cfg.Key && state.RunID == cfg.RunID {
@@ -116,6 +113,11 @@ func (m tunnelManager) Open(cfg TunnelConfig) (TunnelResult, error) {
 	}
 	if scheme != "http" && scheme != "https" {
 		return TunnelResult{}, fmt.Errorf("scheme must be http or https")
+	}
+	if state.SocketPath != "" {
+		if err := m.closeControlMaster(state.SocketPath); err != nil {
+			return TunnelResult{}, fmt.Errorf("unable to replace existing background tunnel: %w", err)
+		}
 	}
 
 	localPort := cfg.LocalPort
@@ -214,7 +216,9 @@ func (m tunnelManager) Open(cfg TunnelConfig) (TunnelResult, error) {
 	}
 	data = append(data, '\n')
 	if err := os.WriteFile(statePath, data, 0o600); err != nil {
-		_ = exec.Command(m.binary, "-F", "/dev/null", "-S", socketPath, "-O", "exit", "rwx-preview").Run()
+		if closeErr := m.closeControlMaster(socketPath); closeErr != nil {
+			return TunnelResult{}, fmt.Errorf("unable to save background tunnel state: %w; additionally failed to close tunnel: %v", err, closeErr)
+		}
 		return TunnelResult{}, fmt.Errorf("unable to save background tunnel state: %w", err)
 	}
 
@@ -246,14 +250,33 @@ func (m tunnelManager) Close(cfg TunnelCloseConfig) error {
 	}
 
 	if state.SocketPath != "" {
-		_ = exec.Command(m.binary, "-F", "/dev/null", "-S", state.SocketPath, "-O", "exit", "rwx-preview").Run()
-		_ = os.Remove(state.SocketPath)
+		if err := m.closeControlMaster(state.SocketPath); err != nil {
+			return err
+		}
+		if err := os.Remove(state.SocketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("unable to remove background tunnel control socket: %w", err)
+		}
 	}
 	if err := os.Remove(statePath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("unable to remove background tunnel state: %w", err)
 	}
 	_ = os.Remove(stateDirectory)
 	return nil
+}
+
+func (m tunnelManager) closeControlMaster(socketPath string) error {
+	output, err := exec.Command(m.binary, "-F", "/dev/null", "-S", socketPath, "-O", "exit", "rwx-preview").CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	if _, statErr := os.Stat(socketPath); errors.Is(statErr, os.ErrNotExist) {
+		return nil
+	}
+	message := strings.TrimSpace(string(output))
+	if message != "" {
+		return fmt.Errorf("unable to close SSH background process tunnel: %s", message)
+	}
+	return fmt.Errorf("unable to close SSH background process tunnel: %w", err)
 }
 
 func (m tunnelManager) CloseAll(runID, stateDirectory string) error {

--- a/internal/ssh/tunnel_test.go
+++ b/internal/ssh/tunnel_test.go
@@ -92,6 +92,9 @@ func TestTunnelManagerDoesNotReuseLocalPortAcrossRuns(t *testing.T) {
 	second, err := manager.Open(config)
 	require.NoError(t, err)
 	require.NotEqual(t, first.LocalPort, second.LocalPort)
+	entries, err := os.ReadDir(config.StateDirectory)
+	require.NoError(t, err)
+	require.Len(t, entries, 2, "same-key tunnels from different runs should have independent state")
 }
 
 func TestTunnelManagerCloseMatchesRun(t *testing.T) {

--- a/internal/ssh/tunnel_test.go
+++ b/internal/ssh/tunnel_test.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -120,6 +121,55 @@ func TestTunnelManagerCloseMatchesRun(t *testing.T) {
 	require.FileExists(t, statePath)
 	require.NoError(t, manager.Close(TunnelCloseConfig{Key: "web", RunID: "run-1", StateDirectory: config.StateDirectory}))
 	require.NoFileExists(t, statePath)
+}
+
+func TestTunnelManagerClosePreservesStateWhenControlMasterShutdownFails(t *testing.T) {
+	manager, config, statePath, state := openTunnelWithFailingShutdown(t)
+
+	err := manager.Close(TunnelCloseConfig{Key: config.Key, RunID: config.RunID, StateDirectory: config.StateDirectory})
+
+	require.ErrorContains(t, err, "control exit failed")
+	require.FileExists(t, statePath)
+	require.FileExists(t, state.SocketPath)
+}
+
+func TestTunnelManagerOpenPreservesStateWhenExistingControlMasterShutdownFails(t *testing.T) {
+	manager, config, statePath, state := openTunnelWithFailingShutdown(t)
+
+	_, err := manager.Open(config)
+
+	require.ErrorContains(t, err, "unable to replace existing background tunnel")
+	require.ErrorContains(t, err, "control exit failed")
+	require.FileExists(t, statePath)
+	require.FileExists(t, state.SocketPath)
+}
+
+func openTunnelWithFailingShutdown(t *testing.T) (tunnelManager, TunnelConfig, string, tunnelState) {
+	t.Helper()
+	tmp := t.TempDir()
+	binary := filepath.Join(tmp, "ssh")
+	script := "#!/bin/sh\ncase \"$*\" in *\"-O exit\"*) echo 'control exit failed' >&2; exit 1;; esac\nexit 0\n"
+	require.NoError(t, os.WriteFile(binary, []byte(script), 0o700))
+	manager := tunnelManager{binary: binary}
+	config := TunnelConfig{
+		Key: "web", RunID: "run-1", Address: "192.0.2.10:22",
+		PrivateUserKey: "private key", PublicHostKey: "ssh-ed25519 public-key",
+		TargetPort: 3000, StateDirectory: filepath.Join(tmp, "state"),
+	}
+	_, err := manager.Open(config)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(config.StateDirectory)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	statePath := filepath.Join(config.StateDirectory, entries[0].Name(), "state.json")
+	data, err := os.ReadFile(statePath)
+	require.NoError(t, err)
+	var state tunnelState
+	require.NoError(t, json.Unmarshal(data, &state))
+	require.NoError(t, os.WriteFile(state.SocketPath, []byte("control socket"), 0o600))
+	t.Cleanup(func() { _ = os.Remove(state.SocketPath) })
+	return manager, config, statePath, state
 }
 
 func TestTunnelManagerReadinessRequiresConnectionToStayOpen(t *testing.T) {

--- a/internal/ssh/tunnel_test.go
+++ b/internal/ssh/tunnel_test.go
@@ -28,16 +28,20 @@ func TestTunnelManagerOpenRefreshesAndReusesLocalPort(t *testing.T) {
 		PrivateUserKey: "private key",
 		PublicHostKey:  "ssh-ed25519 public-key",
 		TargetPort:     3000,
+		Scheme:         "https",
 		StateDirectory: filepath.Join(tmp, "state"),
 	}
 
 	first, err := manager.Open(config)
 	require.NoError(t, err)
 	require.Greater(t, first.LocalPort, 0)
+	require.Equal(t, "https", first.Scheme)
 
+	config.Scheme = ""
 	second, err := manager.Open(config)
 	require.NoError(t, err)
 	require.Equal(t, first.LocalPort, second.LocalPort)
+	require.Equal(t, "https", second.Scheme)
 
 	logData, err := os.ReadFile(logPath)
 	require.NoError(t, err)
@@ -59,6 +63,14 @@ func TestTunnelManagerValidatesPorts(t *testing.T) {
 	require.EqualError(t, err, "local port must be between 1 and 65535")
 }
 
+func TestTunnelManagerValidatesScheme(t *testing.T) {
+	manager := tunnelManager{binary: "ssh"}
+	_, err := manager.Open(TunnelConfig{
+		Key: "web", RunID: "run-1", TargetPort: 3000, Scheme: "ftp", StateDirectory: t.TempDir(),
+	})
+	require.EqualError(t, err, "scheme must be http or https")
+}
+
 func TestTunnelManagerDoesNotReuseLocalPortAcrossRuns(t *testing.T) {
 	tmp := t.TempDir()
 	binary := filepath.Join(tmp, "ssh")
@@ -71,6 +83,7 @@ func TestTunnelManagerDoesNotReuseLocalPortAcrossRuns(t *testing.T) {
 	}
 	first, err := manager.Open(config)
 	require.NoError(t, err)
+	require.Equal(t, "http", first.Scheme)
 
 	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", first.LocalPort))
 	require.NoError(t, err)

--- a/internal/ssh/tunnel_test.go
+++ b/internal/ssh/tunnel_test.go
@@ -1,0 +1,134 @@
+package ssh
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTunnelManagerOpenRefreshesAndReusesLocalPort(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "ssh.log")
+	binary := filepath.Join(tmp, "ssh")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$RWX_TEST_SSH_LOG\"\n"
+	require.NoError(t, os.WriteFile(binary, []byte(script), 0o700))
+	t.Setenv("RWX_TEST_SSH_LOG", logPath)
+
+	manager := tunnelManager{binary: binary}
+	config := TunnelConfig{
+		Key:            "web",
+		RunID:          "run-1",
+		Address:        "192.0.2.10:22",
+		PrivateUserKey: "private key",
+		PublicHostKey:  "ssh-ed25519 public-key",
+		TargetPort:     3000,
+		StateDirectory: filepath.Join(tmp, "state"),
+	}
+
+	first, err := manager.Open(config)
+	require.NoError(t, err)
+	require.Greater(t, first.LocalPort, 0)
+
+	second, err := manager.Open(config)
+	require.NoError(t, err)
+	require.Equal(t, first.LocalPort, second.LocalPort)
+
+	logData, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	invocations := strings.Split(strings.TrimSpace(string(logData)), "\n")
+	require.Len(t, invocations, 3)
+	require.Contains(t, invocations[0], "-L 127.0.0.1:")
+	require.Contains(t, invocations[1], "-O exit")
+	require.Contains(t, invocations[2], "-L 127.0.0.1:")
+	require.Contains(t, invocations[2], ":127.0.0.1:3000")
+}
+
+func TestTunnelManagerValidatesPorts(t *testing.T) {
+	manager := tunnelManager{binary: "ssh"}
+
+	_, err := manager.Open(TunnelConfig{Key: "web", TargetPort: 0})
+	require.EqualError(t, err, "target port must be between 1 and 65535")
+
+	_, err = manager.Open(TunnelConfig{Key: "web", TargetPort: 3000, LocalPort: 70000})
+	require.EqualError(t, err, "local port must be between 1 and 65535")
+}
+
+func TestTunnelManagerDoesNotReuseLocalPortAcrossRuns(t *testing.T) {
+	tmp := t.TempDir()
+	binary := filepath.Join(tmp, "ssh")
+	require.NoError(t, os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0o700))
+	manager := tunnelManager{binary: binary}
+	config := TunnelConfig{
+		Key: "web", RunID: "run-1", Address: "192.0.2.10:22",
+		PrivateUserKey: "private key", PublicHostKey: "ssh-ed25519 public-key",
+		TargetPort: 3000, StateDirectory: filepath.Join(tmp, "state"),
+	}
+	first, err := manager.Open(config)
+	require.NoError(t, err)
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", first.LocalPort))
+	require.NoError(t, err)
+	defer listener.Close()
+	config.RunID = "run-2"
+	second, err := manager.Open(config)
+	require.NoError(t, err)
+	require.NotEqual(t, first.LocalPort, second.LocalPort)
+}
+
+func TestTunnelManagerCloseMatchesRun(t *testing.T) {
+	tmp := t.TempDir()
+	binary := filepath.Join(tmp, "ssh")
+	require.NoError(t, os.WriteFile(binary, []byte("#!/bin/sh\nexit 0\n"), 0o700))
+	manager := tunnelManager{binary: binary}
+	config := TunnelConfig{
+		Key: "web", RunID: "run-1", Address: "192.0.2.10:22",
+		PrivateUserKey: "private key", PublicHostKey: "ssh-ed25519 public-key",
+		TargetPort: 3000, StateDirectory: filepath.Join(tmp, "state"),
+	}
+	_, err := manager.Open(config)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(config.StateDirectory)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	statePath := filepath.Join(config.StateDirectory, entries[0].Name(), "state.json")
+	require.FileExists(t, statePath)
+
+	require.NoError(t, manager.Close(TunnelCloseConfig{Key: "web", RunID: "run-2", StateDirectory: config.StateDirectory}))
+	require.FileExists(t, statePath)
+	require.NoError(t, manager.Close(TunnelCloseConfig{Key: "web", RunID: "run-1", StateDirectory: config.StateDirectory}))
+	require.NoFileExists(t, statePath)
+}
+
+func TestTunnelManagerReadinessRequiresConnectionToStayOpen(t *testing.T) {
+	manager := tunnelManager{}
+
+	closedListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() {
+		connection, acceptErr := closedListener.Accept()
+		if acceptErr == nil {
+			_ = connection.Close()
+		}
+	}()
+	require.False(t, manager.IsReady(closedListener.Addr().(*net.TCPAddr).Port))
+	require.NoError(t, closedListener.Close())
+
+	openListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() {
+		connection, acceptErr := openListener.Accept()
+		if acceptErr == nil {
+			time.Sleep(250 * time.Millisecond)
+			_ = connection.Close()
+		}
+	}()
+	require.True(t, manager.IsReady(openListener.Addr().(*net.TCPAddr).Port))
+	require.NoError(t, openListener.Close())
+}

--- a/test/integration/definitions/sandbox-background.yml
+++ b/test/integration/definitions/sandbox-background.yml
@@ -1,0 +1,44 @@
+on:
+  cli:
+    init:
+      ref: ${{ event.git.sha }}
+
+base:
+  image: ubuntu:24.04
+  config: rwx/base 1.0.0
+
+tasks:
+  - key: code
+    call: git/clone 2.0.7
+    with:
+      repository: https://github.com/rwx-cloud/rwx.git
+      ref: ${{ init.ref }}
+      preserve-git-dir: true
+      fetch-full-depth: true
+
+  - key: build-def
+    use: code
+    run: cp .rwx/build.yml $RWX_ARTIFACTS/build-yml
+
+  - key: build-rwx-cli
+    call: ${{ tasks.build-def.artifacts.build-yml }}
+    init:
+      ref: ${{ init.ref }}
+
+  - key: rwx-cli
+    run: sudo install "$CLI_BINARY" /usr/local/bin
+    env:
+      CLI_BINARY: ${{ tasks.build-rwx-cli.tasks.build.artifacts.rwx }}
+
+  - key: python
+    run: |
+      sudo apt-get update
+      sudo apt-get install --yes python3
+      sudo apt-get clean
+
+  - key: sandbox
+    use: [code, rwx-cli, python]
+    run: rwx-sandbox
+    env:
+      UUID: ${{ run.id }}
+      RWX_ACCESS_TOKEN: ""

--- a/test/integration/sandbox-background-exec-reset.sh
+++ b/test/integration/sandbox-background-exec-reset.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/sandbox-helpers.sh"
 
-export EXPERIMENTAL=true
+export RWX_EXPERIMENTAL=true
 
 start_sandbox "${SCRIPT_DIR}/definitions/sandbox-background.yml"
 trap stop_sandbox EXIT

--- a/test/integration/sandbox-background-exec-reset.sh
+++ b/test/integration/sandbox-background-exec-reset.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/sandbox-helpers.sh"
+
+export EXPERIMENTAL=true
+
+start_sandbox "${SCRIPT_DIR}/definitions/sandbox-background.yml"
+trap stop_sandbox EXIT
+
+background_result=$("${RWX_CLI}" sandbox background \
+  --id "$SANDBOX_RUN_ID" \
+  --name reset-preview \
+  --port 3000 \
+  --json \
+  -- python3 -u -m http.server 3000 --bind 127.0.0.1)
+preview_url=$(echo "$background_result" | jq -r '.URL')
+
+curl --fail --silent --show-error --max-time 10 "$preview_url" >/dev/null
+
+"${RWX_CLI}" sandbox exec \
+  --reset \
+  --init ref=main \
+  --init "cli=${COMMIT_SHA}" \
+  "${SCRIPT_DIR}/definitions/sandbox-background.yml" \
+  -- true
+
+if curl --fail --silent --max-time 2 "$preview_url" >/dev/null 2>&1; then
+  echo "ERROR: Preview tunnel remained reachable after exec --reset"
+  exit 1
+fi
+
+echo "PASS: sandbox exec --reset closed the old background tunnel"

--- a/test/integration/sandbox-background.sh
+++ b/test/integration/sandbox-background.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/sandbox-helpers.sh"
+
+export EXPERIMENTAL=true
+
+preview_name="web"
+preview_port=3000
+preview_file="integration-background-preview.txt"
+
+cleanup() {
+  if [ -n "${SANDBOX_RUN_ID:-}" ]; then
+    "${RWX_CLI}" sandbox background stop --id "$SANDBOX_RUN_ID" --name "$preview_name" >/dev/null 2>&1 || true
+    "${RWX_CLI}" sandbox stop --id "$SANDBOX_RUN_ID" >/dev/null 2>&1 || true
+  fi
+  rm -f "$preview_file"
+}
+trap cleanup EXIT
+
+start_sandbox "${SCRIPT_DIR}/definitions/sandbox-background.yml"
+
+printf 'initial preview\n' > "$preview_file"
+
+start_result=$("${RWX_CLI}" sandbox background \
+  --id "$SANDBOX_RUN_ID" \
+  --name "$preview_name" \
+  --port "$preview_port" \
+  --json \
+  -- python3 -u -m http.server "$preview_port" --bind 127.0.0.1)
+
+preview_url=$(echo "$start_result" | jq -r '.URL')
+start_pid=$(echo "$start_result" | jq -r '.PID')
+start_time=$(echo "$start_result" | jq -r '.StartedAt')
+
+if [ -z "$preview_url" ] || [ "$preview_url" = "null" ]; then
+  echo "background start did not return a preview URL"
+  exit 1
+fi
+
+initial_content=$(curl --fail --silent --show-error --max-time 10 "$preview_url/$preview_file")
+if [ "$initial_content" != "initial preview" ]; then
+  echo "unexpected initial preview content: $initial_content"
+  exit 1
+fi
+
+printf 'updated preview\n' > "$preview_file"
+"${RWX_CLI}" sandbox sync --id "$SANDBOX_RUN_ID" >/dev/null
+
+updated_content=$(curl --fail --silent --show-error --max-time 10 "$preview_url/$preview_file")
+if [ "$updated_content" != "updated preview" ]; then
+  echo "sandbox sync did not update preview content: $updated_content"
+  exit 1
+fi
+
+restart_result=$("${RWX_CLI}" sandbox background restart \
+  --id "$SANDBOX_RUN_ID" \
+  --name "$preview_name" \
+  --json)
+
+restart_url=$(echo "$restart_result" | jq -r '.URL')
+restart_pid=$(echo "$restart_result" | jq -r '.PID')
+restart_time=$(echo "$restart_result" | jq -r '.StartedAt')
+
+if [ "$restart_url" != "$preview_url" ]; then
+  echo "background restart changed preview URL (before: $preview_url, after: $restart_url)"
+  exit 1
+fi
+
+if [ "$restart_pid" = "$start_pid" ] && [ "$restart_time" = "$start_time" ]; then
+  echo "background restart did not replace the managed process"
+  exit 1
+fi
+
+curl --fail --silent --show-error --max-time 10 "$restart_url/$preview_file" >/dev/null
+logs_output=$("${RWX_CLI}" sandbox background logs --id "$SANDBOX_RUN_ID" --name "$preview_name")
+if [[ "$logs_output" != *"$preview_file"* ]]; then
+  echo "background logs did not include the preview request"
+  echo "$logs_output"
+  exit 1
+fi
+
+portless_result=$("${RWX_CLI}" sandbox background \
+  --id "$SANDBOX_RUN_ID" \
+  --name "$preview_name" \
+  --json \
+  -- sh -c 'while :; do sleep 60; done')
+
+if [ "$(echo "$portless_result" | jq -r '.URL')" != "" ]; then
+  echo "portless replacement unexpectedly returned a preview URL"
+  exit 1
+fi
+
+if curl --fail --silent --max-time 2 "$preview_url/$preview_file" >/dev/null 2>&1; then
+  echo "old preview tunnel remained reachable after portless replacement"
+  exit 1
+fi
+
+"${RWX_CLI}" sandbox background stop --id "$SANDBOX_RUN_ID" --name "$preview_name" --json >/dev/null
+
+echo "PASS: sandbox background process, sync, restart, logs, and tunnel cleanup"

--- a/test/integration/sandbox-background.sh
+++ b/test/integration/sandbox-background.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/sandbox-helpers.sh"
 
-export EXPERIMENTAL=true
+export RWX_EXPERIMENTAL=true
 
 preview_name="web"
 preview_port=3000

--- a/test/integration/sandbox-background.sh
+++ b/test/integration/sandbox-background.sh
@@ -46,11 +46,11 @@ if [ "$initial_content" != "initial preview" ]; then
 fi
 
 printf 'updated preview\n' > "$preview_file"
-"${RWX_CLI}" sandbox sync --id "$SANDBOX_RUN_ID" >/dev/null
+"${RWX_CLI}" sandbox push --id "$SANDBOX_RUN_ID" >/dev/null
 
 updated_content=$(curl --fail --silent --show-error --max-time 10 "$preview_url/$preview_file")
 if [ "$updated_content" != "updated preview" ]; then
-  echo "sandbox sync did not update preview content: $updated_content"
+  echo "sandbox push did not update preview content: $updated_content"
   exit 1
 fi
 
@@ -99,4 +99,4 @@ fi
 
 "${RWX_CLI}" sandbox background stop --id "$SANDBOX_RUN_ID" --name "$preview_name" --json >/dev/null
 
-echo "PASS: sandbox background process, sync, restart, logs, and tunnel cleanup"
+echo "PASS: sandbox background process, push, restart, logs, and tunnel cleanup"

--- a/test/integration/sandbox-helpers.sh
+++ b/test/integration/sandbox-helpers.sh
@@ -6,20 +6,30 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 RWX_CLI="${REPO_ROOT}/rwx"
 
 start_sandbox() {
+  local sandbox_config="${1:-${SCRIPT_DIR}/definitions/sandbox.yml}"
   local sandbox_result
   local exit_code=0
-  sandbox_result=$("${RWX_CLI}" sandbox start "${SCRIPT_DIR}/definitions/sandbox.yml" --json --init ref=main --init "cli=${COMMIT_SHA}" --wait) || exit_code=$?
+  sandbox_result=$("${RWX_CLI}" sandbox start "${sandbox_config}" --json --init ref=main --init "cli=${COMMIT_SHA}" --wait) || exit_code=$?
+
+  if [ "$exit_code" -ne 0 ]; then
+    echo "sandbox start failed with exit code ${exit_code}"
+    echo "${sandbox_result}"
+    exit 1
+  fi
 
   local sandbox_url
   sandbox_url=$(echo "${sandbox_result}" | jq -r ".RunURL // empty")
+
+  SANDBOX_RUN_ID=$(echo "${sandbox_result}" | jq -r ".RunID // empty")
+  export SANDBOX_RUN_ID
+
   if [ -n "$sandbox_url" ]; then
     echo "Sandbox URL: ${sandbox_url}"
     echo "$sandbox_url" > "$RWX_LINKS/Sandbox Run"
   fi
 
-  if [ "$exit_code" -ne 0 ]; then
-    echo "sandbox start failed with exit code ${exit_code}"
-    echo "${sandbox_result}"
+  if [ -z "$SANDBOX_RUN_ID" ]; then
+    echo "sandbox start did not return a run ID"
     exit 1
   fi
 }

--- a/test/integration_suite_test.go
+++ b/test/integration_suite_test.go
@@ -56,13 +56,13 @@ func runMint(t *testing.T, input input) result {
 }
 
 func TestSandboxExperimentalGate(t *testing.T) {
-	t.Setenv("EXPERIMENTAL", "")
+	t.Setenv("RWX_EXPERIMENTAL", "")
 	result := runMint(t, input{
 		args: []string{"sandbox", "push", "--access-token", "fake-for-test"},
 	})
 
 	require.Equal(t, 1, result.exitCode)
-	require.Contains(t, result.stderr, "this command is experimental; set EXPERIMENTAL=true to use it")
+	require.Contains(t, result.stderr, "this command is experimental; set RWX_EXPERIMENTAL=true to use it")
 }
 
 func TestImageBuild(t *testing.T) {

--- a/test/integration_suite_test.go
+++ b/test/integration_suite_test.go
@@ -58,7 +58,7 @@ func runMint(t *testing.T, input input) result {
 func TestSandboxExperimentalGate(t *testing.T) {
 	t.Setenv("EXPERIMENTAL", "")
 	result := runMint(t, input{
-		args: []string{"sandbox", "sync", "--access-token", "fake-for-test"},
+		args: []string{"sandbox", "push", "--access-token", "fake-for-test"},
 	})
 
 	require.Equal(t, 1, result.exitCode)

--- a/test/integration_suite_test.go
+++ b/test/integration_suite_test.go
@@ -55,6 +55,16 @@ func runMint(t *testing.T, input input) result {
 	}
 }
 
+func TestSandboxExperimentalGate(t *testing.T) {
+	t.Setenv("EXPERIMENTAL", "")
+	result := runMint(t, input{
+		args: []string{"sandbox", "sync", "--access-token", "fake-for-test"},
+	})
+
+	require.Equal(t, 1, result.exitCode)
+	require.Contains(t, result.stderr, "this command is experimental; set EXPERIMENTAL=true to use it")
+}
+
 func TestImageBuild(t *testing.T) {
 	t.Run("fails when --tag is used with --no-pull", func(t *testing.T) {
 		input := input{


### PR DESCRIPTION
Closes RWX-1591

Adds experimental sandbox commands for background process tunneling and lifecycle. The commands are hidden and require `RWX_EXPERIMENTAL=true`.

```bash
# Enable experimental commands
export RWX_EXPERIMENTAL=true

# Push local changes into the sandbox without running a command
rwx sandbox push

# Start or replace a background process with an HTTP preview
rwx sandbox background \
  --name web \
  --port 3000 \
  -- bundle exec rails server -b 0.0.0.0 -p 3000

# Restart the process after pushing local changes
rwx sandbox background restart --name web

# Show process logs
rwx sandbox background logs --name web

# Stop the process and its local tunnel
rwx sandbox background stop --name web
```

Starting or restarting the process prints guidance for the agent:

```text
Preview "web": http://127.0.0.1:8310/

After local edits:
  Hot reload:    rwx sandbox push
  Hard restart:  rwx sandbox background restart --name web

rwx sandbox exec -- <command> syncs local changes before it runs.
```
