### PR TITLE
Add rwx runs cancel and rwx cancel

### DIFF
--- a/.rwx/integration.yml
+++ b/.rwx/integration.yml
@@ -28,6 +28,11 @@ tasks:
     init:
       ref: ${{ init.commit-sha }}
 
+  - key: run-rwx-runs-cancel-test
+    call: ${{ run.dir }}/integration/runs-cancel-test.yml
+    init:
+      ref: ${{ init.commit-sha }}
+
   - key: run-rwx-dispatch-test
     call: ${{ run.dir }}/integration/dispatch-test.yml
     init:

--- a/.rwx/integration/runs-cancel-test.yml
+++ b/.rwx/integration/runs-cancel-test.yml
@@ -1,0 +1,151 @@
+on:
+  cli:
+    init:
+      ref: ${{ event.git.sha }}
+
+base:
+  image: ubuntu:24.04
+  config: rwx/base 1.1.1
+
+tasks:
+  - key: code
+    call: git/clone 2.0.8
+    with:
+      repository: https://github.com/rwx-cloud/rwx.git
+      ref: ${{ init.ref }}
+
+  - key: build-def
+    use: code
+    run: cp .rwx/build.yml $RWX_ARTIFACTS/build-yml
+
+  - key: build-rwx-cli
+    call: ${{ tasks.build-def.artifacts.build-yml }}
+    init:
+      ref: ${{ init.ref }}
+
+  - key: rwx-cli
+    run: sudo install "$CLI_BINARY" /usr/local/bin
+    env:
+      CLI_BINARY: ${{ tasks.build-rwx-cli.tasks.build.artifacts.rwx }}
+
+  - key: test-runs-cancel
+    use: rwx-cli
+    run: |
+      set -euo pipefail
+
+      # Seeds a run whose only task sleeps, so the run stays active long enough
+      # to cancel. Echoes the run ID.
+      seed_run() {
+        local label="$1" kickoff run_id run_url
+        kickoff=$(rwx run "$RUN_DEF" --json)
+        run_id=$(echo "$kickoff" | jq -r '.RunID')
+        run_url=$(echo "$kickoff" | jq -r '.RunURL // empty')
+        echo "$run_url" > "$RWX_LINKS/$label"
+
+        if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+          echo "Failed to get RunID from kickoff"
+          echo "$kickoff"
+          exit 1
+        fi
+
+        echo "$run_id"
+      }
+
+      run_status() {
+        rwx runs list --limit 100 --json | jq -c --arg id "$1" '.Runs[] | select(.ID == $id) | .Status'
+      }
+
+      # The API accepts the cancellation before it stops the run, so the status
+      # settles a few seconds later. The test polls instead of reading once.
+      wait_for_aborted() {
+        local run_id="$1" status execution
+        for _ in $(seq 1 30); do
+          status=$(run_status "$run_id")
+          execution=$(echo "$status" | jq -r '.Execution')
+          if [ "$execution" != "waiting" ] && [ "$execution" != "in_progress" ]; then
+            if [ "$execution" != "aborted" ]; then
+              echo "Expected execution 'aborted' for cancelled run $run_id, got '$execution'"
+              echo "$status"
+              exit 1
+            fi
+            if [ "$(echo "$status" | jq -r '.AbortedSubStatus')" != "cancelled" ]; then
+              echo "Expected AbortedSubStatus 'cancelled' for run $run_id"
+              echo "$status"
+              exit 1
+            fi
+            return 0
+          fi
+          sleep 5
+        done
+
+        echo "Run $run_id did not reach an aborted status after the cancellation"
+        run_status "$run_id"
+        exit 1
+      }
+
+      # 'rwx runs cancel' cancels an active run and names it on stdout.
+      run_id=$(seed_run "Cancelled Run URL")
+      out=$(rwx runs cancel "$run_id")
+      if ! echo "$out" | grep -q "$run_id"; then
+        echo "Expected the cancel output to name run $run_id"
+        echo "$out"
+        exit 1
+      fi
+      wait_for_aborted "$run_id"
+
+      # Cancelling the same run twice is rejected, because the first request
+      # already applied.
+      exit_code=0
+      out=$(rwx runs cancel "$run_id" 2>&1) || exit_code=$?
+      if [ "$exit_code" -eq 0 ]; then
+        echo "Expected a non-zero exit when cancelling an already-cancelled run"
+        echo "$out"
+        exit 1
+      fi
+      if ! echo "$out" | grep -qi "cancel"; then
+        echo "Expected the repeat-cancel error to mention cancellation"
+        echo "$out"
+        exit 1
+      fi
+
+      # 'rwx cancel' is the top-level form of the same command. It reports the
+      # run ID under --json.
+      alias_run_id=$(seed_run "Alias Cancelled Run URL")
+      alias_json=$(rwx cancel "$alias_run_id" --json)
+      if [ "$(echo "$alias_json" | jq -r '.RunID')" != "$alias_run_id" ]; then
+        echo "Expected .RunID $alias_run_id from 'rwx cancel --json'"
+        echo "$alias_json"
+        exit 1
+      fi
+      wait_for_aborted "$alias_run_id"
+
+      # An unknown run ID surfaces the API's not-found error.
+      exit_code=0
+      out=$(rwx runs cancel 00000000000000000000000000000000 2>&1) || exit_code=$?
+      if [ "$exit_code" -eq 0 ]; then
+        echo "Expected a non-zero exit for an unknown run ID"
+        echo "$out"
+        exit 1
+      fi
+      if ! echo "$out" | grep -qi "not found"; then
+        echo "Expected the unknown-run error to mention that the run was not found"
+        echo "$out"
+        exit 1
+      fi
+
+      # The run ID is required, so a bare invocation fails before any API call.
+      exit_code=0
+      out=$(rwx runs cancel 2>&1) || exit_code=$?
+      if [ "$exit_code" -eq 0 ]; then
+        echo "Expected a non-zero exit when no run ID is given"
+        echo "$out"
+        exit 1
+      fi
+      if ! echo "$out" | grep -q "accepts 1 arg"; then
+        echo "Expected the missing-argument error to report that 1 arg is accepted"
+        echo "$out"
+        exit 1
+      fi
+    env:
+      RWX_ACCESS_TOKEN: ${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}
+      RUN_DEF: ${{ run.dir }}/integration/runs-cancel-test/cancellable.yml

--- a/.rwx/integration/runs-cancel-test/cancellable.yml
+++ b/.rwx/integration/runs-cancel-test/cancellable.yml
@@ -1,0 +1,7 @@
+base:
+  image: ubuntu:24.04
+  config: rwx/base 1.1.1
+
+tasks:
+  - key: long-running
+    run: sleep 600

--- a/cmd/rwx/root.go
+++ b/cmd/rwx/root.go
@@ -224,6 +224,7 @@ func init() {
 
 	// Add commands (GroupID is set in each command's definition)
 	rootCmd.AddCommand(artifactsCmd)
+	rootCmd.AddCommand(cancelCmd)
 	rootCmd.AddCommand(debugCmd)
 	rootCmd.AddCommand(dispatchCmd)
 	rootCmd.AddCommand(imageCmd)

--- a/cmd/rwx/runs.go
+++ b/cmd/rwx/runs.go
@@ -44,6 +44,7 @@ func init() {
 	runsCmd.AddCommand(runsStartCmd)
 	runsCmd.AddCommand(runsShowCmd)
 	runsCmd.AddCommand(runsListCmd)
+	runsCmd.AddCommand(runsCancelCmd)
 
 	rootCmd.AddCommand(runsCmd)
 }

--- a/cmd/rwx/runs_cancel.go
+++ b/cmd/rwx/runs_cancel.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/rwx-cloud/rwx/internal/cli"
+
+	"github.com/spf13/cobra"
+)
+
+var runsCancelCmd = &cobra.Command{
+	Use:   "cancel <run-id>",
+	Short: "Cancel a run",
+	Long:  `Cancel a run that is in progress.`,
+	Args:  cobra.ExactArgs(1),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return requireAccessToken()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		result, err := service.CancelRun(cli.CancelRunConfig{RunID: args[0]})
+		if err != nil {
+			return err
+		}
+
+		if useJsonOutput() {
+			encoded, err := json.Marshal(result)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(os.Stdout, string(encoded))
+			return nil
+		}
+
+		fmt.Fprintf(os.Stdout, "Cancelled run %s\n", result.RunID)
+		return nil
+	},
+}
+
+var cancelCmd = &cobra.Command{
+	GroupID: "execution",
+	Use:     "cancel <run-id>",
+	Short:   runsCancelCmd.Short,
+	Long:    runsCancelCmd.Long,
+	Args:    runsCancelCmd.Args,
+	PreRunE: runsCancelCmd.PreRunE,
+	RunE:    runsCancelCmd.RunE,
+}

--- a/cmd/rwx/runs_cancel_test.go
+++ b/cmd/rwx/runs_cancel_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunsCancelIsRegistered(t *testing.T) {
+	cancelCmd := findSubcommand(runsCmd, "cancel")
+	require.NotNil(t, cancelCmd, "rwx runs cancel should exist")
+	require.False(t, cancelCmd.Hidden, "cancel is a real action and should be visible")
+}
+
+func TestRunsCancelRequiresExactlyOneRunID(t *testing.T) {
+	cancelCmd := findSubcommand(runsCmd, "cancel")
+	require.NotNil(t, cancelCmd)
+
+	require.Error(t, cancelCmd.Args(cancelCmd, []string{}), "cancel should reject a missing run ID")
+	require.NoError(t, cancelCmd.Args(cancelCmd, []string{"run-1"}))
+	require.Error(t, cancelCmd.Args(cancelCmd, []string{"run-1", "run-2"}), "cancel should reject a second run ID")
+}
+
+func TestCancelMirrorsRunsCancel(t *testing.T) {
+	topLevel := findSubcommand(rootCmd, "cancel")
+	require.NotNil(t, topLevel, "rwx cancel should exist")
+	require.False(t, topLevel.Hidden, "cancel is a real action and should be visible")
+	require.Equal(t, "execution", topLevel.GroupID)
+
+	require.True(t, sameFunc(topLevel.RunE, runsCancelCmd.RunE), "cancel should reuse runs cancel's RunE")
+	require.True(t, sameFunc(topLevel.PreRunE, runsCancelCmd.PreRunE), "cancel should reuse runs cancel's PreRunE")
+	require.Equal(t, runsCancelCmd.Short, topLevel.Short)
+	require.Equal(t, runsCancelCmd.Long, topLevel.Long)
+
+	require.Error(t, topLevel.Args(topLevel, []string{}), "cancel should reject a missing run ID")
+	require.NoError(t, topLevel.Args(topLevel, []string{"run-1"}))
+	require.Error(t, topLevel.Args(topLevel, []string{"run-1", "run-2"}), "cancel should reject a second run ID")
+}

--- a/internal/cli/service_runs.go
+++ b/internal/cli/service_runs.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/errors"
 )
 
 type ListRunsConfig struct {
@@ -36,4 +37,26 @@ func (s Service) ListRuns(cfg ListRunsConfig) (*api.ListRunsResult, error) {
 		Cursor:            cfg.Cursor,
 		RetryProgress:     cfg.RetryProgress,
 	})
+}
+
+type CancelRunConfig struct {
+	RunID string
+}
+
+type CancelRunResult struct {
+	RunID string
+}
+
+// CancelRun cancels a run the caller identifies by ID. It sends no scoped token,
+// so the API client authenticates with the user's access token.
+func (s Service) CancelRun(cfg CancelRunConfig) (*CancelRunResult, error) {
+	if cfg.RunID == "" {
+		return nil, errors.New("a run ID is required")
+	}
+
+	if err := s.APIClient.CancelRun(cfg.RunID, ""); err != nil {
+		return nil, err
+	}
+
+	return &CancelRunResult{RunID: cfg.RunID}, nil
 }

--- a/internal/cli/service_runs_test.go
+++ b/internal/cli/service_runs_test.go
@@ -55,3 +55,50 @@ func TestService_ListRuns(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestService_CancelRun(t *testing.T) {
+	t.Run("passes the run ID through to the API with no scoped token", func(t *testing.T) {
+		setup := setupTest(t)
+
+		called := false
+		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
+			called = true
+			require.Equal(t, "run-123", runID)
+			require.Empty(t, scopedToken)
+			return nil
+		}
+
+		result, err := setup.service.CancelRun(cli.CancelRunConfig{RunID: "run-123"})
+
+		require.NoError(t, err)
+		require.True(t, called)
+		require.Equal(t, "run-123", result.RunID)
+	})
+
+	t.Run("returns an error when the run ID is missing", func(t *testing.T) {
+		setup := setupTest(t)
+
+		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
+			t.Fatal("the API must not be called without a run ID")
+			return nil
+		}
+
+		result, err := setup.service.CancelRun(cli.CancelRunConfig{})
+
+		require.Nil(t, result)
+		require.Error(t, err)
+	})
+
+	t.Run("returns an error when the API fails", func(t *testing.T) {
+		setup := setupTest(t)
+
+		setup.mockAPI.MockCancelRun = func(runID, scopedToken string) error {
+			return errors.New("run is already finished")
+		}
+
+		result, err := setup.service.CancelRun(cli.CancelRunConfig{RunID: "run-123"})
+
+		require.Nil(t, result)
+		require.ErrorContains(t, err, "run is already finished")
+	})
+}


### PR DESCRIPTION
This PR adds a somewhat long-overdue command for canceling a run.

It lives at both the top level `rwx cancel <runId>` and in the runs namespace (`rwx runs cancel <runId>`) and reuses the cancel endpoint we had already wired up for use with `rwx sandbox stop` (which is just generically canceling a run under the hood).

Some test runs that were canceled by the CLI on this branch: [fe0b3dc9](https://cloud.rwx.com/rwx/runs/fe0b3dc9c67e4a459dfedb2d3004dcae) and [87859bc5](https://cloud.rwx.com/rwx/runs/87859bc5547d46438b9bdb6a47280c2b).