### PR TITLE
Add run and task retry commands

### DIFF
--- a/cmd/rwx/retry.go
+++ b/cmd/rwx/retry.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rwx-cloud/rwx/internal/api"
 	"github.com/rwx-cloud/rwx/internal/cli"
+	internalErrors "github.com/rwx-cloud/rwx/internal/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -62,6 +63,15 @@ func newRetryCommand(use, short string, targetType api.RetryTargetType, groupID 
 				OutputJSON:       useJsonOutput(),
 			})
 			if err != nil {
+				var requestErr *api.RetryRequestError
+				if useJsonOutput() && internalErrors.As(err, &requestErr) {
+					encoded, encodeErr := json.Marshal(requestErr)
+					if encodeErr != nil {
+						return encodeErr
+					}
+					fmt.Fprintln(service.Stdout, string(encoded))
+					return internalErrors.WrapSentinel(requestErr, HandledError)
+				}
 				return err
 			}
 

--- a/cmd/rwx/retry.go
+++ b/cmd/rwx/retry.go
@@ -32,10 +32,9 @@ var tasksRetryCmd = newRetryCommand(
 )
 
 func newRetryCommand(use, short string, targetType api.RetryTargetType, groupID string) *cobra.Command {
-	var kind string
+	var action string
 	var withoutToolCache []string
-	var debug bool
-	var debugPlacement string
+	var debug string
 
 	cmd := &cobra.Command{
 		GroupID: groupID,
@@ -46,20 +45,14 @@ func newRetryCommand(use, short string, targetType api.RetryTargetType, groupID 
 			return requireAccessToken()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var debugSelection *bool
-			if cmd.Flags().Changed("debug") {
-				debugSelection = &debug
-			}
-
 			result, err := service.Retry(cli.RetryConfig{
 				Target: api.RetryTarget{
 					ID:   args[0],
 					Type: targetType,
 				},
-				Kind:             kind,
+				Action:           action,
 				WithoutToolCache: withoutToolCache,
-				Debug:            debugSelection,
-				DebugPlacement:   debugPlacement,
+				DebugPlacement:   debug,
 				OutputJSON:       useJsonOutput(),
 			})
 			if err != nil {
@@ -93,9 +86,8 @@ func newRetryCommand(use, short string, targetType api.RetryTargetType, groupID 
 		},
 	}
 
-	cmd.Flags().StringVar(&kind, "kind", "", "retry kind to use")
+	cmd.Flags().StringVar(&action, "action", "", "retry action to use")
 	cmd.Flags().StringArrayVar(&withoutToolCache, "without-tool-cache", nil, "tool cache to exclude; can be specified multiple times")
-	cmd.Flags().BoolVar(&debug, "debug", false, "open a breakpoint during the retried task")
-	cmd.Flags().StringVar(&debugPlacement, "debug-placement", "", "where to open the breakpoint: start or end")
+	cmd.Flags().StringVar(&debug, "debug", "", "open a breakpoint at the start or end of the retried task")
 	return cmd
 }

--- a/cmd/rwx/retry.go
+++ b/cmd/rwx/retry.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/cli"
+	"github.com/spf13/cobra"
+)
+
+var retryCmd = newRetryCommand(
+	"retry [flags] <run-or-task-id>",
+	"Retry a run or task",
+	api.RetryTargetInferred,
+	"execution",
+)
+
+var runsRetryCmd = newRetryCommand(
+	"retry [flags] <run-id>",
+	"Retry a run",
+	api.RetryTargetRun,
+	"",
+)
+
+var tasksRetryCmd = newRetryCommand(
+	"retry [flags] <task-id>",
+	"Retry a task",
+	api.RetryTargetTask,
+	"",
+)
+
+func newRetryCommand(use, short string, targetType api.RetryTargetType, groupID string) *cobra.Command {
+	var kind string
+	var withoutToolCache []string
+	var debug bool
+	var debugPlacement string
+
+	cmd := &cobra.Command{
+		GroupID: groupID,
+		Use:     use,
+		Short:   short,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return requireAccessToken()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var debugSelection *bool
+			if cmd.Flags().Changed("debug") {
+				debugSelection = &debug
+			}
+
+			result, err := service.Retry(cli.RetryConfig{
+				Target: api.RetryTarget{
+					ID:   args[0],
+					Type: targetType,
+				},
+				Kind:             kind,
+				WithoutToolCache: withoutToolCache,
+				Debug:            debugSelection,
+				DebugPlacement:   debugPlacement,
+				OutputJSON:       useJsonOutput(),
+			})
+			if err != nil {
+				return err
+			}
+
+			if useJsonOutput() {
+				encoded, err := json.Marshal(result)
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(service.Stdout, string(encoded))
+				return nil
+			}
+
+			if result.TaskID != "" {
+				fmt.Fprintf(service.Stdout, "Retry requested for task %s\n", result.TaskID)
+			} else {
+				fmt.Fprintf(service.Stdout, "Retry requested for run %s\n", result.RunID)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&kind, "kind", "", "retry kind to use")
+	cmd.Flags().StringArrayVar(&withoutToolCache, "without-tool-cache", nil, "tool cache to exclude; can be specified multiple times")
+	cmd.Flags().BoolVar(&debug, "debug", false, "open a breakpoint during the retried task")
+	cmd.Flags().StringVar(&debugPlacement, "debug-placement", "", "where to open the breakpoint: start or end")
+	return cmd
+}

--- a/cmd/rwx/retry_test.go
+++ b/cmd/rwx/retry_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/cli"
+	"github.com/rwx-cloud/rwx/internal/mocks"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryCommandsAreRegistered(t *testing.T) {
+	tests := []struct {
+		name       string
+		parent     *cobra.Command
+		command    string
+		identifier string
+	}{
+		{name: "inferred target", parent: rootCmd, command: "retry", identifier: "run-or-task-id"},
+		{name: "run", parent: runsCmd, command: "retry", identifier: "run-id"},
+		{name: "task", parent: tasksCmd, command: "retry", identifier: "task-id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := findSubcommand(tt.parent, tt.command)
+			require.NotNil(t, cmd)
+			require.Contains(t, cmd.Use, tt.identifier)
+			require.NoError(t, cmd.Args(cmd, []string{"target-123"}))
+			require.Error(t, cmd.Args(cmd, nil))
+			require.Error(t, cmd.Args(cmd, []string{"one", "two"}))
+
+			for _, flag := range []string{"kind", "without-tool-cache", "debug", "debug-placement"} {
+				require.NotNil(t, cmd.Flags().Lookup(flag), "retry should expose --%s", flag)
+			}
+		})
+	}
+
+	tasks := findSubcommand(rootCmd, "tasks")
+	require.NotNil(t, tasks)
+	require.False(t, tasks.Runnable())
+	require.NotNil(t, findSubcommand(tasks, "retry"))
+}
+
+func TestRetryCommandPassesFlagSelectionsToService(t *testing.T) {
+	originalService := service
+	originalFormat := Format
+	t.Cleanup(func() {
+		service = originalService
+		Format = originalFormat
+	})
+
+	mockAPI := new(mocks.API)
+	mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+		require.Equal(t, api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask}, target)
+		return api.RetryOptions{
+			Retryable: true,
+			Kinds: []api.RetryKind{{
+				Value: "no-tool-cache",
+				Label: "Retry without tool caches",
+			}},
+			ToolCaches: []api.RetryToolCache{{Name: "bundler"}, {Name: "golang"}},
+		}, nil
+	}
+	mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+		require.Equal(t, "no-tool-cache", cfg.Kind)
+		require.Equal(t, []string{"bundler", "golang"}, cfg.ToolCacheNames)
+		require.NotNil(t, cfg.Debug)
+		require.False(t, *cfg.Debug)
+		return api.RequestRetryResult{
+			Status: "retry_requested",
+			RunID:  "run-123",
+			TaskID: "task-123",
+		}, nil
+	}
+
+	var stdout strings.Builder
+	service = cli.Service{Config: cli.Config{
+		APIClient: mockAPI,
+		Stdout:    &stdout,
+	}}
+	cmd := newRetryCommand("retry [flags] <task-id>", "Retry a task", api.RetryTargetTask, "")
+	require.NoError(t, cmd.Flags().Parse([]string{
+		"--kind", "no-tool-cache",
+		"--without-tool-cache", "bundler",
+		"--without-tool-cache", "golang",
+		"--debug=false",
+	}))
+
+	err := cmd.RunE(cmd, []string{"task-123"})
+
+	require.NoError(t, err)
+	require.Equal(t, "Retry requested for task task-123\n", stdout.String())
+}

--- a/cmd/rwx/retry_test.go
+++ b/cmd/rwx/retry_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/rwx-cloud/rwx/internal/api"
 	"github.com/rwx-cloud/rwx/internal/cli"
+	internalErrors "github.com/rwx-cloud/rwx/internal/errors"
 	"github.com/rwx-cloud/rwx/internal/mocks"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
@@ -93,4 +95,47 @@ func TestRetryCommandPassesFlagSelectionsToService(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, "Retry requested for task task-123\n", stdout.String())
+}
+
+func TestRetryCommandOutputsEndpointErrorAsJSON(t *testing.T) {
+	originalService := service
+	originalFormat := Format
+	t.Cleanup(func() {
+		service = originalService
+		Format = originalFormat
+	})
+
+	options := api.RetryOptions{
+		Retryable:  true,
+		Kinds:      []api.RetryKind{{Value: "standard", Label: "Standard retry"}},
+		Debug:      api.RetryDebugOptions{Placements: []string{}},
+		ToolCaches: []api.RetryToolCache{},
+	}
+	mockAPI := new(mocks.API)
+	mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+		return options, nil
+	}
+	mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+		return api.RequestRetryResult{}, &api.RetryRequestError{
+			Message: "This retry configuration is not supported.",
+			Errors:  []api.RetryFieldError{{Field: "kind", Message: "Choose `standard`."}},
+			Options: options,
+		}
+	}
+
+	var stdout strings.Builder
+	service = cli.Service{Config: cli.Config{APIClient: mockAPI, Stdout: &stdout}}
+	Format = "json"
+	cmd := newRetryCommand("retry [flags] <task-id>", "Retry a task", api.RetryTargetTask, "")
+	require.NoError(t, cmd.Flags().Parse([]string{"--kind", "standard"}))
+
+	err := cmd.RunE(cmd, []string{"task-123"})
+
+	require.ErrorIs(t, err, HandledError)
+	require.ErrorIs(t, err, internalErrors.ErrBadRequest)
+	var output map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout.String()), &output))
+	require.Equal(t, "This retry configuration is not supported.", output["error"])
+	require.Equal(t, "Choose `standard`.", output["errors"].([]any)[0].(map[string]any)["message"])
+	require.Equal(t, "standard", output["options"].(map[string]any)["kinds"].([]any)[0].(map[string]any)["value"])
 }

--- a/cmd/rwx/retry_test.go
+++ b/cmd/rwx/retry_test.go
@@ -34,9 +34,12 @@ func TestRetryCommandsAreRegistered(t *testing.T) {
 			require.Error(t, cmd.Args(cmd, nil))
 			require.Error(t, cmd.Args(cmd, []string{"one", "two"}))
 
-			for _, flag := range []string{"kind", "without-tool-cache", "debug", "debug-placement"} {
+			for _, flag := range []string{"action", "without-tool-cache", "debug"} {
 				require.NotNil(t, cmd.Flags().Lookup(flag), "retry should expose --%s", flag)
 			}
+			require.Nil(t, cmd.Flags().Lookup("kind"))
+			require.Equal(t, "string", cmd.Flags().Lookup("debug").Value.Type())
+			require.Nil(t, cmd.Flags().Lookup("debug-placement"))
 		})
 	}
 
@@ -59,18 +62,20 @@ func TestRetryCommandPassesFlagSelectionsToService(t *testing.T) {
 		require.Equal(t, api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask}, target)
 		return api.RetryOptions{
 			Retryable: true,
-			Kinds: []api.RetryKind{{
+			Actions: []api.RetryAction{{
 				Value: "no-tool-cache",
 				Label: "Retry without tool caches",
 			}},
+			Debug:      api.RetryDebugOptions{Supported: true, Placements: []string{"end", "start"}},
 			ToolCaches: []api.RetryToolCache{{Name: "bundler"}, {Name: "golang"}},
 		}, nil
 	}
 	mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
-		require.Equal(t, "no-tool-cache", cfg.Kind)
+		require.Equal(t, "no-tool-cache", cfg.Action)
 		require.Equal(t, []string{"bundler", "golang"}, cfg.ToolCacheNames)
 		require.NotNil(t, cfg.Debug)
-		require.False(t, *cfg.Debug)
+		require.True(t, *cfg.Debug)
+		require.Equal(t, "start", cfg.DebugPlacement)
 		return api.RequestRetryResult{
 			Status: "retry_requested",
 			RunID:  "run-123",
@@ -85,10 +90,10 @@ func TestRetryCommandPassesFlagSelectionsToService(t *testing.T) {
 	}}
 	cmd := newRetryCommand("retry [flags] <task-id>", "Retry a task", api.RetryTargetTask, "")
 	require.NoError(t, cmd.Flags().Parse([]string{
-		"--kind", "no-tool-cache",
+		"--action", "no-tool-cache",
 		"--without-tool-cache", "bundler",
 		"--without-tool-cache", "golang",
-		"--debug=false",
+		"--debug", "start",
 	}))
 
 	err := cmd.RunE(cmd, []string{"task-123"})
@@ -107,7 +112,7 @@ func TestRetryCommandOutputsEndpointErrorAsJSON(t *testing.T) {
 
 	options := api.RetryOptions{
 		Retryable:  true,
-		Kinds:      []api.RetryKind{{Value: "standard", Label: "Standard retry"}},
+		Actions:    []api.RetryAction{{Value: "standard", Label: "Standard retry"}},
 		Debug:      api.RetryDebugOptions{Placements: []string{}},
 		ToolCaches: []api.RetryToolCache{},
 	}
@@ -118,7 +123,7 @@ func TestRetryCommandOutputsEndpointErrorAsJSON(t *testing.T) {
 	mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
 		return api.RequestRetryResult{}, &api.RetryRequestError{
 			Message: "This retry configuration is not supported.",
-			Errors:  []api.RetryFieldError{{Field: "kind", Message: "Choose `standard`."}},
+			Errors:  []api.RetryFieldError{{Field: "action", Message: "Choose `standard`."}},
 			Options: options,
 		}
 	}
@@ -127,7 +132,7 @@ func TestRetryCommandOutputsEndpointErrorAsJSON(t *testing.T) {
 	service = cli.Service{Config: cli.Config{APIClient: mockAPI, Stdout: &stdout}}
 	Format = "json"
 	cmd := newRetryCommand("retry [flags] <task-id>", "Retry a task", api.RetryTargetTask, "")
-	require.NoError(t, cmd.Flags().Parse([]string{"--kind", "standard"}))
+	require.NoError(t, cmd.Flags().Parse([]string{"--action", "standard"}))
 
 	err := cmd.RunE(cmd, []string{"task-123"})
 
@@ -137,5 +142,13 @@ func TestRetryCommandOutputsEndpointErrorAsJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(stdout.String()), &output))
 	require.Equal(t, "This retry configuration is not supported.", output["error"])
 	require.Equal(t, "Choose `standard`.", output["errors"].([]any)[0].(map[string]any)["message"])
-	require.Equal(t, "standard", output["options"].(map[string]any)["kinds"].([]any)[0].(map[string]any)["value"])
+	require.Equal(t, "standard", output["options"].(map[string]any)["actions"].([]any)[0].(map[string]any)["value"])
+}
+
+func TestRetryDebugRequiresPlacement(t *testing.T) {
+	cmd := newRetryCommand("retry [flags] <task-id>", "Retry a task", api.RetryTargetTask, "")
+
+	err := cmd.Flags().Parse([]string{"--debug"})
+
+	require.ErrorContains(t, err, "flag needs an argument")
 }

--- a/cmd/rwx/root.go
+++ b/cmd/rwx/root.go
@@ -236,6 +236,7 @@ func init() {
 	rootCmd.AddCommand(packagesCmd)
 	rootCmd.AddCommand(pushCmd)
 	rootCmd.AddCommand(resolveCmd)
+	rootCmd.AddCommand(retryCmd)
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(sandboxCmd)
 	rootCmd.AddCommand(skillCmd)

--- a/cmd/rwx/runs.go
+++ b/cmd/rwx/runs.go
@@ -45,6 +45,7 @@ func init() {
 	runsCmd.AddCommand(runsShowCmd)
 	runsCmd.AddCommand(runsListCmd)
 	runsCmd.AddCommand(runsCancelCmd)
+	runsCmd.AddCommand(runsRetryCmd)
 
 	rootCmd.AddCommand(runsCmd)
 }

--- a/cmd/rwx/tasks.go
+++ b/cmd/rwx/tasks.go
@@ -1,0 +1,14 @@
+package main
+
+import "github.com/spf13/cobra"
+
+var tasksCmd = &cobra.Command{
+	GroupID: "execution",
+	Use:     "tasks",
+	Short:   "Manage tasks",
+}
+
+func init() {
+	tasksCmd.AddCommand(tasksRetryCmd)
+	rootCmd.AddCommand(tasksCmd)
+}

--- a/internal/api/retries.go
+++ b/internal/api/retries.go
@@ -24,7 +24,7 @@ type RetryTarget struct {
 	Type RetryTargetType
 }
 
-type RetryKind struct {
+type RetryAction struct {
 	Value       string `json:"value"`
 	Label       string `json:"label"`
 	Description string `json:"description,omitempty"`
@@ -46,14 +46,14 @@ type RetryToolCache struct {
 type RetryOptions struct {
 	Retryable         bool              `json:"retryable"`
 	UnavailableReason string            `json:"unavailable_reason,omitempty"`
-	Kinds             []RetryKind       `json:"kinds"`
+	Actions           []RetryAction     `json:"actions"`
 	Debug             RetryDebugOptions `json:"debug"`
 	ToolCaches        []RetryToolCache  `json:"tool_caches"`
 }
 
 type RequestRetryConfig struct {
 	Target         RetryTarget
-	Kind           string
+	Action         string
 	Debug          *bool
 	DebugPlacement string
 	ToolCacheNames []string
@@ -120,19 +120,19 @@ func (c Client) RequestRetry(cfg RequestRetryConfig) (RequestRetryResult, error)
 	if err != nil {
 		return RequestRetryResult{}, err
 	}
-	if cfg.Kind == "" {
-		return RequestRetryResult{}, badRetryRequest("missing retry kind")
+	if cfg.Action == "" {
+		return RequestRetryResult{}, badRetryRequest("missing retry action")
 	}
 
 	requestBody := struct {
 		Retry struct {
-			Kind           string   `json:"kind"`
+			Action         string   `json:"action"`
 			Debug          *bool    `json:"debug,omitempty"`
 			DebugPlacement string   `json:"debug_placement,omitempty"`
 			ToolCacheNames []string `json:"tool_cache_names,omitempty"`
 		} `json:"retry"`
 	}{}
-	requestBody.Retry.Kind = cfg.Kind
+	requestBody.Retry.Action = cfg.Action
 	requestBody.Retry.Debug = cfg.Debug
 	requestBody.Retry.DebugPlacement = cfg.DebugPlacement
 	requestBody.Retry.ToolCacheNames = cfg.ToolCacheNames

--- a/internal/api/retries.go
+++ b/internal/api/retries.go
@@ -1,0 +1,217 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/rwx-cloud/rwx/internal/errors"
+)
+
+type RetryTargetType string
+
+const (
+	RetryTargetInferred RetryTargetType = "inferred"
+	RetryTargetRun      RetryTargetType = "run"
+	RetryTargetTask     RetryTargetType = "task"
+)
+
+type RetryTarget struct {
+	ID   string
+	Type RetryTargetType
+}
+
+type RetryKind struct {
+	Value       string `json:"value"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+}
+
+type RetryDebugOptions struct {
+	Supported        bool     `json:"supported"`
+	Placements       []string `json:"placements"`
+	DefaultPlacement string   `json:"default_placement,omitempty"`
+	DisabledReason   string   `json:"disabled_reason,omitempty"`
+}
+
+type RetryToolCache struct {
+	Name             string   `json:"name"`
+	ScopedTaskKeys   []string `json:"scoped_task_keys"`
+	UsageDescription string   `json:"usage_description"`
+}
+
+type RetryOptions struct {
+	Retryable         bool              `json:"retryable"`
+	UnavailableReason string            `json:"unavailable_reason,omitempty"`
+	Kinds             []RetryKind       `json:"kinds"`
+	Debug             RetryDebugOptions `json:"debug"`
+	ToolCaches        []RetryToolCache  `json:"tool_caches"`
+}
+
+type RequestRetryConfig struct {
+	Target         RetryTarget
+	Kind           string
+	Debug          *bool
+	DebugPlacement string
+	ToolCacheNames []string
+}
+
+type RequestRetryResult struct {
+	Status string `json:"status"`
+	RunID  string `json:"run_id"`
+	TaskID string `json:"task_id,omitempty"`
+}
+
+type RetryFieldError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+type RetryRequestError struct {
+	Message string            `json:"error"`
+	Errors  []RetryFieldError `json:"errors"`
+	Options RetryOptions      `json:"options"`
+}
+
+func (e *RetryRequestError) Error() string {
+	var message strings.Builder
+	message.WriteString(e.Message)
+	for _, fieldError := range e.Errors {
+		fmt.Fprintf(&message, "\n  %s: %s", fieldError.Field, fieldError.Message)
+	}
+	return message.String()
+}
+
+func (e *RetryRequestError) Unwrap() error {
+	return errors.ErrBadRequest
+}
+
+func (c Client) GetRetryOptions(target RetryTarget) (RetryOptions, error) {
+	params, err := target.queryParams()
+	if err != nil {
+		return RetryOptions{}, err
+	}
+
+	endpoint := "/mint/api/retries/options?" + params.Encode()
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return RetryOptions{}, errors.Wrap(err, "unable to create new HTTP request")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.RoundTrip(req)
+	if err != nil {
+		return RetryOptions{}, errors.Wrap(err, "HTTP request failed")
+	}
+	defer resp.Body.Close()
+
+	result := RetryOptions{}
+	if err := decodeRetryResponseJSON(resp, &result); err != nil {
+		return RetryOptions{}, err
+	}
+	return result, nil
+}
+
+func (c Client) RequestRetry(cfg RequestRetryConfig) (RequestRetryResult, error) {
+	params, err := cfg.Target.queryParams()
+	if err != nil {
+		return RequestRetryResult{}, err
+	}
+	if cfg.Kind == "" {
+		return RequestRetryResult{}, badRetryRequest("missing retry kind")
+	}
+
+	requestBody := struct {
+		Retry struct {
+			Kind           string   `json:"kind"`
+			Debug          *bool    `json:"debug,omitempty"`
+			DebugPlacement string   `json:"debug_placement,omitempty"`
+			ToolCacheNames []string `json:"tool_cache_names,omitempty"`
+		} `json:"retry"`
+	}{}
+	requestBody.Retry.Kind = cfg.Kind
+	requestBody.Retry.Debug = cfg.Debug
+	requestBody.Retry.DebugPlacement = cfg.DebugPlacement
+	requestBody.Retry.ToolCacheNames = cfg.ToolCacheNames
+
+	encodedBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return RequestRetryResult{}, errors.Wrap(err, "unable to encode as JSON")
+	}
+
+	endpoint := "/mint/api/retries?" + params.Encode()
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(encodedBody))
+	if err != nil {
+		return RequestRetryResult{}, errors.Wrap(err, "unable to create new HTTP request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.RoundTrip(req)
+	if err != nil {
+		return RequestRetryResult{}, errors.Wrap(err, "HTTP request failed")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		requestError := &RetryRequestError{}
+		if err := json.NewDecoder(resp.Body).Decode(requestError); err != nil {
+			return RequestRetryResult{}, errors.WrapSentinel(errors.Wrap(err, "unable to parse API response"), errors.ErrBadRequest)
+		}
+		if requestError.Message == "" {
+			requestError.Message = "Unable to call RWX API - 422 Unprocessable Entity"
+		}
+		return RequestRetryResult{}, requestError
+	}
+
+	result := RequestRetryResult{}
+	if err := decodeRetryResponseJSON(resp, &result); err != nil {
+		return RequestRetryResult{}, err
+	}
+	return result, nil
+}
+
+func (t RetryTarget) queryParams() (url.Values, error) {
+	if t.ID == "" {
+		return nil, badRetryRequest("missing retry target ID")
+	}
+
+	key := ""
+	switch t.Type {
+	case "", RetryTargetInferred:
+		key = "id"
+	case RetryTargetRun:
+		key = "run_id"
+	case RetryTargetTask:
+		key = "task_id"
+	default:
+		return nil, badRetryRequest(fmt.Sprintf("invalid retry target type %q", t.Type))
+	}
+
+	return url.Values{key: []string{t.ID}}, nil
+}
+
+func decodeRetryResponseJSON(resp *http.Response, result any) error {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if err := json.NewDecoder(resp.Body).Decode(result); err != nil {
+			return errors.Wrap(err, "unable to parse API response")
+		}
+		return nil
+	}
+
+	message := extractErrorMessage(resp.Body)
+	if message == "" {
+		message = fmt.Sprintf("Unable to call RWX API - %s", resp.Status)
+	}
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnprocessableEntity {
+		return badRetryRequest(message)
+	}
+	return classifyHTTPStatusError(resp.StatusCode, message)
+}
+
+func badRetryRequest(message string) error {
+	return errors.WrapSentinel(errors.New(message), errors.ErrBadRequest)
+}

--- a/internal/api/retries_test.go
+++ b/internal/api/retries_test.go
@@ -1,0 +1,190 @@
+package api_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	internalErrors "github.com/rwx-cloud/rwx/internal/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIClient_GetRetryOptions(t *testing.T) {
+	t.Run("fetches the available choices for each target type", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			target    api.RetryTarget
+			queryName string
+		}{
+			{name: "inferred", target: api.RetryTarget{ID: "target-123", Type: api.RetryTargetInferred}, queryName: "id"},
+			{name: "run", target: api.RetryTarget{ID: "run-123", Type: api.RetryTargetRun}, queryName: "run_id"},
+			{name: "task", target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask}, queryName: "task_id"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				client := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+					require.Equal(t, http.MethodGet, req.Method)
+					require.Equal(t, "/mint/api/retries/options", req.URL.Path)
+					require.Equal(t, tt.target.ID, req.URL.Query().Get(tt.queryName))
+					require.Len(t, req.URL.Query(), 1)
+					require.Equal(t, "application/json", req.Header.Get("Accept"))
+
+					return &http.Response{
+						Status:     "200 OK",
+						StatusCode: http.StatusOK,
+						Body: io.NopCloser(strings.NewReader(`{
+							"retryable": true,
+							"kinds": [{"value":"standard","label":"Retry all tasks","description":"Every task will run again."}],
+							"debug": {"supported":true,"placements":["end","start"],"default_placement":"end"},
+							"tool_caches": [{"name":"bundler","scoped_task_keys":["test"],"usage_description":"Used by test"}]
+						}`)),
+					}, nil
+				})
+
+				options, err := client.GetRetryOptions(tt.target)
+
+				require.NoError(t, err)
+				require.True(t, options.Retryable)
+				require.Equal(t, []api.RetryKind{{
+					Value:       "standard",
+					Label:       "Retry all tasks",
+					Description: "Every task will run again.",
+				}}, options.Kinds)
+				require.Equal(t, api.RetryDebugOptions{
+					Supported:        true,
+					Placements:       []string{"end", "start"},
+					DefaultPlacement: "end",
+				}, options.Debug)
+				require.Equal(t, []api.RetryToolCache{{
+					Name:             "bundler",
+					ScopedTaskKeys:   []string{"test"},
+					UsageDescription: "Used by test",
+				}}, options.ToolCaches)
+			})
+		}
+	})
+
+	t.Run("requires a target identifier", func(t *testing.T) {
+		client := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			t.Fatal("the API must not be called")
+			return nil, nil
+		})
+
+		_, err := client.GetRetryOptions(api.RetryTarget{Type: api.RetryTargetRun})
+
+		require.EqualError(t, err, "missing retry target ID")
+		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
+	})
+}
+
+func TestAPIClient_RequestRetry(t *testing.T) {
+	t.Run("requests a task retry with all selected options", func(t *testing.T) {
+		debug := true
+		client := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, http.MethodPost, req.Method)
+			require.Equal(t, "/mint/api/retries", req.URL.Path)
+			require.Equal(t, "task-123", req.URL.Query().Get("task_id"))
+			require.Equal(t, "application/json", req.Header.Get("Content-Type"))
+			require.Equal(t, "application/json", req.Header.Get("Accept"))
+
+			var body map[string]any
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			require.Equal(t, map[string]any{
+				"retry": map[string]any{
+					"kind":             "no-tool-cache",
+					"debug":            true,
+					"debug_placement":  "start",
+					"tool_cache_names": []any{"bundler", "golang"},
+				},
+			}, body)
+
+			return &http.Response{
+				Status:     "202 Accepted",
+				StatusCode: http.StatusAccepted,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"retry_requested","run_id":"run-123","task_id":"task-123"}`)),
+			}, nil
+		})
+
+		result, err := client.RequestRetry(api.RequestRetryConfig{
+			Target:         api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+			Kind:           "no-tool-cache",
+			Debug:          &debug,
+			DebugPlacement: "start",
+			ToolCacheNames: []string{"bundler", "golang"},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, api.RequestRetryResult{
+			Status: "retry_requested",
+			RunID:  "run-123",
+			TaskID: "task-123",
+		}, result)
+	})
+
+	t.Run("omits optional selections", func(t *testing.T) {
+		client := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			var body map[string]any
+			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
+			require.Equal(t, map[string]any{
+				"retry": map[string]any{"kind": "standard"},
+			}, body)
+
+			return &http.Response{
+				Status:     "202 Accepted",
+				StatusCode: http.StatusAccepted,
+				Body:       io.NopCloser(strings.NewReader(`{"status":"retry_requested","run_id":"run-123"}`)),
+			}, nil
+		})
+
+		_, err := client.RequestRetry(api.RequestRetryConfig{
+			Target: api.RetryTarget{ID: "run-123", Type: api.RetryTargetRun},
+			Kind:   "standard",
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("returns validation details and refreshed options", func(t *testing.T) {
+		client := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "422 Unprocessable Content",
+				StatusCode: http.StatusUnprocessableEntity,
+				Body: io.NopCloser(strings.NewReader(`{
+					"error":"This retry configuration is not supported.",
+					"errors":[{"field":"kind","message":"Choose \u0060standard\u0060."}],
+					"options":{"retryable":true,"kinds":[{"value":"standard","label":"Standard retry"}],"debug":{"supported":false,"placements":[]},"tool_caches":[]}
+				}`)),
+			}, nil
+		})
+
+		_, err := client.RequestRetry(api.RequestRetryConfig{
+			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+			Kind:   "clean",
+		})
+
+		var requestErr *api.RetryRequestError
+		require.ErrorAs(t, err, &requestErr)
+		require.EqualError(t, err, "This retry configuration is not supported.\n  kind: Choose `standard`.")
+		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
+		require.Equal(t, []api.RetryFieldError{{Field: "kind", Message: "Choose `standard`."}}, requestErr.Errors)
+		require.Equal(t, "standard", requestErr.Options.Kinds[0].Value)
+	})
+
+	t.Run("requires a retry kind", func(t *testing.T) {
+		client := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
+			t.Fatal("the API must not be called")
+			return nil, nil
+		})
+
+		_, err := client.RequestRetry(api.RequestRetryConfig{
+			Target: api.RetryTarget{ID: "run-123", Type: api.RetryTargetRun},
+		})
+
+		require.EqualError(t, err, "missing retry kind")
+		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
+	})
+}

--- a/internal/api/retries_test.go
+++ b/internal/api/retries_test.go
@@ -38,7 +38,7 @@ func TestAPIClient_GetRetryOptions(t *testing.T) {
 						StatusCode: http.StatusOK,
 						Body: io.NopCloser(strings.NewReader(`{
 							"retryable": true,
-							"kinds": [{"value":"standard","label":"Retry all tasks","description":"Every task will run again."}],
+							"actions": [{"value":"standard","label":"Retry all tasks","description":"Every task will run again."}],
 							"debug": {"supported":true,"placements":["end","start"],"default_placement":"end"},
 							"tool_caches": [{"name":"bundler","scoped_task_keys":["test"],"usage_description":"Used by test"}]
 						}`)),
@@ -49,11 +49,11 @@ func TestAPIClient_GetRetryOptions(t *testing.T) {
 
 				require.NoError(t, err)
 				require.True(t, options.Retryable)
-				require.Equal(t, []api.RetryKind{{
+				require.Equal(t, []api.RetryAction{{
 					Value:       "standard",
 					Label:       "Retry all tasks",
 					Description: "Every task will run again.",
-				}}, options.Kinds)
+				}}, options.Actions)
 				require.Equal(t, api.RetryDebugOptions{
 					Supported:        true,
 					Placements:       []string{"end", "start"},
@@ -95,7 +95,7 @@ func TestAPIClient_RequestRetry(t *testing.T) {
 			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
 			require.Equal(t, map[string]any{
 				"retry": map[string]any{
-					"kind":             "no-tool-cache",
+					"action":           "no-tool-cache",
 					"debug":            true,
 					"debug_placement":  "start",
 					"tool_cache_names": []any{"bundler", "golang"},
@@ -111,7 +111,7 @@ func TestAPIClient_RequestRetry(t *testing.T) {
 
 		result, err := client.RequestRetry(api.RequestRetryConfig{
 			Target:         api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
-			Kind:           "no-tool-cache",
+			Action:         "no-tool-cache",
 			Debug:          &debug,
 			DebugPlacement: "start",
 			ToolCacheNames: []string{"bundler", "golang"},
@@ -130,7 +130,7 @@ func TestAPIClient_RequestRetry(t *testing.T) {
 			var body map[string]any
 			require.NoError(t, json.NewDecoder(req.Body).Decode(&body))
 			require.Equal(t, map[string]any{
-				"retry": map[string]any{"kind": "standard"},
+				"retry": map[string]any{"action": "standard"},
 			}, body)
 
 			return &http.Response{
@@ -142,7 +142,7 @@ func TestAPIClient_RequestRetry(t *testing.T) {
 
 		_, err := client.RequestRetry(api.RequestRetryConfig{
 			Target: api.RetryTarget{ID: "run-123", Type: api.RetryTargetRun},
-			Kind:   "standard",
+			Action: "standard",
 		})
 
 		require.NoError(t, err)
@@ -155,26 +155,26 @@ func TestAPIClient_RequestRetry(t *testing.T) {
 				StatusCode: http.StatusUnprocessableEntity,
 				Body: io.NopCloser(strings.NewReader(`{
 					"error":"This retry configuration is not supported.",
-					"errors":[{"field":"kind","message":"Choose \u0060standard\u0060."}],
-					"options":{"retryable":true,"kinds":[{"value":"standard","label":"Standard retry"}],"debug":{"supported":false,"placements":[]},"tool_caches":[]}
+					"errors":[{"field":"action","message":"Choose \u0060standard\u0060."}],
+					"options":{"retryable":true,"actions":[{"value":"standard","label":"Standard retry"}],"debug":{"supported":false,"placements":[]},"tool_caches":[]}
 				}`)),
 			}, nil
 		})
 
 		_, err := client.RequestRetry(api.RequestRetryConfig{
 			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
-			Kind:   "clean",
+			Action: "clean",
 		})
 
 		var requestErr *api.RetryRequestError
 		require.ErrorAs(t, err, &requestErr)
-		require.EqualError(t, err, "This retry configuration is not supported.\n  kind: Choose `standard`.")
+		require.EqualError(t, err, "This retry configuration is not supported.\n  action: Choose `standard`.")
 		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
-		require.Equal(t, []api.RetryFieldError{{Field: "kind", Message: "Choose `standard`."}}, requestErr.Errors)
-		require.Equal(t, "standard", requestErr.Options.Kinds[0].Value)
+		require.Equal(t, []api.RetryFieldError{{Field: "action", Message: "Choose `standard`."}}, requestErr.Errors)
+		require.Equal(t, "standard", requestErr.Options.Actions[0].Value)
 	})
 
-	t.Run("requires a retry kind", func(t *testing.T) {
+	t.Run("requires a retry action", func(t *testing.T) {
 		client := api.NewClientWithRoundTrip(func(req *http.Request) (*http.Response, error) {
 			t.Fatal("the API must not be called")
 			return nil, nil
@@ -184,7 +184,7 @@ func TestAPIClient_RequestRetry(t *testing.T) {
 			Target: api.RetryTarget{ID: "run-123", Type: api.RetryTargetRun},
 		})
 
-		require.EqualError(t, err, "missing retry kind")
+		require.EqualError(t, err, "missing retry action")
 		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
 	})
 }

--- a/internal/cli/interfaces.go
+++ b/internal/cli/interfaces.go
@@ -43,6 +43,8 @@ type APIClient interface {
 	RunStatus(api.RunStatusConfig) (api.RunStatusResult, error)
 	GetRunDetails(api.RunDetailsConfig) (map[string]any, error)
 	ListRuns(api.ListRunsConfig) (*api.ListRunsResult, error)
+	GetRetryOptions(api.RetryTarget) (api.RetryOptions, error)
+	RequestRetry(api.RequestRetryConfig) (api.RequestRetryResult, error)
 	GetLogDownloadRequest(taskId string) (api.LogDownloadRequestResult, error)
 	GetLogDownloadRequestByTaskKey(runID, taskKey string) (api.LogDownloadRequestResult, error)
 	DownloadLogs(api.LogDownloadRequestResult, ...int) ([]byte, error)

--- a/internal/cli/service_retry.go
+++ b/internal/cli/service_retry.go
@@ -12,9 +12,8 @@ import (
 
 type RetryConfig struct {
 	Target           api.RetryTarget
-	Kind             string
+	Action           string
 	WithoutToolCache []string
-	Debug            *bool
 	DebugPlacement   string
 	OutputJSON       bool
 }
@@ -55,7 +54,7 @@ func (s Service) Retry(cfg RetryConfig) (*api.RequestRetryResult, error) {
 	if !errors.As(err, &requestErr) {
 		return nil, err
 	}
-	if interactive && cfg.bare() && requestErr.Options.Retryable && len(requestErr.Options.Kinds) > 0 {
+	if interactive && cfg.bare() && requestErr.Options.Retryable && len(requestErr.Options.Actions) > 0 {
 		fmt.Fprintln(s.Stdout, "The available retry options changed.")
 		fmt.Fprintln(s.Stdout)
 
@@ -91,27 +90,33 @@ func (s Service) selectRetryRequest(
 		return api.RequestRetryConfig{}, retryBadRequest(reason)
 	}
 
-	kind := cfg.Kind
-	if kind == "" {
+	action := cfg.Action
+	if action == "" && len(options.Actions) == 1 {
+		action = options.Actions[0].Value
+	}
+	if action == "" {
 		if !interactive {
-			return api.RequestRetryConfig{}, retryKindSelectionError("retry kind selection is required", cfg.Target, options.Kinds)
+			return api.RequestRetryConfig{}, retryActionSelectionError("retry action selection is required", cfg.Target, options.Actions)
 		}
-		selected, err := s.promptForRetryKind(input, options.Kinds)
+		selected, err := s.promptForRetryAction(input, options.Actions)
 		if err != nil {
 			return api.RequestRetryConfig{}, err
 		}
-		kind = selected
+		action = selected
 	}
-	if !retryKindAvailable(kind, options.Kinds) {
-		return api.RequestRetryConfig{}, retryKindSelectionError(fmt.Sprintf("retry kind %q is not available", kind), cfg.Target, options.Kinds)
+	if !retryActionAvailable(action, options.Actions) {
+		return api.RequestRetryConfig{}, retryActionSelectionError(fmt.Sprintf("retry action %q is not available", action), cfg.Target, options.Actions)
 	}
 
 	toolCacheNames := uniqueStrings(cfg.WithoutToolCache)
-	if kind == "no-tool-cache" {
+	if action == "no-tool-cache" {
+		if len(toolCacheNames) == 0 && len(options.ToolCaches) == 1 {
+			toolCacheNames = []string{options.ToolCaches[0].Name}
+		}
 		if len(toolCacheNames) == 0 {
 			if !interactive {
 				return api.RequestRetryConfig{}, retryToolCacheSelectionError(
-					"tool cache selection is required for retry kind \"no-tool-cache\"",
+					"tool cache selection is required for retry action \"no-tool-cache\"",
 					cfg.Target,
 					options.ToolCaches,
 				)
@@ -132,17 +137,17 @@ func (s Service) selectRetryRequest(
 			}
 		}
 	} else if len(toolCacheNames) > 0 {
-		return api.RequestRetryConfig{}, retryBadRequest("--without-tool-cache can only be used with --kind no-tool-cache")
+		return api.RequestRetryConfig{}, retryBadRequest("--without-tool-cache can only be used with --action no-tool-cache")
 	}
 
-	debug, debugPlacement, err := s.selectRetryDebugOptions(input, interactive, cfg.Debug, cfg.DebugPlacement, options.Debug)
+	debug, debugPlacement, err := selectRetryDebugOptions(cfg.DebugPlacement, options.Debug)
 	if err != nil {
 		return api.RequestRetryConfig{}, err
 	}
 
 	return api.RequestRetryConfig{
 		Target:         cfg.Target,
-		Kind:           kind,
+		Action:         action,
 		Debug:          debug,
 		DebugPlacement: debugPlacement,
 		ToolCacheNames: toolCacheNames,
@@ -150,32 +155,31 @@ func (s Service) selectRetryRequest(
 }
 
 func (c RetryConfig) bare() bool {
-	return c.Kind == "" &&
+	return c.Action == "" &&
 		len(c.WithoutToolCache) == 0 &&
-		c.Debug == nil &&
 		c.DebugPlacement == ""
 }
 
-func (s Service) promptForRetryKind(input *bufio.Reader, kinds []api.RetryKind) (string, error) {
-	if len(kinds) == 0 {
-		return "", retryBadRequest("no retry kinds are available")
+func (s Service) promptForRetryAction(input *bufio.Reader, actions []api.RetryAction) (string, error) {
+	if len(actions) == 0 {
+		return "", retryBadRequest("no retry actions are available")
 	}
 
-	fmt.Fprintln(s.Stdout, "Select a retry kind:")
-	for index, kind := range kinds {
-		fmt.Fprintf(s.Stdout, "  %d. %s (%s)\n", index+1, kind.Label, kind.Value)
-		if kind.Description != "" {
-			fmt.Fprintf(s.Stdout, "     %s\n", kind.Description)
+	fmt.Fprintln(s.Stdout, "Select a retry action:")
+	for index, action := range actions {
+		fmt.Fprintf(s.Stdout, "  %d. %s (%s)\n", index+1, action.Label, action.Value)
+		if action.Description != "" {
+			fmt.Fprintf(s.Stdout, "     %s\n", action.Description)
 		}
 	}
 	fmt.Fprintln(s.Stdout)
-	fmt.Fprintf(s.Stdout, "Enter a number (1-%d): ", len(kinds))
+	fmt.Fprintf(s.Stdout, "Enter a number (1-%d): ", len(actions))
 
-	choice, err := readRetryChoice(input, len(kinds), "retry kind")
+	choice, err := readRetryChoice(input, len(actions), "retry action")
 	if err != nil {
 		return "", err
 	}
-	return kinds[choice-1].Value, nil
+	return actions[choice-1].Value, nil
 }
 
 func (s Service) promptForRetryToolCaches(input *bufio.Reader, caches []api.RetryToolCache) ([]string, error) {
@@ -219,34 +223,9 @@ func (s Service) promptForRetryToolCaches(input *bufio.Reader, caches []api.Retr
 	return selected, nil
 }
 
-func (s Service) selectRetryDebugOptions(
-	input *bufio.Reader,
-	interactive bool,
-	debug *bool,
-	placement string,
-	options api.RetryDebugOptions,
-) (*bool, string, error) {
-	if debug == nil && placement != "" {
-		enabled := true
-		debug = &enabled
-	}
-
-	if debug == nil && interactive && options.Supported {
-		selected, err := s.promptForRetryDebug(input)
-		if err != nil {
-			return nil, "", err
-		}
-		debug = &selected
-	}
-
-	if debug == nil {
+func selectRetryDebugOptions(placement string, options api.RetryDebugOptions) (*bool, string, error) {
+	if placement == "" {
 		return nil, "", nil
-	}
-	if !*debug {
-		if placement != "" {
-			return nil, "", retryBadRequest("--debug-placement cannot be used with --debug=false")
-		}
-		return debug, "", nil
 	}
 	if !options.Supported {
 		reason := options.DisabledReason
@@ -256,62 +235,15 @@ func (s Service) selectRetryDebugOptions(
 		return nil, "", retryBadRequest(reason)
 	}
 
-	if placement == "" {
-		if interactive {
-			selected, err := s.promptForRetryDebugPlacement(input, options.Placements)
-			if err != nil {
-				return nil, "", err
-			}
-			placement = selected
-		} else {
-			placement = options.DefaultPlacement
-			if placement == "" && len(options.Placements) == 1 {
-				placement = options.Placements[0]
-			}
-		}
-	}
 	if !stringAvailable(placement, options.Placements) {
 		return nil, "", retryBadRequest(fmt.Sprintf(
-			"debug placement %q is not available; choose one of: %s",
+			"breakpoint placement %q is not available; choose one of: %s",
 			placement,
 			strings.Join(options.Placements, ", "),
 		))
 	}
-	return debug, placement, nil
-}
-
-func (s Service) promptForRetryDebug(input *bufio.Reader) (bool, error) {
-	fmt.Fprint(s.Stdout, "Open a breakpoint? [y/N]: ")
-	line, err := readRetryLine(input, "no breakpoint selection provided")
-	if err != nil {
-		return false, err
-	}
-	switch strings.ToLower(line) {
-	case "", "n", "no":
-		return false, nil
-	case "y", "yes":
-		return true, nil
-	default:
-		return false, retryBadRequest(fmt.Sprintf("invalid breakpoint selection: %s", line))
-	}
-}
-
-func (s Service) promptForRetryDebugPlacement(input *bufio.Reader, placements []string) (string, error) {
-	if len(placements) == 0 {
-		return "", retryBadRequest("no breakpoint placements are available")
-	}
-	fmt.Fprintln(s.Stdout, "Select breakpoint placement:")
-	for index, placement := range placements {
-		fmt.Fprintf(s.Stdout, "  %d. %s\n", index+1, placement)
-	}
-	fmt.Fprintln(s.Stdout)
-	fmt.Fprintf(s.Stdout, "Enter a number (1-%d): ", len(placements))
-
-	choice, err := readRetryChoice(input, len(placements), "breakpoint placement")
-	if err != nil {
-		return "", err
-	}
-	return placements[choice-1], nil
+	enabled := true
+	return &enabled, placement, nil
 }
 
 func readRetryChoice(input *bufio.Reader, count int, selectionName string) (int, error) {
@@ -334,9 +266,9 @@ func readRetryLine(input *bufio.Reader, emptyMessage string) (string, error) {
 	return strings.TrimSpace(line), nil
 }
 
-func retryKindAvailable(value string, kinds []api.RetryKind) bool {
-	for _, kind := range kinds {
-		if kind.Value == value {
+func retryActionAvailable(value string, actions []api.RetryAction) bool {
+	for _, action := range actions {
+		if action.Value == value {
 			return true
 		}
 	}
@@ -376,22 +308,22 @@ func uniqueStrings(values []string) []string {
 	return unique
 }
 
-func retryKindSelectionError(reason string, target api.RetryTarget, kinds []api.RetryKind) error {
+func retryActionSelectionError(reason string, target api.RetryTarget, actions []api.RetryAction) error {
 	var message strings.Builder
 	message.WriteString(reason)
-	message.WriteString("\n\nAvailable retry kinds:\n")
-	for _, kind := range kinds {
-		fmt.Fprintf(&message, "  %s - %s\n", kind.Value, kind.Label)
-		if kind.Description != "" {
-			fmt.Fprintf(&message, "    %s\n", kind.Description)
+	message.WriteString("\n\nAvailable retry actions:\n")
+	for _, action := range actions {
+		fmt.Fprintf(&message, "  %s - %s\n", action.Value, action.Label)
+		if action.Description != "" {
+			fmt.Fprintf(&message, "    %s\n", action.Description)
 		}
 	}
-	if len(kinds) > 0 {
+	if len(actions) > 0 {
 		fmt.Fprintf(
 			&message,
-			"\nChoose a kind and retry:\n  %s --kind %s %s",
+			"\nChoose an action and retry:\n  %s --action %s %s",
 			retryCommand(target.Type),
-			kinds[0].Value,
+			actions[0].Value,
 			target.ID,
 		)
 	}
@@ -411,7 +343,7 @@ func retryToolCacheSelectionError(reason string, target api.RetryTarget, caches 
 	if len(caches) > 0 {
 		fmt.Fprintf(
 			&message,
-			"\nChoose one or more tool caches and retry:\n  %s --kind no-tool-cache --without-tool-cache %s %s",
+			"\nChoose one or more tool caches and retry:\n  %s --action no-tool-cache --without-tool-cache %s %s",
 			retryCommand(target.Type),
 			caches[0].Name,
 			target.ID,
@@ -435,15 +367,15 @@ func retryEndpointError(requestErr *api.RetryRequestError, request api.RequestRe
 	var message strings.Builder
 	message.WriteString(requestErr.Message)
 
-	showKinds := false
+	showActions := false
 	showToolCaches := false
 	showDebugPlacements := false
 	showAll := len(requestErr.Errors) == 0
 	for _, fieldError := range requestErr.Errors {
 		switch fieldError.Field {
-		case "kind":
-			fmt.Fprintf(&message, "\n\nRetry kind: %s", fieldError.Message)
-			showKinds = true
+		case "action":
+			fmt.Fprintf(&message, "\n\nRetry action: %s", fieldError.Message)
+			showActions = true
 		case "tool_cache_names":
 			fmt.Fprintf(&message, "\n\nTool cache: %s", fieldError.Message)
 			showToolCaches = true
@@ -458,16 +390,16 @@ func retryEndpointError(requestErr *api.RetryRequestError, request api.RequestRe
 		}
 	}
 	if showAll {
-		showKinds = len(requestErr.Options.Kinds) > 0
+		showActions = len(requestErr.Options.Actions) > 0
 		showToolCaches = len(requestErr.Options.ToolCaches) > 0
 	}
 
-	if showKinds {
-		message.WriteString("\n\nAvailable retry kinds:\n")
-		for _, kind := range requestErr.Options.Kinds {
-			fmt.Fprintf(&message, "  %s - %s\n", kind.Value, kind.Label)
-			if kind.Description != "" {
-				fmt.Fprintf(&message, "    %s\n", kind.Description)
+	if showActions {
+		message.WriteString("\n\nAvailable retry actions:\n")
+		for _, action := range requestErr.Options.Actions {
+			fmt.Fprintf(&message, "  %s - %s\n", action.Value, action.Label)
+			if action.Description != "" {
+				fmt.Fprintf(&message, "    %s\n", action.Description)
 			}
 		}
 	}
@@ -511,26 +443,26 @@ func retryEndpointError(requestErr *api.RetryRequestError, request api.RequestRe
 	}
 
 	switch {
-	case showKinds && len(requestErr.Options.Kinds) > 0:
+	case showActions && len(requestErr.Options.Actions) > 0:
 		fmt.Fprintf(
 			&message,
-			"\nTry:\n  %s %s --kind %s",
+			"\nTry:\n  %s %s --action %s",
 			retryCommand(request.Target.Type),
 			request.Target.ID,
-			requestErr.Options.Kinds[0].Value,
+			requestErr.Options.Actions[0].Value,
 		)
 	case showToolCaches && len(requestErr.Options.ToolCaches) > 0:
 		fmt.Fprintf(
 			&message,
-			"\nTry:\n  %s %s --kind no-tool-cache --without-tool-cache %s",
+			"\nTry:\n  %s %s --action no-tool-cache --without-tool-cache %s",
 			retryCommand(request.Target.Type),
 			request.Target.ID,
 			requestErr.Options.ToolCaches[0].Name,
 		)
 	case showDebugPlacements && len(requestErr.Options.Debug.Placements) > 0:
-		kind := request.Kind
-		if !retryKindAvailable(kind, requestErr.Options.Kinds) && len(requestErr.Options.Kinds) > 0 {
-			kind = requestErr.Options.Kinds[0].Value
+		action := request.Action
+		if !retryActionAvailable(action, requestErr.Options.Actions) && len(requestErr.Options.Actions) > 0 {
+			action = requestErr.Options.Actions[0].Value
 		}
 		placement := requestErr.Options.Debug.DefaultPlacement
 		if placement == "" {
@@ -538,10 +470,10 @@ func retryEndpointError(requestErr *api.RetryRequestError, request api.RequestRe
 		}
 		fmt.Fprintf(
 			&message,
-			"\nTry:\n  %s %s --kind %s --debug --debug-placement %s",
+			"\nTry:\n  %s %s --action %s --debug %s",
 			retryCommand(request.Target.Type),
 			request.Target.ID,
-			kind,
+			action,
 			placement,
 		)
 	}

--- a/internal/cli/service_retry.go
+++ b/internal/cli/service_retry.go
@@ -35,13 +35,6 @@ func (s Service) Retry(cfg RetryConfig) (*api.RequestRetryResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !options.Retryable {
-		reason := options.UnavailableReason
-		if reason == "" {
-			reason = "This run or task cannot be retried in its current state."
-		}
-		return nil, retryBadRequest(reason)
-	}
 
 	interactive := s.StdoutIsTTY && !cfg.OutputJSON
 	var input *bufio.Reader
@@ -49,38 +42,89 @@ func (s Service) Retry(cfg RetryConfig) (*api.RequestRetryResult, error) {
 		input = bufio.NewReader(s.Stdin)
 	}
 
-	kind := cfg.Kind
-	if kind == "" {
-		if !interactive {
-			return nil, retryKindSelectionError("retry kind selection is required", cfg.Target, options.Kinds)
-		}
-		kind, err = s.promptForRetryKind(input, options.Kinds)
+	request, err := s.selectRetryRequest(input, interactive, cfg, options)
+	if err != nil {
+		return nil, err
+	}
+	result, err := s.APIClient.RequestRetry(request)
+	if err == nil {
+		return &result, nil
+	}
+
+	var requestErr *api.RetryRequestError
+	if !errors.As(err, &requestErr) {
+		return nil, err
+	}
+	if interactive && cfg.bare() && requestErr.Options.Retryable && len(requestErr.Options.Kinds) > 0 {
+		fmt.Fprintln(s.Stdout, "The available retry options changed.")
+		fmt.Fprintln(s.Stdout)
+
+		request, err = s.selectRetryRequest(input, true, RetryConfig{Target: cfg.Target}, requestErr.Options)
 		if err != nil {
 			return nil, err
 		}
+		result, err = s.APIClient.RequestRetry(request)
+		if err == nil {
+			return &result, nil
+		}
+		if !errors.As(err, &requestErr) {
+			return nil, err
+		}
+	}
+	if cfg.OutputJSON {
+		return nil, requestErr
+	}
+	return nil, retryEndpointError(requestErr, request)
+}
+
+func (s Service) selectRetryRequest(
+	input *bufio.Reader,
+	interactive bool,
+	cfg RetryConfig,
+	options api.RetryOptions,
+) (api.RequestRetryConfig, error) {
+	if !options.Retryable {
+		reason := options.UnavailableReason
+		if reason == "" {
+			reason = "This run or task cannot be retried in its current state."
+		}
+		return api.RequestRetryConfig{}, retryBadRequest(reason)
+	}
+
+	kind := cfg.Kind
+	if kind == "" {
+		if !interactive {
+			return api.RequestRetryConfig{}, retryKindSelectionError("retry kind selection is required", cfg.Target, options.Kinds)
+		}
+		selected, err := s.promptForRetryKind(input, options.Kinds)
+		if err != nil {
+			return api.RequestRetryConfig{}, err
+		}
+		kind = selected
 	}
 	if !retryKindAvailable(kind, options.Kinds) {
-		return nil, retryKindSelectionError(fmt.Sprintf("retry kind %q is not available", kind), cfg.Target, options.Kinds)
+		return api.RequestRetryConfig{}, retryKindSelectionError(fmt.Sprintf("retry kind %q is not available", kind), cfg.Target, options.Kinds)
 	}
 
 	toolCacheNames := uniqueStrings(cfg.WithoutToolCache)
 	if kind == "no-tool-cache" {
 		if len(toolCacheNames) == 0 {
 			if !interactive {
-				return nil, retryToolCacheSelectionError(
+				return api.RequestRetryConfig{}, retryToolCacheSelectionError(
 					"tool cache selection is required for retry kind \"no-tool-cache\"",
 					cfg.Target,
 					options.ToolCaches,
 				)
 			}
-			toolCacheNames, err = s.promptForRetryToolCaches(input, options.ToolCaches)
+			selected, err := s.promptForRetryToolCaches(input, options.ToolCaches)
 			if err != nil {
-				return nil, err
+				return api.RequestRetryConfig{}, err
 			}
+			toolCacheNames = selected
 		}
 		for _, name := range toolCacheNames {
 			if !retryToolCacheAvailable(name, options.ToolCaches) {
-				return nil, retryToolCacheSelectionError(
+				return api.RequestRetryConfig{}, retryToolCacheSelectionError(
 					fmt.Sprintf("tool cache %q is not available", name),
 					cfg.Target,
 					options.ToolCaches,
@@ -88,25 +132,28 @@ func (s Service) Retry(cfg RetryConfig) (*api.RequestRetryResult, error) {
 			}
 		}
 	} else if len(toolCacheNames) > 0 {
-		return nil, retryBadRequest("--without-tool-cache can only be used with --kind no-tool-cache")
+		return api.RequestRetryConfig{}, retryBadRequest("--without-tool-cache can only be used with --kind no-tool-cache")
 	}
 
 	debug, debugPlacement, err := s.selectRetryDebugOptions(input, interactive, cfg.Debug, cfg.DebugPlacement, options.Debug)
 	if err != nil {
-		return nil, err
+		return api.RequestRetryConfig{}, err
 	}
 
-	result, err := s.APIClient.RequestRetry(api.RequestRetryConfig{
+	return api.RequestRetryConfig{
 		Target:         cfg.Target,
 		Kind:           kind,
 		Debug:          debug,
 		DebugPlacement: debugPlacement,
 		ToolCacheNames: toolCacheNames,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &result, nil
+	}, nil
+}
+
+func (c RetryConfig) bare() bool {
+	return c.Kind == "" &&
+		len(c.WithoutToolCache) == 0 &&
+		c.Debug == nil &&
+		c.DebugPlacement == ""
 }
 
 func (s Service) promptForRetryKind(input *bufio.Reader, kinds []api.RetryKind) (string, error) {
@@ -382,6 +429,124 @@ func retryCommand(targetType api.RetryTargetType) string {
 	default:
 		return "rwx retry"
 	}
+}
+
+func retryEndpointError(requestErr *api.RetryRequestError, request api.RequestRetryConfig) error {
+	var message strings.Builder
+	message.WriteString(requestErr.Message)
+
+	showKinds := false
+	showToolCaches := false
+	showDebugPlacements := false
+	showAll := len(requestErr.Errors) == 0
+	for _, fieldError := range requestErr.Errors {
+		switch fieldError.Field {
+		case "kind":
+			fmt.Fprintf(&message, "\n\nRetry kind: %s", fieldError.Message)
+			showKinds = true
+		case "tool_cache_names":
+			fmt.Fprintf(&message, "\n\nTool cache: %s", fieldError.Message)
+			showToolCaches = true
+		case "debug":
+			fmt.Fprintf(&message, "\n\nBreakpoint: %s", fieldError.Message)
+		case "debug_placement":
+			fmt.Fprintf(&message, "\n\nBreakpoint placement: %s", fieldError.Message)
+			showDebugPlacements = true
+		default:
+			fmt.Fprintf(&message, "\n\nRetry: %s", fieldError.Message)
+			showAll = true
+		}
+	}
+	if showAll {
+		showKinds = len(requestErr.Options.Kinds) > 0
+		showToolCaches = len(requestErr.Options.ToolCaches) > 0
+	}
+
+	if showKinds {
+		message.WriteString("\n\nAvailable retry kinds:\n")
+		for _, kind := range requestErr.Options.Kinds {
+			fmt.Fprintf(&message, "  %s - %s\n", kind.Value, kind.Label)
+			if kind.Description != "" {
+				fmt.Fprintf(&message, "    %s\n", kind.Description)
+			}
+		}
+	}
+	if showAll && (requestErr.Options.Debug.Supported || requestErr.Options.Debug.DisabledReason != "") {
+		message.WriteString("\n\nBreakpoint:\n")
+		if requestErr.Options.Debug.Supported {
+			message.WriteString("  Supported\n")
+			message.WriteString("  Placements: ")
+			for index, placement := range requestErr.Options.Debug.Placements {
+				if index > 0 {
+					message.WriteString(", ")
+				}
+				message.WriteString(placement)
+				if placement == requestErr.Options.Debug.DefaultPlacement {
+					message.WriteString(" (default)")
+				}
+			}
+			message.WriteString("\n")
+		} else {
+			fmt.Fprintf(&message, "  %s\n", requestErr.Options.Debug.DisabledReason)
+		}
+	}
+	if showToolCaches {
+		message.WriteString("\n\nAvailable tool caches:\n")
+		for _, cache := range requestErr.Options.ToolCaches {
+			fmt.Fprintf(&message, "  %s\n", cache.Name)
+			if cache.UsageDescription != "" {
+				fmt.Fprintf(&message, "    %s\n", cache.UsageDescription)
+			}
+		}
+	}
+	if showDebugPlacements {
+		message.WriteString("\n\nAvailable breakpoint placements:\n")
+		for _, placement := range requestErr.Options.Debug.Placements {
+			fmt.Fprintf(&message, "  %s", placement)
+			if placement == requestErr.Options.Debug.DefaultPlacement {
+				message.WriteString(" (default)")
+			}
+			message.WriteString("\n")
+		}
+	}
+
+	switch {
+	case showKinds && len(requestErr.Options.Kinds) > 0:
+		fmt.Fprintf(
+			&message,
+			"\nTry:\n  %s %s --kind %s",
+			retryCommand(request.Target.Type),
+			request.Target.ID,
+			requestErr.Options.Kinds[0].Value,
+		)
+	case showToolCaches && len(requestErr.Options.ToolCaches) > 0:
+		fmt.Fprintf(
+			&message,
+			"\nTry:\n  %s %s --kind no-tool-cache --without-tool-cache %s",
+			retryCommand(request.Target.Type),
+			request.Target.ID,
+			requestErr.Options.ToolCaches[0].Name,
+		)
+	case showDebugPlacements && len(requestErr.Options.Debug.Placements) > 0:
+		kind := request.Kind
+		if !retryKindAvailable(kind, requestErr.Options.Kinds) && len(requestErr.Options.Kinds) > 0 {
+			kind = requestErr.Options.Kinds[0].Value
+		}
+		placement := requestErr.Options.Debug.DefaultPlacement
+		if placement == "" {
+			placement = requestErr.Options.Debug.Placements[0]
+		}
+		fmt.Fprintf(
+			&message,
+			"\nTry:\n  %s %s --kind %s --debug --debug-placement %s",
+			retryCommand(request.Target.Type),
+			request.Target.ID,
+			kind,
+			placement,
+		)
+	}
+
+	return retryBadRequest(strings.TrimRight(message.String(), "\n"))
 }
 
 func retryBadRequest(message string) error {

--- a/internal/cli/service_retry.go
+++ b/internal/cli/service_retry.go
@@ -1,0 +1,389 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/errors"
+)
+
+type RetryConfig struct {
+	Target           api.RetryTarget
+	Kind             string
+	WithoutToolCache []string
+	Debug            *bool
+	DebugPlacement   string
+	OutputJSON       bool
+}
+
+func (c RetryConfig) Validate() error {
+	if c.Target.ID == "" {
+		return errors.WrapSentinel(errors.New("you must specify a run ID or task ID"), errors.ErrBadRequest)
+	}
+	return nil
+}
+
+func (s Service) Retry(cfg RetryConfig) (*api.RequestRetryResult, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	options, err := s.APIClient.GetRetryOptions(cfg.Target)
+	if err != nil {
+		return nil, err
+	}
+	if !options.Retryable {
+		reason := options.UnavailableReason
+		if reason == "" {
+			reason = "This run or task cannot be retried in its current state."
+		}
+		return nil, retryBadRequest(reason)
+	}
+
+	interactive := s.StdoutIsTTY && !cfg.OutputJSON
+	var input *bufio.Reader
+	if interactive {
+		input = bufio.NewReader(s.Stdin)
+	}
+
+	kind := cfg.Kind
+	if kind == "" {
+		if !interactive {
+			return nil, retryKindSelectionError("retry kind selection is required", cfg.Target, options.Kinds)
+		}
+		kind, err = s.promptForRetryKind(input, options.Kinds)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !retryKindAvailable(kind, options.Kinds) {
+		return nil, retryKindSelectionError(fmt.Sprintf("retry kind %q is not available", kind), cfg.Target, options.Kinds)
+	}
+
+	toolCacheNames := uniqueStrings(cfg.WithoutToolCache)
+	if kind == "no-tool-cache" {
+		if len(toolCacheNames) == 0 {
+			if !interactive {
+				return nil, retryToolCacheSelectionError(
+					"tool cache selection is required for retry kind \"no-tool-cache\"",
+					cfg.Target,
+					options.ToolCaches,
+				)
+			}
+			toolCacheNames, err = s.promptForRetryToolCaches(input, options.ToolCaches)
+			if err != nil {
+				return nil, err
+			}
+		}
+		for _, name := range toolCacheNames {
+			if !retryToolCacheAvailable(name, options.ToolCaches) {
+				return nil, retryToolCacheSelectionError(
+					fmt.Sprintf("tool cache %q is not available", name),
+					cfg.Target,
+					options.ToolCaches,
+				)
+			}
+		}
+	} else if len(toolCacheNames) > 0 {
+		return nil, retryBadRequest("--without-tool-cache can only be used with --kind no-tool-cache")
+	}
+
+	debug, debugPlacement, err := s.selectRetryDebugOptions(input, interactive, cfg.Debug, cfg.DebugPlacement, options.Debug)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := s.APIClient.RequestRetry(api.RequestRetryConfig{
+		Target:         cfg.Target,
+		Kind:           kind,
+		Debug:          debug,
+		DebugPlacement: debugPlacement,
+		ToolCacheNames: toolCacheNames,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (s Service) promptForRetryKind(input *bufio.Reader, kinds []api.RetryKind) (string, error) {
+	if len(kinds) == 0 {
+		return "", retryBadRequest("no retry kinds are available")
+	}
+
+	fmt.Fprintln(s.Stdout, "Select a retry kind:")
+	for index, kind := range kinds {
+		fmt.Fprintf(s.Stdout, "  %d. %s (%s)\n", index+1, kind.Label, kind.Value)
+		if kind.Description != "" {
+			fmt.Fprintf(s.Stdout, "     %s\n", kind.Description)
+		}
+	}
+	fmt.Fprintln(s.Stdout)
+	fmt.Fprintf(s.Stdout, "Enter a number (1-%d): ", len(kinds))
+
+	choice, err := readRetryChoice(input, len(kinds), "retry kind")
+	if err != nil {
+		return "", err
+	}
+	return kinds[choice-1].Value, nil
+}
+
+func (s Service) promptForRetryToolCaches(input *bufio.Reader, caches []api.RetryToolCache) ([]string, error) {
+	if len(caches) == 0 {
+		return nil, retryBadRequest("no tool caches are available")
+	}
+
+	fmt.Fprintln(s.Stdout, "Select one or more tool caches:")
+	for index, cache := range caches {
+		fmt.Fprintf(s.Stdout, "  %d. %s\n", index+1, cache.Name)
+		if cache.UsageDescription != "" {
+			fmt.Fprintf(s.Stdout, "     %s\n", cache.UsageDescription)
+		}
+	}
+	fmt.Fprintln(s.Stdout)
+	fmt.Fprintf(s.Stdout, "Enter numbers separated by commas (1-%d): ", len(caches))
+
+	line, err := readRetryLine(input, "no tool caches selected")
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.FieldsFunc(line, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t'
+	})
+	if len(parts) == 0 {
+		return nil, retryBadRequest("no tool caches selected")
+	}
+
+	selected := make([]string, 0, len(parts))
+	seen := make(map[int]bool)
+	for _, part := range parts {
+		choice, err := strconv.Atoi(part)
+		if err != nil || choice < 1 || choice > len(caches) {
+			return nil, retryBadRequest(fmt.Sprintf("invalid tool cache selection: %s", line))
+		}
+		if !seen[choice] {
+			selected = append(selected, caches[choice-1].Name)
+			seen[choice] = true
+		}
+	}
+	return selected, nil
+}
+
+func (s Service) selectRetryDebugOptions(
+	input *bufio.Reader,
+	interactive bool,
+	debug *bool,
+	placement string,
+	options api.RetryDebugOptions,
+) (*bool, string, error) {
+	if debug == nil && placement != "" {
+		enabled := true
+		debug = &enabled
+	}
+
+	if debug == nil && interactive && options.Supported {
+		selected, err := s.promptForRetryDebug(input)
+		if err != nil {
+			return nil, "", err
+		}
+		debug = &selected
+	}
+
+	if debug == nil {
+		return nil, "", nil
+	}
+	if !*debug {
+		if placement != "" {
+			return nil, "", retryBadRequest("--debug-placement cannot be used with --debug=false")
+		}
+		return debug, "", nil
+	}
+	if !options.Supported {
+		reason := options.DisabledReason
+		if reason == "" {
+			reason = "A breakpoint is not available for this retry target."
+		}
+		return nil, "", retryBadRequest(reason)
+	}
+
+	if placement == "" {
+		if interactive {
+			selected, err := s.promptForRetryDebugPlacement(input, options.Placements)
+			if err != nil {
+				return nil, "", err
+			}
+			placement = selected
+		} else {
+			placement = options.DefaultPlacement
+			if placement == "" && len(options.Placements) == 1 {
+				placement = options.Placements[0]
+			}
+		}
+	}
+	if !stringAvailable(placement, options.Placements) {
+		return nil, "", retryBadRequest(fmt.Sprintf(
+			"debug placement %q is not available; choose one of: %s",
+			placement,
+			strings.Join(options.Placements, ", "),
+		))
+	}
+	return debug, placement, nil
+}
+
+func (s Service) promptForRetryDebug(input *bufio.Reader) (bool, error) {
+	fmt.Fprint(s.Stdout, "Open a breakpoint? [y/N]: ")
+	line, err := readRetryLine(input, "no breakpoint selection provided")
+	if err != nil {
+		return false, err
+	}
+	switch strings.ToLower(line) {
+	case "", "n", "no":
+		return false, nil
+	case "y", "yes":
+		return true, nil
+	default:
+		return false, retryBadRequest(fmt.Sprintf("invalid breakpoint selection: %s", line))
+	}
+}
+
+func (s Service) promptForRetryDebugPlacement(input *bufio.Reader, placements []string) (string, error) {
+	if len(placements) == 0 {
+		return "", retryBadRequest("no breakpoint placements are available")
+	}
+	fmt.Fprintln(s.Stdout, "Select breakpoint placement:")
+	for index, placement := range placements {
+		fmt.Fprintf(s.Stdout, "  %d. %s\n", index+1, placement)
+	}
+	fmt.Fprintln(s.Stdout)
+	fmt.Fprintf(s.Stdout, "Enter a number (1-%d): ", len(placements))
+
+	choice, err := readRetryChoice(input, len(placements), "breakpoint placement")
+	if err != nil {
+		return "", err
+	}
+	return placements[choice-1], nil
+}
+
+func readRetryChoice(input *bufio.Reader, count int, selectionName string) (int, error) {
+	line, err := readRetryLine(input, fmt.Sprintf("no %s selected", selectionName))
+	if err != nil {
+		return 0, err
+	}
+	choice, err := strconv.Atoi(line)
+	if err != nil || choice < 1 || choice > count {
+		return 0, retryBadRequest(fmt.Sprintf("invalid %s selection: %s", selectionName, line))
+	}
+	return choice, nil
+}
+
+func readRetryLine(input *bufio.Reader, emptyMessage string) (string, error) {
+	line, err := input.ReadString('\n')
+	if err != nil && line == "" {
+		return "", retryBadRequest(emptyMessage)
+	}
+	return strings.TrimSpace(line), nil
+}
+
+func retryKindAvailable(value string, kinds []api.RetryKind) bool {
+	for _, kind := range kinds {
+		if kind.Value == value {
+			return true
+		}
+	}
+	return false
+}
+
+func retryToolCacheAvailable(name string, caches []api.RetryToolCache) bool {
+	for _, cache := range caches {
+		if cache.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func stringAvailable(value string, choices []string) bool {
+	for _, choice := range choices {
+		if choice == value {
+			return true
+		}
+	}
+	return false
+}
+
+func uniqueStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	unique := make([]string, 0, len(values))
+	seen := make(map[string]bool)
+	for _, value := range values {
+		if !seen[value] {
+			unique = append(unique, value)
+			seen[value] = true
+		}
+	}
+	return unique
+}
+
+func retryKindSelectionError(reason string, target api.RetryTarget, kinds []api.RetryKind) error {
+	var message strings.Builder
+	message.WriteString(reason)
+	message.WriteString("\n\nAvailable retry kinds:\n")
+	for _, kind := range kinds {
+		fmt.Fprintf(&message, "  %s - %s\n", kind.Value, kind.Label)
+		if kind.Description != "" {
+			fmt.Fprintf(&message, "    %s\n", kind.Description)
+		}
+	}
+	if len(kinds) > 0 {
+		fmt.Fprintf(
+			&message,
+			"\nChoose a kind and retry:\n  %s --kind %s %s",
+			retryCommand(target.Type),
+			kinds[0].Value,
+			target.ID,
+		)
+	}
+	return retryBadRequest(message.String())
+}
+
+func retryToolCacheSelectionError(reason string, target api.RetryTarget, caches []api.RetryToolCache) error {
+	var message strings.Builder
+	message.WriteString(reason)
+	message.WriteString("\n\nAvailable tool caches:\n")
+	for _, cache := range caches {
+		fmt.Fprintf(&message, "  %s\n", cache.Name)
+		if cache.UsageDescription != "" {
+			fmt.Fprintf(&message, "    %s\n", cache.UsageDescription)
+		}
+	}
+	if len(caches) > 0 {
+		fmt.Fprintf(
+			&message,
+			"\nChoose one or more tool caches and retry:\n  %s --kind no-tool-cache --without-tool-cache %s %s",
+			retryCommand(target.Type),
+			caches[0].Name,
+			target.ID,
+		)
+	}
+	return retryBadRequest(message.String())
+}
+
+func retryCommand(targetType api.RetryTargetType) string {
+	switch targetType {
+	case api.RetryTargetRun:
+		return "rwx runs retry"
+	case api.RetryTargetTask:
+		return "rwx tasks retry"
+	default:
+		return "rwx retry"
+	}
+}
+
+func retryBadRequest(message string) error {
+	return errors.WrapSentinel(errors.New(message), errors.ErrBadRequest)
+}

--- a/internal/cli/service_retry_test.go
+++ b/internal/cli/service_retry_test.go
@@ -1,0 +1,181 @@
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/rwx-cloud/rwx/internal/api"
+	"github.com/rwx-cloud/rwx/internal/cli"
+	internalErrors "github.com/rwx-cloud/rwx/internal/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func retryOptions() api.RetryOptions {
+	return api.RetryOptions{
+		Retryable: true,
+		Kinds: []api.RetryKind{
+			{Value: "standard", Label: "Standard retry", Description: "The task will run again."},
+			{Value: "no-tool-cache", Label: "Retry without tool caches", Description: "Only affected tasks will run again."},
+		},
+		Debug: api.RetryDebugOptions{
+			Supported:        true,
+			Placements:       []string{"end", "start"},
+			DefaultPlacement: "end",
+		},
+		ToolCaches: []api.RetryToolCache{
+			{Name: "bundler", ScopedTaskKeys: []string{"test"}, UsageDescription: "Used by test"},
+			{Name: "golang", ScopedTaskKeys: []string{"build", "test"}, UsageDescription: "Used by 2 tasks"},
+		},
+	}
+}
+
+func TestService_Retry(t *testing.T) {
+	t.Run("prints available kinds when a non-TTY must make a selection", func(t *testing.T) {
+		setup := setupTest(t)
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			require.Equal(t, api.RetryTarget{ID: "target-123", Type: api.RetryTargetInferred}, target)
+			return retryOptions(), nil
+		}
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			t.Fatal("the API must not request a retry before a kind is selected")
+			return api.RequestRetryResult{}, nil
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "target-123", Type: api.RetryTargetInferred},
+		})
+
+		require.Nil(t, result)
+		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
+		require.EqualError(t, err, `retry kind selection is required
+
+Available retry kinds:
+  standard - Standard retry
+    The task will run again.
+  no-tool-cache - Retry without tool caches
+    Only affected tasks will run again.
+
+Choose a kind and retry:
+  rwx retry --kind standard target-123`)
+	})
+
+	t.Run("uses flag selections without prompting", func(t *testing.T) {
+		setup := setupTest(t)
+		debug := false
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return retryOptions(), nil
+		}
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			require.Equal(t, api.RequestRetryConfig{
+				Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+				Kind:   "standard",
+				Debug:  &debug,
+			}, cfg)
+			return api.RequestRetryResult{Status: "retry_requested", RunID: "run-123", TaskID: "task-123"}, nil
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+			Kind:   "standard",
+			Debug:  &debug,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, &api.RequestRetryResult{Status: "retry_requested", RunID: "run-123", TaskID: "task-123"}, result)
+		require.Empty(t, setup.mockStdout.String())
+	})
+
+	t.Run("prints available caches when a non-TTY must make a selection", func(t *testing.T) {
+		setup := setupTest(t)
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return retryOptions(), nil
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "run-123", Type: api.RetryTargetRun},
+			Kind:   "no-tool-cache",
+		})
+
+		require.Nil(t, result)
+		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
+		require.EqualError(t, err, `tool cache selection is required for retry kind "no-tool-cache"
+
+Available tool caches:
+  bundler
+    Used by test
+  golang
+    Used by 2 tasks
+
+Choose one or more tool caches and retry:
+  rwx runs retry --kind no-tool-cache --without-tool-cache bundler run-123`)
+	})
+
+	t.Run("prompts for all choices in a TTY", func(t *testing.T) {
+		setup := setupTestWithTTY(t)
+		_, err := setup.mockStdin.WriteString("2\n1,2\ny\n2\n")
+		require.NoError(t, err)
+
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return retryOptions(), nil
+		}
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			require.Equal(t, "no-tool-cache", cfg.Kind)
+			require.Equal(t, []string{"bundler", "golang"}, cfg.ToolCacheNames)
+			require.NotNil(t, cfg.Debug)
+			require.True(t, *cfg.Debug)
+			require.Equal(t, "start", cfg.DebugPlacement)
+			return api.RequestRetryResult{Status: "retry_requested", RunID: "run-123", TaskID: "task-123"}, nil
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		output := setup.mockStdout.String()
+		require.Contains(t, output, "Select a retry kind:")
+		require.Contains(t, output, "2. Retry without tool caches (no-tool-cache)")
+		require.Contains(t, output, "Select one or more tool caches:")
+		require.Contains(t, output, "Open a breakpoint? [y/N]:")
+		require.Contains(t, output, "Select breakpoint placement:")
+	})
+
+	t.Run("uses the default debug placement outside a TTY", func(t *testing.T) {
+		setup := setupTest(t)
+		debug := true
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return retryOptions(), nil
+		}
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			require.Equal(t, "end", cfg.DebugPlacement)
+			return api.RequestRetryResult{Status: "retry_requested", RunID: "run-123", TaskID: "task-123"}, nil
+		}
+
+		_, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+			Kind:   "standard",
+			Debug:  &debug,
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("reports unavailable targets before prompting", func(t *testing.T) {
+		setup := setupTestWithTTY(t)
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return api.RetryOptions{
+				Retryable:         false,
+				UnavailableReason: "This task cannot be retried in its current state.",
+			}, nil
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+		})
+
+		require.Nil(t, result)
+		require.EqualError(t, err, "This task cannot be retried in its current state.")
+		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
+		require.Empty(t, setup.mockStdout.String())
+	})
+}

--- a/internal/cli/service_retry_test.go
+++ b/internal/cli/service_retry_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/rwx-cloud/rwx/internal/api"
@@ -177,5 +178,290 @@ Choose one or more tool caches and retry:
 		require.EqualError(t, err, "This task cannot be retried in its current state.")
 		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
 		require.Empty(t, setup.mockStdout.String())
+	})
+
+	t.Run("prints refreshed retry kinds after the endpoint rejects an explicit kind", func(t *testing.T) {
+		setup := setupTest(t)
+		initialOptions := retryOptions()
+		initialOptions.Kinds = append([]api.RetryKind{{Value: "clean", Label: "Clean retry"}}, initialOptions.Kinds...)
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return initialOptions, nil
+		}
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			return api.RequestRetryResult{}, &api.RetryRequestError{
+				Message: "This retry configuration is not supported.",
+				Errors: []api.RetryFieldError{{
+					Field:   "kind",
+					Message: "`clean` is not available for this task. Choose one of: `standard`, `no-tool-cache`.",
+				}},
+				Options: retryOptions(),
+			}
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+			Kind:   "clean",
+		})
+
+		require.Nil(t, result)
+		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
+		require.EqualError(t, err, "This retry configuration is not supported.\n\n"+
+			"Retry kind: `clean` is not available for this task. Choose one of: `standard`, `no-tool-cache`.\n\n"+
+			"Available retry kinds:\n"+
+			"  standard - Standard retry\n"+
+			"    The task will run again.\n"+
+			"  no-tool-cache - Retry without tool caches\n"+
+			"    Only affected tasks will run again.\n\n"+
+			"Try:\n"+
+			"  rwx tasks retry task-123 --kind standard")
+	})
+
+	t.Run("prints refreshed tool caches after the endpoint rejects an explicit cache", func(t *testing.T) {
+		setup := setupTest(t)
+		initialOptions := retryOptions()
+		initialOptions.ToolCaches = append(initialOptions.ToolCaches, api.RetryToolCache{Name: "obsolete"})
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return initialOptions, nil
+		}
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			return api.RequestRetryResult{}, &api.RetryRequestError{
+				Message: "This retry configuration is not supported.",
+				Errors: []api.RetryFieldError{{
+					Field:   "tool_cache_names",
+					Message: "`obsolete` is not available for this retry target.",
+				}},
+				Options: retryOptions(),
+			}
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target:           api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+			Kind:             "no-tool-cache",
+			WithoutToolCache: []string{"obsolete"},
+		})
+
+		require.Nil(t, result)
+		require.EqualError(t, err, "This retry configuration is not supported.\n\n"+
+			"Tool cache: `obsolete` is not available for this retry target.\n\n"+
+			"Available tool caches:\n"+
+			"  bundler\n"+
+			"    Used by test\n"+
+			"  golang\n"+
+			"    Used by 2 tasks\n\n"+
+			"Try:\n"+
+			"  rwx tasks retry task-123 --kind no-tool-cache --without-tool-cache bundler")
+	})
+
+	t.Run("prints refreshed breakpoint placements after the endpoint rejects an explicit placement", func(t *testing.T) {
+		setup := setupTest(t)
+		initialOptions := retryOptions()
+		initialOptions.Debug.Placements = append(initialOptions.Debug.Placements, "middle")
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return initialOptions, nil
+		}
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			return api.RequestRetryResult{}, &api.RetryRequestError{
+				Message: "This retry configuration is not supported.",
+				Errors: []api.RetryFieldError{{
+					Field:   "debug_placement",
+					Message: "`middle` is not a valid breakpoint placement.",
+				}},
+				Options: retryOptions(),
+			}
+		}
+		debug := true
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target:         api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+			Kind:           "standard",
+			Debug:          &debug,
+			DebugPlacement: "middle",
+		})
+
+		require.Nil(t, result)
+		require.EqualError(t, err, "This retry configuration is not supported.\n\n"+
+			"Breakpoint placement: `middle` is not a valid breakpoint placement.\n\n"+
+			"Available breakpoint placements:\n"+
+			"  end (default)\n"+
+			"  start\n\n"+
+			"Try:\n"+
+			"  rwx tasks retry task-123 --kind standard --debug --debug-placement end")
+	})
+
+	t.Run("prompts once more with refreshed endpoint options for a bare TTY command", func(t *testing.T) {
+		setup := setupTestWithTTY(t)
+		_, err := setup.mockStdin.WriteString("1\n1\n")
+		require.NoError(t, err)
+
+		initialOptions := api.RetryOptions{
+			Retryable: true,
+			Kinds:     []api.RetryKind{{Value: "clean", Label: "Clean retry"}},
+		}
+		refreshedOptions := api.RetryOptions{
+			Retryable: true,
+			Kinds:     []api.RetryKind{{Value: "standard", Label: "Standard retry"}},
+		}
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return initialOptions, nil
+		}
+		calls := 0
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			calls++
+			if calls == 1 {
+				require.Equal(t, "clean", cfg.Kind)
+				return api.RequestRetryResult{}, &api.RetryRequestError{
+					Message: "This retry configuration is not supported.",
+					Errors:  []api.RetryFieldError{{Field: "kind", Message: "`clean` is no longer available."}},
+					Options: refreshedOptions,
+				}
+			}
+
+			require.Equal(t, "standard", cfg.Kind)
+			return api.RequestRetryResult{Status: "retry_requested", RunID: "run-123", TaskID: "task-123"}, nil
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "task-123", result.TaskID)
+		require.Equal(t, 2, calls)
+		output := setup.mockStdout.String()
+		require.Contains(t, output, "The available retry options changed.\n\n")
+		require.Equal(t, 2, strings.Count(output, "Select a retry kind:"))
+		require.Contains(t, output, "1. Standard retry (standard)")
+	})
+
+	t.Run("prints every refreshed option for an unknown endpoint field", func(t *testing.T) {
+		setup := setupTest(t)
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return retryOptions(), nil
+		}
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			return api.RequestRetryResult{}, &api.RetryRequestError{
+				Message: "This retry configuration is not supported.",
+				Errors:  []api.RetryFieldError{{Field: "target", Message: "The retry target changed."}},
+				Options: retryOptions(),
+			}
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+			Kind:   "standard",
+		})
+
+		require.Nil(t, result)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Retry: The retry target changed.")
+		require.NotContains(t, err.Error(), "target:")
+		require.Contains(t, err.Error(), "Available retry kinds:")
+		require.Contains(t, err.Error(), "Breakpoint:\n  Supported\n  Placements: end (default), start")
+		require.Contains(t, err.Error(), "Available tool caches:")
+		require.Contains(t, err.Error(), "Try:\n  rwx tasks retry task-123 --kind standard")
+	})
+
+	t.Run("does not replace an explicit TTY selection", func(t *testing.T) {
+		setup := setupTestWithTTY(t)
+		initialOptions := api.RetryOptions{
+			Retryable: true,
+			Kinds:     []api.RetryKind{{Value: "clean", Label: "Clean retry"}},
+		}
+		refreshedOptions := api.RetryOptions{
+			Retryable: true,
+			Kinds:     []api.RetryKind{{Value: "standard", Label: "Standard retry"}},
+		}
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return initialOptions, nil
+		}
+		calls := 0
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			calls++
+			return api.RequestRetryResult{}, &api.RetryRequestError{
+				Message: "This retry configuration is not supported.",
+				Errors:  []api.RetryFieldError{{Field: "kind", Message: "`clean` is no longer available."}},
+				Options: refreshedOptions,
+			}
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+			Kind:   "clean",
+		})
+
+		require.Nil(t, result)
+		require.Error(t, err)
+		require.Equal(t, 1, calls)
+		require.Empty(t, setup.mockStdout.String())
+		require.Contains(t, err.Error(), "Available retry kinds:")
+	})
+
+	t.Run("stops after one retry with refreshed TTY options", func(t *testing.T) {
+		setup := setupTestWithTTY(t)
+		_, err := setup.mockStdin.WriteString("1\n1\n")
+		require.NoError(t, err)
+
+		initialOptions := api.RetryOptions{
+			Retryable: true,
+			Kinds:     []api.RetryKind{{Value: "clean", Label: "Clean retry"}},
+		}
+		refreshedOptions := api.RetryOptions{
+			Retryable: true,
+			Kinds:     []api.RetryKind{{Value: "standard", Label: "Standard retry"}},
+		}
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return initialOptions, nil
+		}
+		calls := 0
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			calls++
+			return api.RequestRetryResult{}, &api.RetryRequestError{
+				Message: "This retry configuration is not supported.",
+				Errors:  []api.RetryFieldError{{Field: "kind", Message: "The selected kind is no longer available."}},
+				Options: refreshedOptions,
+			}
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+		})
+
+		require.Nil(t, result)
+		require.Error(t, err)
+		require.Equal(t, 2, calls)
+		require.Equal(t, 1, strings.Count(setup.mockStdout.String(), "The available retry options changed."))
+	})
+
+	t.Run("prints the breakpoint reason after the endpoint rejects debugging", func(t *testing.T) {
+		setup := setupTest(t)
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return retryOptions(), nil
+		}
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			options := retryOptions()
+			options.Debug = api.RetryDebugOptions{
+				Supported:      false,
+				DisabledReason: "A breakpoint cannot be opened because vault access is required.",
+			}
+			return api.RequestRetryResult{}, &api.RetryRequestError{
+				Message: "This retry configuration is not supported.",
+				Errors: []api.RetryFieldError{{
+					Field:   "debug",
+					Message: options.Debug.DisabledReason,
+				}},
+				Options: options,
+			}
+		}
+		debug := true
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+			Kind:   "standard",
+			Debug:  &debug,
+		})
+
+		require.Nil(t, result)
+		require.EqualError(t, err, "This retry configuration is not supported.\n\n"+
+			"Breakpoint: A breakpoint cannot be opened because vault access is required.")
 	})
 }

--- a/internal/cli/service_retry_test.go
+++ b/internal/cli/service_retry_test.go
@@ -13,7 +13,7 @@ import (
 func retryOptions() api.RetryOptions {
 	return api.RetryOptions{
 		Retryable: true,
-		Kinds: []api.RetryKind{
+		Actions: []api.RetryAction{
 			{Value: "standard", Label: "Standard retry", Description: "The task will run again."},
 			{Value: "no-tool-cache", Label: "Retry without tool caches", Description: "Only affected tasks will run again."},
 		},
@@ -30,14 +30,91 @@ func retryOptions() api.RetryOptions {
 }
 
 func TestService_Retry(t *testing.T) {
-	t.Run("prints available kinds when a non-TTY must make a selection", func(t *testing.T) {
+	t.Run("uses the only retry action without prompting", func(t *testing.T) {
+		setup := setupTest(t)
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return api.RetryOptions{
+				Retryable: true,
+				Actions:   []api.RetryAction{{Value: "standard", Label: "Standard retry"}},
+			}, nil
+		}
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			require.Equal(t, "standard", cfg.Action)
+			return api.RequestRetryResult{Status: "retry_requested", RunID: "run-123", TaskID: "task-123"}, nil
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "task-123", result.TaskID)
+		require.Empty(t, setup.mockStdout.String())
+	})
+
+	t.Run("uses the only tool cache without prompting", func(t *testing.T) {
+		setup := setupTest(t)
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return api.RetryOptions{
+				Retryable: true,
+				Actions:   []api.RetryAction{{Value: "no-tool-cache", Label: "Retry without tool caches"}},
+				ToolCaches: []api.RetryToolCache{{
+					Name:             "bundler",
+					UsageDescription: "Used by test",
+				}},
+			}, nil
+		}
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			require.Equal(t, "no-tool-cache", cfg.Action)
+			require.Equal(t, []string{"bundler"}, cfg.ToolCacheNames)
+			return api.RequestRetryResult{Status: "retry_requested", RunID: "run-123", TaskID: "task-123"}, nil
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "task-123", result.TaskID)
+		require.Empty(t, setup.mockStdout.String())
+	})
+
+	t.Run("does not prompt for debugging", func(t *testing.T) {
+		setup := setupTestWithTTY(t)
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return api.RetryOptions{
+				Retryable: true,
+				Actions:   []api.RetryAction{{Value: "standard", Label: "Standard retry"}},
+				Debug: api.RetryDebugOptions{
+					Supported:        true,
+					Placements:       []string{"end", "start"},
+					DefaultPlacement: "end",
+				},
+			}, nil
+		}
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			require.Nil(t, cfg.Debug)
+			require.Empty(t, cfg.DebugPlacement)
+			return api.RequestRetryResult{Status: "retry_requested", RunID: "run-123", TaskID: "task-123"}, nil
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "task-123", result.TaskID)
+		require.NotContains(t, setup.mockStdout.String(), "Open a breakpoint?")
+	})
+
+	t.Run("prints available actions when a non-TTY must make a selection", func(t *testing.T) {
 		setup := setupTest(t)
 		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
 			require.Equal(t, api.RetryTarget{ID: "target-123", Type: api.RetryTargetInferred}, target)
 			return retryOptions(), nil
 		}
 		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
-			t.Fatal("the API must not request a retry before a kind is selected")
+			t.Fatal("the API must not request a retry before a action is selected")
 			return api.RequestRetryResult{}, nil
 		}
 
@@ -47,37 +124,34 @@ func TestService_Retry(t *testing.T) {
 
 		require.Nil(t, result)
 		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
-		require.EqualError(t, err, `retry kind selection is required
+		require.EqualError(t, err, `retry action selection is required
 
-Available retry kinds:
+Available retry actions:
   standard - Standard retry
     The task will run again.
   no-tool-cache - Retry without tool caches
     Only affected tasks will run again.
 
-Choose a kind and retry:
-  rwx retry --kind standard target-123`)
+Choose an action and retry:
+  rwx retry --action standard target-123`)
 	})
 
 	t.Run("uses flag selections without prompting", func(t *testing.T) {
 		setup := setupTest(t)
-		debug := false
 		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
 			return retryOptions(), nil
 		}
 		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
 			require.Equal(t, api.RequestRetryConfig{
 				Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
-				Kind:   "standard",
-				Debug:  &debug,
+				Action: "standard",
 			}, cfg)
 			return api.RequestRetryResult{Status: "retry_requested", RunID: "run-123", TaskID: "task-123"}, nil
 		}
 
 		result, err := setup.service.Retry(cli.RetryConfig{
 			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
-			Kind:   "standard",
-			Debug:  &debug,
+			Action: "standard",
 		})
 
 		require.NoError(t, err)
@@ -93,12 +167,12 @@ Choose a kind and retry:
 
 		result, err := setup.service.Retry(cli.RetryConfig{
 			Target: api.RetryTarget{ID: "run-123", Type: api.RetryTargetRun},
-			Kind:   "no-tool-cache",
+			Action: "no-tool-cache",
 		})
 
 		require.Nil(t, result)
 		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
-		require.EqualError(t, err, `tool cache selection is required for retry kind "no-tool-cache"
+		require.EqualError(t, err, `tool cache selection is required for retry action "no-tool-cache"
 
 Available tool caches:
   bundler
@@ -107,23 +181,22 @@ Available tool caches:
     Used by 2 tasks
 
 Choose one or more tool caches and retry:
-  rwx runs retry --kind no-tool-cache --without-tool-cache bundler run-123`)
+  rwx runs retry --action no-tool-cache --without-tool-cache bundler run-123`)
 	})
 
-	t.Run("prompts for all choices in a TTY", func(t *testing.T) {
+	t.Run("prompts for retry actions and tool caches in a TTY", func(t *testing.T) {
 		setup := setupTestWithTTY(t)
-		_, err := setup.mockStdin.WriteString("2\n1,2\ny\n2\n")
+		_, err := setup.mockStdin.WriteString("2\n1,2\n")
 		require.NoError(t, err)
 
 		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
 			return retryOptions(), nil
 		}
 		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
-			require.Equal(t, "no-tool-cache", cfg.Kind)
+			require.Equal(t, "no-tool-cache", cfg.Action)
 			require.Equal(t, []string{"bundler", "golang"}, cfg.ToolCacheNames)
-			require.NotNil(t, cfg.Debug)
-			require.True(t, *cfg.Debug)
-			require.Equal(t, "start", cfg.DebugPlacement)
+			require.Nil(t, cfg.Debug)
+			require.Empty(t, cfg.DebugPlacement)
 			return api.RequestRetryResult{Status: "retry_requested", RunID: "run-123", TaskID: "task-123"}, nil
 		}
 
@@ -134,31 +207,52 @@ Choose one or more tool caches and retry:
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		output := setup.mockStdout.String()
-		require.Contains(t, output, "Select a retry kind:")
+		require.Contains(t, output, "Select a retry action:")
 		require.Contains(t, output, "2. Retry without tool caches (no-tool-cache)")
 		require.Contains(t, output, "Select one or more tool caches:")
-		require.Contains(t, output, "Open a breakpoint? [y/N]:")
-		require.Contains(t, output, "Select breakpoint placement:")
+		require.NotContains(t, output, "Open a breakpoint?")
+		require.NotContains(t, output, "Select breakpoint placement:")
 	})
 
-	t.Run("uses the default debug placement outside a TTY", func(t *testing.T) {
+	t.Run("enables debugging at the selected placement", func(t *testing.T) {
 		setup := setupTest(t)
-		debug := true
 		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
 			return retryOptions(), nil
 		}
 		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			require.NotNil(t, cfg.Debug)
+			require.True(t, *cfg.Debug)
 			require.Equal(t, "end", cfg.DebugPlacement)
 			return api.RequestRetryResult{Status: "retry_requested", RunID: "run-123", TaskID: "task-123"}, nil
 		}
 
 		_, err := setup.service.Retry(cli.RetryConfig{
-			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
-			Kind:   "standard",
-			Debug:  &debug,
+			Target:         api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+			Action:         "standard",
+			DebugPlacement: "end",
 		})
 
 		require.NoError(t, err)
+	})
+
+	t.Run("rejects an unavailable debug placement before requesting a retry", func(t *testing.T) {
+		setup := setupTest(t)
+		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
+			return retryOptions(), nil
+		}
+		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+			t.Fatal("the API must not receive an invalid breakpoint placement")
+			return api.RequestRetryResult{}, nil
+		}
+
+		result, err := setup.service.Retry(cli.RetryConfig{
+			Target:         api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+			Action:         "standard",
+			DebugPlacement: "middle",
+		})
+
+		require.Nil(t, result)
+		require.EqualError(t, err, "breakpoint placement \"middle\" is not available; choose one of: end, start")
 	})
 
 	t.Run("reports unavailable targets before prompting", func(t *testing.T) {
@@ -180,10 +274,10 @@ Choose one or more tool caches and retry:
 		require.Empty(t, setup.mockStdout.String())
 	})
 
-	t.Run("prints refreshed retry kinds after the endpoint rejects an explicit kind", func(t *testing.T) {
+	t.Run("prints refreshed retry actions after the endpoint rejects an explicit action", func(t *testing.T) {
 		setup := setupTest(t)
 		initialOptions := retryOptions()
-		initialOptions.Kinds = append([]api.RetryKind{{Value: "clean", Label: "Clean retry"}}, initialOptions.Kinds...)
+		initialOptions.Actions = append([]api.RetryAction{{Value: "clean", Label: "Clean retry"}}, initialOptions.Actions...)
 		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
 			return initialOptions, nil
 		}
@@ -191,7 +285,7 @@ Choose one or more tool caches and retry:
 			return api.RequestRetryResult{}, &api.RetryRequestError{
 				Message: "This retry configuration is not supported.",
 				Errors: []api.RetryFieldError{{
-					Field:   "kind",
+					Field:   "action",
 					Message: "`clean` is not available for this task. Choose one of: `standard`, `no-tool-cache`.",
 				}},
 				Options: retryOptions(),
@@ -200,20 +294,20 @@ Choose one or more tool caches and retry:
 
 		result, err := setup.service.Retry(cli.RetryConfig{
 			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
-			Kind:   "clean",
+			Action: "clean",
 		})
 
 		require.Nil(t, result)
 		require.ErrorIs(t, err, internalErrors.ErrBadRequest)
 		require.EqualError(t, err, "This retry configuration is not supported.\n\n"+
-			"Retry kind: `clean` is not available for this task. Choose one of: `standard`, `no-tool-cache`.\n\n"+
-			"Available retry kinds:\n"+
+			"Retry action: `clean` is not available for this task. Choose one of: `standard`, `no-tool-cache`.\n\n"+
+			"Available retry actions:\n"+
 			"  standard - Standard retry\n"+
 			"    The task will run again.\n"+
 			"  no-tool-cache - Retry without tool caches\n"+
 			"    Only affected tasks will run again.\n\n"+
 			"Try:\n"+
-			"  rwx tasks retry task-123 --kind standard")
+			"  rwx tasks retry task-123 --action standard")
 	})
 
 	t.Run("prints refreshed tool caches after the endpoint rejects an explicit cache", func(t *testing.T) {
@@ -236,7 +330,7 @@ Choose one or more tool caches and retry:
 
 		result, err := setup.service.Retry(cli.RetryConfig{
 			Target:           api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
-			Kind:             "no-tool-cache",
+			Action:           "no-tool-cache",
 			WithoutToolCache: []string{"obsolete"},
 		})
 
@@ -249,7 +343,7 @@ Choose one or more tool caches and retry:
 			"  golang\n"+
 			"    Used by 2 tasks\n\n"+
 			"Try:\n"+
-			"  rwx tasks retry task-123 --kind no-tool-cache --without-tool-cache bundler")
+			"  rwx tasks retry task-123 --action no-tool-cache --without-tool-cache bundler")
 	})
 
 	t.Run("prints refreshed breakpoint placements after the endpoint rejects an explicit placement", func(t *testing.T) {
@@ -269,12 +363,9 @@ Choose one or more tool caches and retry:
 				Options: retryOptions(),
 			}
 		}
-		debug := true
-
 		result, err := setup.service.Retry(cli.RetryConfig{
 			Target:         api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
-			Kind:           "standard",
-			Debug:          &debug,
+			Action:         "standard",
 			DebugPlacement: "middle",
 		})
 
@@ -285,21 +376,19 @@ Choose one or more tool caches and retry:
 			"  end (default)\n"+
 			"  start\n\n"+
 			"Try:\n"+
-			"  rwx tasks retry task-123 --kind standard --debug --debug-placement end")
+			"  rwx tasks retry task-123 --action standard --debug end")
 	})
 
-	t.Run("prompts once more with refreshed endpoint options for a bare TTY command", func(t *testing.T) {
+	t.Run("uses a sole refreshed endpoint option for a bare TTY command", func(t *testing.T) {
 		setup := setupTestWithTTY(t)
-		_, err := setup.mockStdin.WriteString("1\n1\n")
-		require.NoError(t, err)
 
 		initialOptions := api.RetryOptions{
 			Retryable: true,
-			Kinds:     []api.RetryKind{{Value: "clean", Label: "Clean retry"}},
+			Actions:   []api.RetryAction{{Value: "clean", Label: "Clean retry"}},
 		}
 		refreshedOptions := api.RetryOptions{
 			Retryable: true,
-			Kinds:     []api.RetryKind{{Value: "standard", Label: "Standard retry"}},
+			Actions:   []api.RetryAction{{Value: "standard", Label: "Standard retry"}},
 		}
 		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
 			return initialOptions, nil
@@ -308,15 +397,15 @@ Choose one or more tool caches and retry:
 		setup.mockAPI.MockRequestRetry = func(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
 			calls++
 			if calls == 1 {
-				require.Equal(t, "clean", cfg.Kind)
+				require.Equal(t, "clean", cfg.Action)
 				return api.RequestRetryResult{}, &api.RetryRequestError{
 					Message: "This retry configuration is not supported.",
-					Errors:  []api.RetryFieldError{{Field: "kind", Message: "`clean` is no longer available."}},
+					Errors:  []api.RetryFieldError{{Field: "action", Message: "`clean` is no longer available."}},
 					Options: refreshedOptions,
 				}
 			}
 
-			require.Equal(t, "standard", cfg.Kind)
+			require.Equal(t, "standard", cfg.Action)
 			return api.RequestRetryResult{Status: "retry_requested", RunID: "run-123", TaskID: "task-123"}, nil
 		}
 
@@ -329,8 +418,7 @@ Choose one or more tool caches and retry:
 		require.Equal(t, 2, calls)
 		output := setup.mockStdout.String()
 		require.Contains(t, output, "The available retry options changed.\n\n")
-		require.Equal(t, 2, strings.Count(output, "Select a retry kind:"))
-		require.Contains(t, output, "1. Standard retry (standard)")
+		require.NotContains(t, output, "Select a retry action:")
 	})
 
 	t.Run("prints every refreshed option for an unknown endpoint field", func(t *testing.T) {
@@ -348,28 +436,28 @@ Choose one or more tool caches and retry:
 
 		result, err := setup.service.Retry(cli.RetryConfig{
 			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
-			Kind:   "standard",
+			Action: "standard",
 		})
 
 		require.Nil(t, result)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Retry: The retry target changed.")
 		require.NotContains(t, err.Error(), "target:")
-		require.Contains(t, err.Error(), "Available retry kinds:")
+		require.Contains(t, err.Error(), "Available retry actions:")
 		require.Contains(t, err.Error(), "Breakpoint:\n  Supported\n  Placements: end (default), start")
 		require.Contains(t, err.Error(), "Available tool caches:")
-		require.Contains(t, err.Error(), "Try:\n  rwx tasks retry task-123 --kind standard")
+		require.Contains(t, err.Error(), "Try:\n  rwx tasks retry task-123 --action standard")
 	})
 
 	t.Run("does not replace an explicit TTY selection", func(t *testing.T) {
 		setup := setupTestWithTTY(t)
 		initialOptions := api.RetryOptions{
 			Retryable: true,
-			Kinds:     []api.RetryKind{{Value: "clean", Label: "Clean retry"}},
+			Actions:   []api.RetryAction{{Value: "clean", Label: "Clean retry"}},
 		}
 		refreshedOptions := api.RetryOptions{
 			Retryable: true,
-			Kinds:     []api.RetryKind{{Value: "standard", Label: "Standard retry"}},
+			Actions:   []api.RetryAction{{Value: "standard", Label: "Standard retry"}},
 		}
 		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
 			return initialOptions, nil
@@ -379,21 +467,21 @@ Choose one or more tool caches and retry:
 			calls++
 			return api.RequestRetryResult{}, &api.RetryRequestError{
 				Message: "This retry configuration is not supported.",
-				Errors:  []api.RetryFieldError{{Field: "kind", Message: "`clean` is no longer available."}},
+				Errors:  []api.RetryFieldError{{Field: "action", Message: "`clean` is no longer available."}},
 				Options: refreshedOptions,
 			}
 		}
 
 		result, err := setup.service.Retry(cli.RetryConfig{
 			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
-			Kind:   "clean",
+			Action: "clean",
 		})
 
 		require.Nil(t, result)
 		require.Error(t, err)
 		require.Equal(t, 1, calls)
 		require.Empty(t, setup.mockStdout.String())
-		require.Contains(t, err.Error(), "Available retry kinds:")
+		require.Contains(t, err.Error(), "Available retry actions:")
 	})
 
 	t.Run("stops after one retry with refreshed TTY options", func(t *testing.T) {
@@ -403,11 +491,11 @@ Choose one or more tool caches and retry:
 
 		initialOptions := api.RetryOptions{
 			Retryable: true,
-			Kinds:     []api.RetryKind{{Value: "clean", Label: "Clean retry"}},
+			Actions:   []api.RetryAction{{Value: "clean", Label: "Clean retry"}},
 		}
 		refreshedOptions := api.RetryOptions{
 			Retryable: true,
-			Kinds:     []api.RetryKind{{Value: "standard", Label: "Standard retry"}},
+			Actions:   []api.RetryAction{{Value: "standard", Label: "Standard retry"}},
 		}
 		setup.mockAPI.MockGetRetryOptions = func(target api.RetryTarget) (api.RetryOptions, error) {
 			return initialOptions, nil
@@ -417,7 +505,7 @@ Choose one or more tool caches and retry:
 			calls++
 			return api.RequestRetryResult{}, &api.RetryRequestError{
 				Message: "This retry configuration is not supported.",
-				Errors:  []api.RetryFieldError{{Field: "kind", Message: "The selected kind is no longer available."}},
+				Errors:  []api.RetryFieldError{{Field: "action", Message: "The selected action is no longer available."}},
 				Options: refreshedOptions,
 			}
 		}
@@ -452,12 +540,10 @@ Choose one or more tool caches and retry:
 				Options: options,
 			}
 		}
-		debug := true
-
 		result, err := setup.service.Retry(cli.RetryConfig{
-			Target: api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
-			Kind:   "standard",
-			Debug:  &debug,
+			Target:         api.RetryTarget{ID: "task-123", Type: api.RetryTargetTask},
+			Action:         "standard",
+			DebugPlacement: "end",
 		})
 
 		require.Nil(t, result)

--- a/internal/mocks/api.go
+++ b/internal/mocks/api.go
@@ -40,6 +40,8 @@ type API struct {
 	MockRunStatus                               func(api.RunStatusConfig) (api.RunStatusResult, error)
 	MockGetRunDetails                           func(api.RunDetailsConfig) (map[string]any, error)
 	MockListRuns                                func(api.ListRunsConfig) (*api.ListRunsResult, error)
+	MockGetRetryOptions                         func(api.RetryTarget) (api.RetryOptions, error)
+	MockRequestRetry                            func(api.RequestRetryConfig) (api.RequestRetryResult, error)
 	MockGetLogDownloadRequest                   func(string) (api.LogDownloadRequestResult, error)
 	MockGetLogDownloadRequestByTaskKey          func(string, string) (api.LogDownloadRequestResult, error)
 	MockDownloadLogs                            func(api.LogDownloadRequestResult) ([]byte, error)
@@ -416,6 +418,22 @@ func (c *API) CancelRun(runID, scopedToken string) error {
 	}
 
 	return errors.New("MockCancelRun was not configured")
+}
+
+func (c *API) GetRetryOptions(target api.RetryTarget) (api.RetryOptions, error) {
+	if c.MockGetRetryOptions != nil {
+		return c.MockGetRetryOptions(target)
+	}
+
+	return api.RetryOptions{}, errors.New("MockGetRetryOptions was not configured")
+}
+
+func (c *API) RequestRetry(cfg api.RequestRetryConfig) (api.RequestRetryResult, error) {
+	if c.MockRequestRetry != nil {
+		return c.MockRequestRetry(cfg)
+	}
+
+	return api.RequestRetryResult{}, errors.New("MockRequestRetry was not configured")
 }
 
 func (c *API) GetSandboxInitTemplate() (api.SandboxInitTemplateResult, error) {


### PR DESCRIPTION
Adds `rwx retry <run-or-task-id>`, `rwx runs retry <run-id>`, and `rwx tasks retry <task-id>`.

In a TTY, we'll interactively prompt you for anything you haven't specified via flags. Outside of a TTY, we'll error and provide you options.
