### PR TITLE
Skip base injection for package files

### DIFF
--- a/.rwx/build.yml
+++ b/.rwx/build.yml
@@ -5,11 +5,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       preserve-git-dir: true
       repository: https://github.com/rwx-cloud/rwx.git
@@ -28,7 +28,7 @@ tasks:
       - language-server-ref
 
   - key: lsp-code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/language-server.git
       ref: ${{ tasks.tool-versions.values.language-server-ref }}
@@ -44,13 +44,13 @@ tasks:
       ref: ${{ tasks.tool-versions.values.language-server-ref }}
 
   - key: go
-    call: golang/install 1.2.2
+    call: golang/install 1.3.0
     with:
       go-version: ${{ tasks.tool-versions.values.golang }}
 
   - key: go-deps
     use: [go, code]
-    call: golang/mod-download 1.0.2
+    call: golang/mod-download 1.1.0
     filter: [go.mod, go.sum]
 
   - key: build

--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -5,11 +5,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       preserve-git-dir: true
       repository: https://github.com/rwx-cloud/rwx.git
@@ -28,7 +28,7 @@ tasks:
       - language-server-ref
 
   - key: go-installation
-    call: golang/install 1.2.2
+    call: golang/install 1.3.0
     with:
       go-version: ${{ tasks.tool-versions.values.golang }}
 
@@ -43,7 +43,7 @@ tasks:
 
   - key: go-deps
     use: [go, code]
-    call: golang/mod-download 1.0.2
+    call: golang/mod-download 1.1.0
     filter: [go.mod, go.sum]
     with:
       tool-cache: cli-go-deps
@@ -65,7 +65,7 @@ tasks:
       git lfs install --skip-repo
 
   - key: lsp-code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/language-server.git
       ref: ${{ tasks.tool-versions.values.language-server-ref }}

--- a/.rwx/integration-sandbox.yml
+++ b/.rwx/integration-sandbox.yml
@@ -5,11 +5,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       preserve-git-dir: true
       repository: https://github.com/rwx-cloud/rwx.git
@@ -28,7 +28,7 @@ tasks:
       - language-server-ref
 
   - key: go-installation
-    call: golang/install 1.2.2
+    call: golang/install 1.3.0
     with:
       go-version: ${{ tasks.tool-versions.values.golang }}
 
@@ -38,7 +38,7 @@ tasks:
 
   - key: go-deps
     use: [go, code]
-    call: golang/mod-download 1.0.2
+    call: golang/mod-download 1.1.0
     filter: [go.mod, go.sum]
     with:
       tool-cache: cli-go-deps
@@ -56,7 +56,7 @@ tasks:
       git lfs install --skip-repo
 
   - key: lsp-code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/language-server.git
       ref: ${{ tasks.tool-versions.values.language-server-ref }}

--- a/.rwx/integration.yml
+++ b/.rwx/integration.yml
@@ -5,7 +5,7 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: run-rwx-run-test

--- a/.rwx/integration/artifacts-test.yml
+++ b/.rwx/integration/artifacts-test.yml
@@ -5,11 +5,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/artifacts-test/run-def.yml
+++ b/.rwx/integration/artifacts-test/run-def.yml
@@ -1,6 +1,6 @@
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: artifact-producer

--- a/.rwx/integration/dispatch-test.yml
+++ b/.rwx/integration/dispatch-test.yml
@@ -5,11 +5,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/image-test.yml
+++ b/.rwx/integration/image-test.yml
@@ -5,17 +5,17 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: build-image
     call: ${{ run.dir }}/integration/image-test/build-image.yml
 
   - key: aws-cli
-    call: aws/install-cli 1.0.12
+    call: aws/install-cli 1.1.0
 
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}
@@ -36,7 +36,7 @@ tasks:
 
   - key: aws-role
     use: aws-cli
-    call: aws/assume-role 2.0.10
+    call: aws/assume-role 2.1.0
     with:
       region: us-east-2
       role-to-assume: arn:aws:iam::646244215049:role/rwx-repo-cd

--- a/.rwx/integration/lint-test.yml
+++ b/.rwx/integration/lint-test.yml
@@ -7,11 +7,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}
@@ -28,7 +28,7 @@ tasks:
       - language-server-ref
 
   - key: go-installation
-    call: golang/install 1.2.2
+    call: golang/install 1.3.0
     with:
       go-version: ${{ tasks.tool-versions.values.golang }}
 
@@ -37,22 +37,22 @@ tasks:
     run: echo "$(go env GOPATH)/bin" > "${MINT_ENV}/PATH"
 
   - key: node
-    call: nodejs/install 1.1.15
+    call: nodejs/install 1.2.0
     with:
       node-version: ${{ tasks.tool-versions.values.nodejs }}
 
   - key: min-supported-node
-    call: nodejs/install 1.1.15
+    call: nodejs/install 1.2.0
     with:
       node-version: 18.0.0
 
   - key: unsupported-node
-    call: nodejs/install 1.1.15
+    call: nodejs/install 1.2.0
     with:
       node-version: 17.0.0
 
   - key: lsp-code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/language-server.git
       ref: ${{ tasks.tool-versions.values.language-server-ref }}
@@ -73,7 +73,7 @@ tasks:
 
   - key: go-deps
     use: [go, code]
-    call: golang/mod-download 1.0.2
+    call: golang/mod-download 1.1.0
     filter: [go.mod, go.sum]
     with:
       tool-cache: cli-go-deps

--- a/.rwx/integration/logs-test.yml
+++ b/.rwx/integration/logs-test.yml
@@ -5,11 +5,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/logs-test/run-def.yml
+++ b/.rwx/integration/logs-test/run-def.yml
@@ -1,6 +1,6 @@
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: log-producer

--- a/.rwx/integration/resolve-update-test.yml
+++ b/.rwx/integration/resolve-update-test.yml
@@ -7,11 +7,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/results-test.yml
+++ b/.rwx/integration/results-test.yml
@@ -5,11 +5,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/results-test/failing.yml
+++ b/.rwx/integration/results-test/failing.yml
@@ -1,6 +1,6 @@
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: will-fail-fast

--- a/.rwx/integration/results-test/mixed-task-statuses.yml
+++ b/.rwx/integration/results-test/mixed-task-statuses.yml
@@ -1,6 +1,6 @@
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: will-fail-fast

--- a/.rwx/integration/results-test/passing.yml
+++ b/.rwx/integration/results-test/passing.yml
@@ -1,6 +1,6 @@
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: hello

--- a/.rwx/integration/run-test.yml
+++ b/.rwx/integration/run-test.yml
@@ -5,11 +5,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: rwx-testing-code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/rwx-testing.git
       ref: main
@@ -28,7 +28,7 @@ tasks:
       cli: ${{ init.cli }}
 
   - key: rwx-cli-code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.cli }}

--- a/.rwx/integration/run-test/dir-test/.rwx/nested-ci.yml
+++ b/.rwx/integration/run-test/dir-test/.rwx/nested-ci.yml
@@ -1,6 +1,6 @@
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: hello

--- a/.rwx/integration/run-test/failing-def.yml
+++ b/.rwx/integration/run-test/failing-def.yml
@@ -1,6 +1,6 @@
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: will-fail-fast

--- a/.rwx/integration/run-test/multi-task-def.yml
+++ b/.rwx/integration/run-test/multi-task-def.yml
@@ -1,6 +1,6 @@
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: task-a

--- a/.rwx/integration/run-test/simple-def.yml
+++ b/.rwx/integration/run-test/simple-def.yml
@@ -1,6 +1,6 @@
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: hello

--- a/.rwx/integration/runs-cancel-test.yml
+++ b/.rwx/integration/runs-cancel-test.yml
@@ -5,11 +5,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/runs-cancel-test/cancellable.yml
+++ b/.rwx/integration/runs-cancel-test/cancellable.yml
@@ -1,6 +1,6 @@
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: long-running

--- a/.rwx/integration/runs-list-test.yml
+++ b/.rwx/integration/runs-list-test.yml
@@ -5,11 +5,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/runs-list-test/passing.yml
+++ b/.rwx/integration/runs-list-test/passing.yml
@@ -1,6 +1,6 @@
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: hello

--- a/.rwx/integration/skill-test.yml
+++ b/.rwx/integration/skill-test.yml
@@ -5,11 +5,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/integration/whoami-test.yml
+++ b/.rwx/integration/whoami-test.yml
@@ -5,11 +5,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: ${{ init.ref }}

--- a/.rwx/language-server-update.yml
+++ b/.rwx/language-server-update.yml
@@ -4,11 +4,11 @@ on:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/rwx.git
       ref: main
@@ -16,7 +16,7 @@ tasks:
       preserve-git-dir: true
 
   - key: gh-cli
-    call: github/install-cli 1.0.11
+    call: github/install-cli 1.1.0
 
   - key: update-ref
     use: [code, gh-cli]
@@ -45,7 +45,7 @@ tasks:
       GITHUB_TOKEN: ${{ github['rwx-cloud'].token }}
 
   - key: create-pull-request
-    call: github/create-pull-request 1.0.7
+    call: github/create-pull-request 1.1.0
     use: update-ref
     with:
       github-token: ${{ github-apps.rwx-cloud-bot.token }}

--- a/.rwx/release.yml
+++ b/.rwx/release.yml
@@ -25,7 +25,7 @@ concurrency-pools:
 
 base:
   image: ubuntu:24.04
-  config: rwx/base 1.1.1
+  config: rwx/base 1.2.0
 
 tasks:
   - key: verify-inputs
@@ -54,7 +54,7 @@ tasks:
       - language-server-ref
 
   - key: go
-    call: golang/install 1.2.2
+    call: golang/install 1.3.0
     with:
       go-version: ${{ tasks.tool-versions.values.golang }}
 
@@ -82,7 +82,7 @@ tasks:
       printf "$aliasedVersion" > "$RWX_VALUES/aliased-version"
 
   - key: code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     after: verify-inputs
     with:
       preserve-git-dir: true
@@ -92,7 +92,7 @@ tasks:
 
   - key: go-deps
     use: [go, code]
-    call: golang/mod-download 1.0.2
+    call: golang/mod-download 1.1.0
     filter: [go.mod, go.sum]
     with:
       tool-cache: cli-go-deps
@@ -139,7 +139,7 @@ tasks:
       GH_TOKEN: ${{ github-apps.rwx-cloud-bot.token }}
 
   - key: lsp-code
-    call: git/clone 2.0.8
+    call: git/clone 2.1.0
     with:
       repository: https://github.com/rwx-cloud/language-server.git
       ref: ${{ tasks.tool-versions.values.language-server-ref }}
@@ -349,7 +349,7 @@ tasks:
       LINEAR_ACCESS_KEY: ${{ vaults.rwx_cli_development.secrets.linear-release-access-key }}
 
   - key: rwx-cli
-    call: rwx/install-cli 4.0.5
+    call: rwx/install-cli 4.1.0
 
   - key: homebrew-release
     use: rwx-cli

--- a/internal/cli/service_insert_base.go
+++ b/internal/cli/service_insert_base.go
@@ -184,6 +184,11 @@ func (s Service) getFilesForBaseInsert(entries []RwxDirectoryEntry) ([]BaseLayer
 			return false
 		}
 
+		// Skip package definitions; bases are not valid in them
+		if doc.HasPackage() {
+			return false
+		}
+
 		// Skip if all tasks in this file are embedded runs
 		if doc.AllTasksAreEmbeddedRuns() {
 			return false

--- a/internal/cli/service_insert_base_test.go
+++ b/internal/cli/service_insert_base_test.go
@@ -449,6 +449,40 @@ tasks:
 		})
 	})
 
+	t.Run("when yaml file has a top-level package key and doesn't include base", func(t *testing.T) {
+		bl := setupBaseLayer(t)
+
+		err := os.WriteFile(filepath.Join(bl.mintDir, "foo.yaml"), []byte(`
+package:
+  name: my-package
+  version: 1.0.0
+
+tasks:
+  - key: a
+    run: /bin/true
+`), 0o644)
+		require.NoError(t, err)
+
+		t.Run("does not add base to file", func(t *testing.T) {
+			_, err = bl.s.service.InsertBase(cli.InsertBaseConfig{})
+			require.NoError(t, err)
+
+			var contents []byte
+
+			contents, err = os.ReadFile(filepath.Join(bl.mintDir, "foo.yaml"))
+			require.NoError(t, err)
+			require.Equal(t, `
+package:
+  name: my-package
+  version: 1.0.0
+
+tasks:
+  - key: a
+    run: /bin/true
+`, string(contents))
+		})
+	})
+
 	t.Run("when yaml file calls into the packages directory and doesn't include base", func(t *testing.T) {
 		bl := setupBaseLayer(t)
 

--- a/internal/cli/yaml.go
+++ b/internal/cli/yaml.go
@@ -71,6 +71,10 @@ func (doc *YAMLDoc) HasTasks() bool {
 	return doc.hasPath("$.tasks")
 }
 
+func (doc *YAMLDoc) HasPackage() bool {
+	return doc.hasPath("$.package")
+}
+
 // packagesDirCallRe matches calls into the local packages directory, eg.
 // `call: ${{ run.dir }}/packages/my-package`
 var packagesDirCallRe = regexp.MustCompile(`^\$\{\{\s*run\.dir\s*\}\}/packages/`)


### PR DESCRIPTION
I ran into this when running `rwx update` in a repo with a local package. It injected a base, which made the local package invalid.

<details><summary>AI Summary</summary>
<p>
Package definition files can contain tasks, so `rwx update`, `rwx resolve`, and the implicit base insertion on `rwx run` were injecting a default base into them. Bases are not valid in package definitions, so skip any file with a top-level `package` key when selecting files for base insertion.


Claude-Session: https://claude.ai/code/session_015LofU2fhyAmWKGHKwktGiB
</p>
</details> 
