### PR TITLE
Read configured sandbox process logs by ID

### DIFF
--- a/cmd/rwx/sandbox.go
+++ b/cmd/rwx/sandbox.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 
 	"github.com/manifoldco/promptui"
 	"github.com/rwx-cloud/rwx/internal/cli"
@@ -383,11 +385,14 @@ var sandboxBackgroundLogsCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		useJson := useJsonOutput()
+		ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
 		result, err := service.LogsSandboxBackground(cli.SandboxBackgroundLogsConfig{
-			Name:   sandboxBackgroundName,
-			RunID:  sandboxRunID,
-			Json:   useJson,
-			Follow: sandboxBackgroundFollow,
+			Context: ctx,
+			Name:    sandboxBackgroundName,
+			RunID:   sandboxRunID,
+			Json:    useJson,
+			Follow:  sandboxBackgroundFollow,
 		})
 		if err != nil {
 			return err

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -2,9 +2,13 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -89,10 +93,11 @@ type SandboxBackgroundConfig struct {
 }
 
 type SandboxBackgroundLogsConfig struct {
-	Name   string
-	RunID  string
-	Json   bool
-	Follow bool
+	Context context.Context
+	Name    string
+	RunID   string
+	Json    bool
+	Follow  bool
 }
 
 type ListSandboxesConfig struct {
@@ -150,6 +155,7 @@ type SandboxBackgroundResult struct {
 	StdoutPath  string
 	StderrPath  string
 	LogPath     string `json:"logPath,omitempty"`
+	LogsID      string `json:"-"`
 }
 
 type sandboxOperationConfig struct {
@@ -691,7 +697,60 @@ func (s Service) LogsSandboxBackground(cfg SandboxBackgroundLogsConfig) (*Sandbo
 		return nil, err
 	}
 	result := sandboxBackgroundResult(sandbox.runID, process)
+	if process.LogsID == "" && process.LogPath == "" && process.StdoutPath == "" && process.StderrPath == "" {
+		return nil, fmt.Errorf("logs for background process %q are unavailable", cfg.Name)
+	}
 	if cfg.Json {
+		return result, nil
+	}
+	if process.LogsID != "" {
+		sandbox.close()
+		logDownloadRequest, err := s.APIClient.GetLogDownloadRequest(sandbox.runID)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to authorize configured sandbox process logs")
+		}
+
+		archiveEndpoint, err := url.Parse(logDownloadRequest.URL)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to parse configured sandbox process logs endpoint")
+		}
+		logsEndpoint := *archiveEndpoint
+		logsEndpoint.Path = ""
+		logsEndpoint.RawPath = ""
+		logsEndpoint.RawQuery = ""
+		logsEndpoint.Fragment = ""
+		pathElements := []string{"api", "logs", url.PathEscape(process.LogsID)}
+		if !cfg.Follow {
+			pathElements = append(pathElements, "download")
+		}
+		individualEndpoint := logsEndpoint.JoinPath(pathElements...)
+
+		if cfg.Context == nil {
+			cfg.Context = context.Background()
+		}
+		req, err := http.NewRequestWithContext(cfg.Context, http.MethodGet, individualEndpoint.String(), nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to create configured sandbox process logs request")
+		}
+		req.Header.Set("Authorization", "Bearer "+logDownloadRequest.Token)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			if cfg.Context.Err() != nil {
+				return result, nil
+			}
+			return nil, errors.Wrap(err, "unable to read configured sandbox process logs")
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			return nil, fmt.Errorf("unable to read configured sandbox process logs: logs server returned %s", resp.Status)
+		}
+		if _, err := io.Copy(s.Stdout, resp.Body); err != nil {
+			if cfg.Context.Err() != nil {
+				return result, nil
+			}
+			return nil, errors.Wrap(err, "unable to stream configured sandbox process logs")
+		}
 		return result, nil
 	}
 
@@ -748,6 +807,7 @@ type sandboxProcessResponse struct {
 	StdoutPath  string `json:"stdoutPath"`
 	StderrPath  string `json:"stderrPath"`
 	LogPath     string `json:"logPath"`
+	LogsID      string `json:"logsId,omitempty"`
 }
 
 func (s Service) executeSandboxProcessDirective(directive string, request any, action string) (sandboxProcessResponse, error) {
@@ -850,7 +910,7 @@ func sandboxBackgroundResult(runID string, process sandboxProcessResponse) *Sand
 		RunID: runID, Name: process.Key, Status: process.Status, TargetPort: process.TargetPort,
 		PID: process.PID, PGID: process.PGID, StartedAt: process.StartedAt, CompletedAt: process.CompletedAt,
 		ExitCode: process.ExitCode, Signal: process.Signal, StdoutPath: process.StdoutPath, StderrPath: process.StderrPath,
-		LogPath: process.LogPath,
+		LogPath: process.LogPath, LogsID: process.LogsID,
 	}
 }
 

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -2,9 +2,12 @@ package cli_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1624,6 +1627,195 @@ func TestService_LogsSandboxBackground(t *testing.T) {
 		var output map[string]any
 		require.NoError(t, json.Unmarshal(data, &output))
 		require.Equal(t, "/tmp/web.log", output["logPath"])
+	})
+
+	t.Run("decodes configured logs in JSON mode", func(t *testing.T) {
+		setup, _, connectCount := setupLogs(t, `{
+			"key":"api",
+			"status":"available",
+			"logsId":"configured-process-logs-id"
+		}`)
+
+		result, err := setup.service.LogsSandboxBackground(cli.SandboxBackgroundLogsConfig{
+			Name: "api", RunID: "run-background", Json: true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 1, *connectCount, "JSON logs should not reconnect or contact the logs server")
+		require.Equal(t, "configured-process-logs-id", result.LogsID)
+	})
+
+	t.Run("returns a clear error when the response has no log source", func(t *testing.T) {
+		setup, _, connectCount := setupLogs(t, `{
+			"key":"api",
+			"status":"not_found",
+			"observedAt":"2026-08-27T19:00:00Z"
+		}`)
+
+		_, err := setup.service.LogsSandboxBackground(cli.SandboxBackgroundLogsConfig{
+			Name: "api", RunID: "run-background",
+		})
+
+		require.EqualError(t, err, `logs for background process "api" are unavailable`)
+		require.Equal(t, 1, *connectCount)
+	})
+
+	t.Run("streams a configured log snapshot with authorization and an escaped ID", func(t *testing.T) {
+		logsID := "configured/process ?#"
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			require.Equal(t, http.MethodGet, r.Method)
+			require.Equal(t, "/api/logs/configured%2Fprocess%20%3F%23/download", r.URL.EscapedPath())
+			require.Empty(t, r.URL.RawQuery)
+			require.Equal(t, "Bearer signed-logs-token", r.Header.Get("Authorization"))
+			_, err := io.WriteString(w, "historical\ncurrent\n")
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		setup, commands, connectCount := setupLogs(t, fmt.Sprintf(`{
+			"key":"api",
+			"status":"available",
+			"logsId":%q,
+			"logPath":"/tmp/ad-hoc.log"
+		}`, logsID))
+		setup.mockAPI.MockGetLogDownloadRequest = func(runID string) (api.LogDownloadRequestResult, error) {
+			require.Equal(t, "run-background", runID)
+			return api.LogDownloadRequestResult{
+				URL:   server.URL + "/archive/download?archive=true",
+				Token: "signed-logs-token",
+			}, nil
+		}
+
+		result, err := setup.service.LogsSandboxBackground(cli.SandboxBackgroundLogsConfig{
+			Name: "api", RunID: "run-background",
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, logsID, result.LogsID)
+		require.Equal(t, "historical\ncurrent\n", setup.mockStdout.String())
+		require.Equal(t, 1, requestCount)
+		require.Equal(t, 1, *connectCount, "configured logs should not reconnect over SSH")
+		require.NotContains(t, strings.Join(*commands, "\n"), "tail -n +1")
+	})
+
+	t.Run("returns a Cloud authorization failure", func(t *testing.T) {
+		setup, _, connectCount := setupLogs(t, `{
+			"key":"api",
+			"status":"available",
+			"logsId":"configured-process-logs-id"
+		}`)
+		setup.mockAPI.MockGetLogDownloadRequest = func(runID string) (api.LogDownloadRequestResult, error) {
+			require.Equal(t, "run-background", runID)
+			return api.LogDownloadRequestResult{}, fmt.Errorf("authorization denied")
+		}
+
+		_, err := setup.service.LogsSandboxBackground(cli.SandboxBackgroundLogsConfig{
+			Name: "api", RunID: "run-background",
+		})
+
+		require.EqualError(t, err, "unable to authorize configured sandbox process logs: authorization denied")
+		require.Equal(t, 1, *connectCount)
+	})
+
+	t.Run("returns a logs-server failure", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+		}))
+		defer server.Close()
+
+		setup, _, _ := setupLogs(t, `{
+			"key":"api",
+			"status":"available",
+			"logsId":"configured-process-logs-id"
+		}`)
+		setup.mockAPI.MockGetLogDownloadRequest = func(string) (api.LogDownloadRequestResult, error) {
+			return api.LogDownloadRequestResult{URL: server.URL + "/archive/download", Token: "signed-logs-token"}, nil
+		}
+
+		_, err := setup.service.LogsSandboxBackground(cli.SandboxBackgroundLogsConfig{
+			Name: "api", RunID: "run-background",
+		})
+
+		require.EqualError(t, err, "unable to read configured sandbox process logs: logs server returned 502 Bad Gateway")
+	})
+
+	t.Run("follows configured logs until its context is canceled", func(t *testing.T) {
+		requestStarted := make(chan struct{})
+		requestCanceled := make(chan struct{})
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/api/logs/configured-process-logs-id", r.URL.EscapedPath())
+			require.Equal(t, "Bearer signed-logs-token", r.Header.Get("Authorization"))
+			flusher, ok := w.(http.Flusher)
+			require.True(t, ok)
+			_, err := io.WriteString(w, "historical\n")
+			require.NoError(t, err)
+			flusher.Flush()
+			_, err = io.WriteString(w, "live\n")
+			require.NoError(t, err)
+			flusher.Flush()
+			close(requestStarted)
+			<-r.Context().Done()
+			close(requestCanceled)
+		}))
+		defer server.Close()
+
+		setup, _, connectCount := setupLogs(t, `{
+			"key":"api",
+			"status":"available",
+			"logsId":"configured-process-logs-id"
+		}`)
+		setup.mockAPI.MockGetLogDownloadRequest = func(string) (api.LogDownloadRequestResult, error) {
+			return api.LogDownloadRequestResult{URL: server.URL + "/archive/download", Token: "signed-logs-token"}, nil
+		}
+		stdoutReader, stdoutWriter := io.Pipe()
+		defer stdoutReader.Close()
+		defer stdoutWriter.Close()
+		setup.service.Stdout = stdoutWriter
+		streamedOutput := make(chan string, 1)
+		go func() {
+			output := make([]byte, len("historical\nlive\n"))
+			_, err := io.ReadFull(stdoutReader, output)
+			if err != nil {
+				streamedOutput <- ""
+				return
+			}
+			streamedOutput <- string(output)
+		}()
+		ctx, cancel := context.WithCancel(context.Background())
+		resultCh := make(chan error, 1)
+		go func() {
+			_, err := setup.service.LogsSandboxBackground(cli.SandboxBackgroundLogsConfig{
+				Context: ctx, Name: "api", RunID: "run-background", Follow: true,
+			})
+			resultCh <- err
+		}()
+
+		select {
+		case <-requestStarted:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for configured log stream")
+		}
+		select {
+		case output := <-streamedOutput:
+			require.Equal(t, "historical\nlive\n", output)
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for historical configured log output")
+		}
+		cancel()
+		select {
+		case err := <-resultCh:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("configured log follow did not stop after cancellation")
+		}
+		select {
+		case <-requestCanceled:
+		case <-time.After(5 * time.Second):
+			t.Fatal("logs-server request context was not canceled")
+		}
+		require.Equal(t, 1, *connectCount, "configured follow should not reconnect over SSH")
 	})
 
 	t.Run("prefers the combined log for a one-shot read", func(t *testing.T) {


### PR DESCRIPTION
Adds support for fetching configured background process logs using the same interface as adhoc sandbox background processes.

Landing this ahead of landing agent support.

<details> 
<summary>AI Summary</summary>

## Summary

Adds support for reading configured sandbox background-process logs through their existing `logsId`.

When the sandbox agent returns a `logsId`, the CLI:

- Uses the sandbox run ID to request the existing signed logs token from Cloud.
- Streams snapshots from `/api/logs/:logsId/download`.
- Streams historical and live output from `/api/logs/:logsId` with `--follow`.
- Cancels the follow request cleanly on Ctrl-C.
- Escapes log IDs when constructing URLs.

Responses without `logsId` continue using the existing SSH and file-backed log behavior. If both a log ID and file paths are present, the log ID takes precedence.

## Testing

- `go fmt ./...`
- `golangci-lint run ./...`
- `go test ./...`
- `go build ./cmd/rwx`
- Focused race tests for the changed CLI packages

Also tested end to end with a locally compiled CLI

- Configured log metadata and snapshot
- Historical and live `--follow` output
- Ctrl-C cancellation
- Log availability after stop
- Stable log ID across restart generations
- Ad hoc file-backed fallback

</details>