### PR TITLE
Unhide sandbox background commands and remove experimental gating

### DIFF
--- a/cmd/rwx/sandbox.go
+++ b/cmd/rwx/sandbox.go
@@ -243,12 +243,21 @@ CONFIG FILE
 }
 
 var sandboxPushCmd = &cobra.Command{
-	Use:    "push",
-	Short:  "Push local changes to a sandbox",
-	Hidden: true,
-	Args:   cobra.NoArgs,
+	Use:   "push",
+	Short: "Push local changes to a sandbox",
+	Long: `Sync local changes to an existing sandbox without running a command.
+
+"rwx sandbox exec" syncs local changes before running its command. Use push
+when you want to update the sandbox without running a command.
+
+The sandbox is reset to the local Git state, including staged, unstaged, and
+untracked changes. Changes made only in the sandbox are not preserved.
+
+By default, push targets the sandbox for the current directory and Git branch.
+Use --id to target a specific sandbox.`,
+	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return requireExperimentalSandboxAccess()
+		return requireAccessToken()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		useJson := useJsonOutput()
@@ -273,15 +282,19 @@ var sandboxPushCmd = &cobra.Command{
 }
 
 var sandboxBackgroundCmd = &cobra.Command{
-	Use:    "background -- <command>",
-	Short:  "Start or replace a sandbox background process",
-	Hidden: true,
-	Long: `Start or replace a named managed process in an existing sandbox.
-Local changes are synced before the process starts. When --port is provided,
-the port is forwarded locally and its localhost URL is printed.`,
+	Use:   "background -- <command>",
+	Short: "Start or replace a sandbox background process",
+	Long: `Start or replace a named process in an existing sandbox.
+
+Starting a process syncs the local Git state first. Changes made only in the
+sandbox are not preserved. The process runs until you stop it or the sandbox
+stops.
+
+Use --port to forward a sandbox port to localhost. Use --id to target a
+specific sandbox.`,
 	Args: cobra.ArbitraryArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return requireExperimentalSandboxAccess()
+		return requireAccessToken()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dashIndex := cmd.ArgsLenAtDash()
@@ -318,12 +331,15 @@ the port is forwarded locally and its localhost URL is printed.`,
 }
 
 var sandboxBackgroundRestartCmd = &cobra.Command{
-	Use:    "restart",
-	Short:  "Sync changes and restart a sandbox background process",
-	Hidden: true,
-	Args:   cobra.NoArgs,
+	Use:   "restart",
+	Short: "Sync changes and restart a sandbox background process",
+	Long: `Sync the local Git state and restart a named process, reusing its saved
+command and sandbox port. Changes made only in the sandbox are not preserved.
+If the process forwards a port, restart reopens the local tunnel and prints its
+URL.`,
+	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return requireExperimentalSandboxAccess()
+		return requireAccessToken()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		useJson := useJsonOutput()
@@ -347,12 +363,11 @@ var sandboxBackgroundRestartCmd = &cobra.Command{
 }
 
 var sandboxBackgroundStopCmd = &cobra.Command{
-	Use:    "stop",
-	Short:  "Stop a sandbox background process",
-	Hidden: true,
-	Args:   cobra.NoArgs,
+	Use:   "stop",
+	Short: "Stop a sandbox background process",
+	Args:  cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return requireExperimentalSandboxAccess()
+		return requireAccessToken()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		useJson := useJsonOutput()
@@ -376,12 +391,13 @@ var sandboxBackgroundStopCmd = &cobra.Command{
 }
 
 var sandboxBackgroundLogsCmd = &cobra.Command{
-	Use:    "logs",
-	Short:  "Show logs for a sandbox background process",
-	Hidden: true,
-	Args:   cobra.NoArgs,
+	Use:   "logs",
+	Short: "Show logs for a sandbox background process",
+	Long: `Show logs for an ad hoc background process or one declared in the sandbox
+configuration. Use --follow to stream new output.`,
+	Args: cobra.NoArgs,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return requireExperimentalSandboxAccess()
+		return requireAccessToken()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		useJson := useJsonOutput()
@@ -571,13 +587,6 @@ var (
 	sandboxInitParams          []string
 )
 
-func requireExperimentalSandboxAccess() error {
-	if os.Getenv("RWX_EXPERIMENTAL") != "true" {
-		return fmt.Errorf("this command is experimental; set RWX_EXPERIMENTAL=true to use it")
-	}
-	return requireAccessToken()
-}
-
 func init() {
 	sandboxCmd.AddCommand(sandboxInitCmd)
 	sandboxCmd.AddCommand(sandboxStartCmd)
@@ -614,7 +623,7 @@ func init() {
 
 	// background flags
 	sandboxBackgroundCmd.PersistentFlags().StringVar(&sandboxRunID, "id", "", "Use specific run ID")
-	sandboxBackgroundCmd.PersistentFlags().StringVar(&sandboxBackgroundName, "name", "", "Name of the managed sandbox process")
+	sandboxBackgroundCmd.PersistentFlags().StringVar(&sandboxBackgroundName, "name", "", "Name of the sandbox background process")
 	sandboxBackgroundCmd.Flags().IntVar(&sandboxBackgroundPort, "port", 0, "Sandbox port to forward locally")
 	sandboxBackgroundCmd.Flags().IntVar(&sandboxBackgroundLocalPort, "local-port", 0, "Local port to use (default: allocate or reuse one)")
 	sandboxBackgroundCmd.Flags().StringVar(&sandboxBackgroundScheme, "scheme", "", "URL scheme for the forwarded port: http or https (default: http)")

--- a/cmd/rwx/sandbox_test.go
+++ b/cmd/rwx/sandbox_test.go
@@ -3,12 +3,11 @@ package main
 import (
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
-func TestSandboxPushCommandIsHidden(t *testing.T) {
-	require.True(t, sandboxPushCmd.Hidden)
+func TestSandboxPushCommandIsVisible(t *testing.T) {
+	require.False(t, sandboxPushCmd.Hidden)
 	require.Equal(t, "push", sandboxPushCmd.Use)
 	require.NotNil(t, sandboxPushCmd.Flags().Lookup("id"))
 	require.Nil(t, sandboxPushCmd.Flags().Lookup("dir"))
@@ -17,8 +16,8 @@ func TestSandboxPushCommandIsHidden(t *testing.T) {
 	require.Error(t, sandboxPushCmd.Args(sandboxPushCmd, []string{".rwx/sandbox.yml"}))
 }
 
-func TestSandboxBackgroundCommandIsHidden(t *testing.T) {
-	require.True(t, sandboxBackgroundCmd.Hidden)
+func TestSandboxBackgroundCommandsAreVisible(t *testing.T) {
+	require.False(t, sandboxBackgroundCmd.Hidden)
 	require.Equal(t, "background -- <command>", sandboxBackgroundCmd.Use)
 	require.NotNil(t, sandboxBackgroundCmd.PersistentFlags().Lookup("name"))
 	require.NotNil(t, sandboxBackgroundCmd.Flags().Lookup("port"))
@@ -26,39 +25,10 @@ func TestSandboxBackgroundCommandIsHidden(t *testing.T) {
 	require.Nil(t, sandboxBackgroundCmd.Flags().Lookup("dir"))
 	require.Nil(t, sandboxBackgroundCmd.Flags().Lookup("init"))
 	require.Equal(t, "restart", sandboxBackgroundRestartCmd.Use)
-	require.True(t, sandboxBackgroundRestartCmd.Hidden)
+	require.False(t, sandboxBackgroundRestartCmd.Hidden)
 	require.Equal(t, "stop", sandboxBackgroundStopCmd.Use)
-	require.True(t, sandboxBackgroundStopCmd.Hidden)
+	require.False(t, sandboxBackgroundStopCmd.Hidden)
 	require.Equal(t, "logs", sandboxBackgroundLogsCmd.Use)
-	require.True(t, sandboxBackgroundLogsCmd.Hidden)
+	require.False(t, sandboxBackgroundLogsCmd.Hidden)
 	require.NotNil(t, sandboxBackgroundLogsCmd.Flags().Lookup("follow"))
-}
-
-func TestExperimentalSandboxCommandsRequireOptIn(t *testing.T) {
-	commands := []*cobra.Command{
-		sandboxPushCmd,
-		sandboxBackgroundCmd,
-		sandboxBackgroundRestartCmd,
-		sandboxBackgroundStopCmd,
-		sandboxBackgroundLogsCmd,
-	}
-
-	for _, value := range []string{"", "false", "TRUE", "1"} {
-		t.Run("RWX_EXPERIMENTAL="+value, func(t *testing.T) {
-			t.Setenv("RWX_EXPERIMENTAL", value)
-			for _, command := range commands {
-				require.EqualError(t, command.PreRunE(command, nil), "this command is experimental; set RWX_EXPERIMENTAL=true to use it")
-			}
-		})
-	}
-
-	t.Run("RWX_EXPERIMENTAL=true", func(t *testing.T) {
-		t.Setenv("RWX_EXPERIMENTAL", "true")
-		originalAccessToken := AccessToken
-		AccessToken = "test-token"
-		t.Cleanup(func() { AccessToken = originalAccessToken })
-		for _, command := range commands {
-			require.NoError(t, command.PreRunE(command, nil))
-		}
-	})
 }

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -817,7 +817,7 @@ func (s Service) executeSandboxProcessDirective(directive string, request any, a
 	}
 	exitCode, output, stderr, err := s.SSHClient.ExecuteCommandWithSeparateOutput(directive + " " + string(payload))
 	if err != nil {
-		return sandboxProcessResponse{}, errors.Wrapf(err, "failed to %s managed sandbox process", action)
+		return sandboxProcessResponse{}, errors.Wrapf(err, "failed to %s sandbox background process", action)
 	}
 	if exitCode == 127 {
 		return sandboxProcessResponse{}, fmt.Errorf("background processes are not supported by this sandbox")
@@ -825,9 +825,9 @@ func (s Service) executeSandboxProcessDirective(directive string, request any, a
 	if exitCode != 0 {
 		stderr = strings.TrimSpace(stderr)
 		if stderr != "" && !strings.Contains(stderr, "__rwx_sandbox_") {
-			return sandboxProcessResponse{}, fmt.Errorf("sandbox agent failed to %s managed process: %s", action, stderr)
+			return sandboxProcessResponse{}, fmt.Errorf("sandbox agent failed to %s background process: %s", action, stderr)
 		}
-		return sandboxProcessResponse{}, fmt.Errorf("sandbox agent failed to %s managed process (exit code %d)", action, exitCode)
+		return sandboxProcessResponse{}, fmt.Errorf("sandbox agent failed to %s background process (exit code %d)", action, exitCode)
 	}
 	var process sandboxProcessResponse
 	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &process); err != nil {

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1237,7 +1237,7 @@ func TestService_BackgroundSandbox(t *testing.T) {
 		require.EqualError(t, err, "background process name must be at most 255 bytes")
 	})
 
-	t.Run("syncs, starts a managed process, and opens a local tunnel", func(t *testing.T) {
+	t.Run("syncs, starts a background process, and opens a local tunnel", func(t *testing.T) {
 		setup, commands := setupBackground(t)
 		var tunnelConfig rwxssh.TunnelConfig
 		setup.mockTunnel.MockOpen = func(cfg rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
@@ -1537,7 +1537,7 @@ rwx sandbox exec -- <command> syncs local changes before it runs.
 		require.NotContains(t, setup.mockStderr.String(), "__rwx_sandbox_")
 	})
 
-	t.Run("returns managed process diagnostics without exposing directives", func(t *testing.T) {
+	t.Run("returns background process diagnostics without exposing directives", func(t *testing.T) {
 		setup, _ := setupBackground(t)
 		setup.mockSSH.MockExecuteCommandWithSeparateOutput = func(command string) (int, string, string, error) {
 			if strings.HasPrefix(command, "__rwx_sandbox_process_restart__ ") {
@@ -1551,7 +1551,7 @@ rwx sandbox exec -- <command> syncs local changes before it runs.
 			Name: "web", RunID: "run-background", Json: true,
 		})
 
-		require.EqualError(t, err, `sandbox agent failed to restart managed process: sandbox process "web" has no stored definition`)
+		require.EqualError(t, err, `sandbox agent failed to restart background process: sandbox process "web" has no stored definition`)
 		require.NotContains(t, err.Error(), "__rwx_sandbox_")
 	})
 

--- a/test/integration/sandbox-background-exec-reset.sh
+++ b/test/integration/sandbox-background-exec-reset.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/sandbox-helpers.sh"
 
-export RWX_EXPERIMENTAL=true
-
 start_sandbox "${SCRIPT_DIR}/definitions/sandbox-background.yml"
 trap stop_sandbox EXIT
 

--- a/test/integration/sandbox-background.sh
+++ b/test/integration/sandbox-background.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/sandbox-helpers.sh"
 
-export RWX_EXPERIMENTAL=true
-
 preview_name="web"
 preview_port=3000
 preview_file="integration-background-preview.txt"
@@ -69,7 +67,7 @@ if [ "$restart_url" != "$preview_url" ]; then
 fi
 
 if [ "$restart_pid" = "$start_pid" ] && [ "$restart_time" = "$start_time" ]; then
-  echo "background restart did not replace the managed process"
+  echo "background restart did not replace the background process"
   exit 1
 fi
 

--- a/test/integration_suite_test.go
+++ b/test/integration_suite_test.go
@@ -55,16 +55,6 @@ func runMint(t *testing.T, input input) result {
 	}
 }
 
-func TestSandboxExperimentalGate(t *testing.T) {
-	t.Setenv("RWX_EXPERIMENTAL", "")
-	result := runMint(t, input{
-		args: []string{"sandbox", "push", "--access-token", "fake-for-test"},
-	})
-
-	require.Equal(t, 1, result.exitCode)
-	require.Contains(t, result.stderr, "this command is experimental; set RWX_EXPERIMENTAL=true to use it")
-}
-
 func TestImageBuild(t *testing.T) {
 	t.Run("fails when --tag is used with --no-pull", func(t *testing.T) {
 		input := input{


### PR DESCRIPTION
- [ ] Waiting for some changes to land in daily before this can be released.

Unhide docs and remove `RWX_EXPERIMENTAL` gate from `rwx sandbox background` and `rwx sandbox push` commands, enabling users to start, manage, and preview adhoc and configured background processes.