### PR TITLE
Rename sandbox background process flag from --name to --key

### DIFF
--- a/cmd/rwx/sandbox.go
+++ b/cmd/rwx/sandbox.go
@@ -614,13 +614,23 @@ func init() {
 
 	// background flags
 	sandboxBackgroundCmd.PersistentFlags().StringVar(&sandboxRunID, "id", "", "Use specific run ID")
+	sandboxBackgroundCmd.PersistentFlags().StringVar(&sandboxBackgroundName, "key", "", "Key of the managed sandbox process")
 	sandboxBackgroundCmd.PersistentFlags().StringVar(&sandboxBackgroundName, "name", "", "Name of the managed sandbox process")
+	if err := sandboxBackgroundCmd.PersistentFlags().MarkDeprecated("name", "use --key instead"); err != nil {
+		panic(err)
+	}
 	sandboxBackgroundCmd.Flags().IntVar(&sandboxBackgroundPort, "port", 0, "Sandbox port to forward locally")
 	sandboxBackgroundCmd.Flags().IntVar(&sandboxBackgroundLocalPort, "local-port", 0, "Local port to use (default: allocate or reuse one)")
 	sandboxBackgroundCmd.Flags().StringVar(&sandboxBackgroundScheme, "scheme", "", "URL scheme for the forwarded port: http or https (default: http)")
 	sandboxBackgroundLogsCmd.Flags().BoolVarP(&sandboxBackgroundFollow, "follow", "f", false, "Follow log output")
-	if err := sandboxBackgroundCmd.MarkPersistentFlagRequired("name"); err != nil {
-		panic(err)
+	for _, command := range []*cobra.Command{
+		sandboxBackgroundCmd,
+		sandboxBackgroundRestartCmd,
+		sandboxBackgroundStopCmd,
+		sandboxBackgroundLogsCmd,
+	} {
+		command.MarkFlagsOneRequired("name", "key")
+		command.MarkFlagsMutuallyExclusive("name", "key")
 	}
 
 	// stop flags

--- a/cmd/rwx/sandbox_test.go
+++ b/cmd/rwx/sandbox_test.go
@@ -20,7 +20,13 @@ func TestSandboxPushCommandIsHidden(t *testing.T) {
 func TestSandboxBackgroundCommandIsHidden(t *testing.T) {
 	require.True(t, sandboxBackgroundCmd.Hidden)
 	require.Equal(t, "background -- <command>", sandboxBackgroundCmd.Use)
-	require.NotNil(t, sandboxBackgroundCmd.PersistentFlags().Lookup("name"))
+	nameFlag := sandboxBackgroundCmd.PersistentFlags().Lookup("name")
+	keyFlag := sandboxBackgroundCmd.PersistentFlags().Lookup("key")
+	require.NotNil(t, nameFlag)
+	require.True(t, nameFlag.Hidden)
+	require.Equal(t, "use --key instead", nameFlag.Deprecated)
+	require.NotNil(t, keyFlag)
+	require.False(t, keyFlag.Hidden)
 	require.NotNil(t, sandboxBackgroundCmd.Flags().Lookup("port"))
 	require.NotNil(t, sandboxBackgroundCmd.Flags().Lookup("local-port"))
 	require.Nil(t, sandboxBackgroundCmd.Flags().Lookup("dir"))
@@ -32,6 +38,44 @@ func TestSandboxBackgroundCommandIsHidden(t *testing.T) {
 	require.Equal(t, "logs", sandboxBackgroundLogsCmd.Use)
 	require.True(t, sandboxBackgroundLogsCmd.Hidden)
 	require.NotNil(t, sandboxBackgroundLogsCmd.Flags().Lookup("follow"))
+}
+
+func TestSandboxBackgroundNameAndKeyFlags(t *testing.T) {
+	nameFlag := sandboxBackgroundCmd.PersistentFlags().Lookup("name")
+	keyFlag := sandboxBackgroundCmd.PersistentFlags().Lookup("key")
+	originalNameChanged := nameFlag.Changed
+	originalKeyChanged := keyFlag.Changed
+	originalName := sandboxBackgroundName
+	t.Cleanup(func() {
+		nameFlag.Changed = originalNameChanged
+		keyFlag.Changed = originalKeyChanged
+		require.NoError(t, keyFlag.Value.Set(originalName))
+	})
+
+	commands := []*cobra.Command{
+		sandboxBackgroundCmd,
+		sandboxBackgroundRestartCmd,
+		sandboxBackgroundStopCmd,
+		sandboxBackgroundLogsCmd,
+	}
+
+	nameFlag.Changed = false
+	keyFlag.Changed = false
+	for _, command := range commands {
+		require.Error(t, command.ValidateFlagGroups(), "%s should require --key or its compatibility alias", command.CommandPath())
+	}
+
+	require.NoError(t, keyFlag.Value.Set("worker"))
+	require.Equal(t, "worker", sandboxBackgroundName)
+	keyFlag.Changed = true
+	for _, command := range commands {
+		require.NoError(t, command.ValidateFlagGroups(), "%s should accept --key", command.CommandPath())
+	}
+
+	nameFlag.Changed = true
+	for _, command := range commands {
+		require.Error(t, command.ValidateFlagGroups(), "%s should reject --name with --key", command.CommandPath())
+	}
 }
 
 func TestExperimentalSandboxCommandsRequireOptIn(t *testing.T) {

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -896,7 +896,7 @@ func (s Service) finishSandboxBackground(sandbox *syncedSandbox, process sandbox
 			fmt.Fprintf(s.Stdout, "Preview %q: %s\n\n", process.Key, result.URL)
 			fmt.Fprintln(s.Stdout, "After local edits:")
 			fmt.Fprintln(s.Stdout, "  Hot reload:    rwx sandbox push")
-			fmt.Fprintf(s.Stdout, "  Hard restart:  rwx sandbox background restart --name %s\n\n", process.Key)
+			fmt.Fprintf(s.Stdout, "  Hard restart:  rwx sandbox background restart --key %s\n\n", process.Key)
 			fmt.Fprintln(s.Stdout, "rwx sandbox exec -- <command> syncs local changes before it runs.")
 		} else {
 			fmt.Fprintf(s.Stdout, "%s background process %q.\n", action, process.Key)

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1350,7 +1350,7 @@ func TestService_BackgroundSandbox(t *testing.T) {
 
 After local edits:
   Hot reload:    rwx sandbox push
-  Hard restart:  rwx sandbox background restart --name web
+  Hard restart:  rwx sandbox background restart --key web
 
 rwx sandbox exec -- <command> syncs local changes before it runs.
 `, setup.mockStdout.String())

--- a/test/integration/sandbox-background-exec-reset.sh
+++ b/test/integration/sandbox-background-exec-reset.sh
@@ -11,7 +11,7 @@ trap stop_sandbox EXIT
 
 background_result=$("${RWX_CLI}" sandbox background \
   --id "$SANDBOX_RUN_ID" \
-  --name reset-preview \
+  --key reset-preview \
   --port 3000 \
   --json \
   -- python3 -u -m http.server 3000 --bind 127.0.0.1)

--- a/test/integration/sandbox-background.sh
+++ b/test/integration/sandbox-background.sh
@@ -12,7 +12,7 @@ preview_file="integration-background-preview.txt"
 
 cleanup() {
   if [ -n "${SANDBOX_RUN_ID:-}" ]; then
-    "${RWX_CLI}" sandbox background stop --id "$SANDBOX_RUN_ID" --name "$preview_name" >/dev/null 2>&1 || true
+    "${RWX_CLI}" sandbox background stop --id "$SANDBOX_RUN_ID" --key "$preview_name" >/dev/null 2>&1 || true
     "${RWX_CLI}" sandbox stop --id "$SANDBOX_RUN_ID" >/dev/null 2>&1 || true
   fi
   rm -f "$preview_file"
@@ -25,7 +25,7 @@ printf 'initial preview\n' > "$preview_file"
 
 start_result=$("${RWX_CLI}" sandbox background \
   --id "$SANDBOX_RUN_ID" \
-  --name "$preview_name" \
+  --key "$preview_name" \
   --port "$preview_port" \
   --json \
   -- python3 -u -m http.server "$preview_port" --bind 127.0.0.1)
@@ -56,7 +56,7 @@ fi
 
 restart_result=$("${RWX_CLI}" sandbox background restart \
   --id "$SANDBOX_RUN_ID" \
-  --name "$preview_name" \
+  --key "$preview_name" \
   --json)
 
 restart_url=$(echo "$restart_result" | jq -r '.URL')
@@ -74,7 +74,7 @@ if [ "$restart_pid" = "$start_pid" ] && [ "$restart_time" = "$start_time" ]; the
 fi
 
 curl --fail --silent --show-error --max-time 10 "$restart_url/$preview_file" >/dev/null
-logs_output=$("${RWX_CLI}" sandbox background logs --id "$SANDBOX_RUN_ID" --name "$preview_name")
+logs_output=$("${RWX_CLI}" sandbox background logs --id "$SANDBOX_RUN_ID" --key "$preview_name")
 if [[ "$logs_output" != *"$preview_file"* ]]; then
   echo "background logs did not include the preview request"
   echo "$logs_output"
@@ -83,7 +83,7 @@ fi
 
 portless_result=$("${RWX_CLI}" sandbox background \
   --id "$SANDBOX_RUN_ID" \
-  --name "$preview_name" \
+  --key "$preview_name" \
   --json \
   -- sh -c 'while :; do sleep 60; done')
 
@@ -97,6 +97,6 @@ if curl --fail --silent --max-time 2 "$preview_url/$preview_file" >/dev/null 2>&
   exit 1
 fi
 
-"${RWX_CLI}" sandbox background stop --id "$SANDBOX_RUN_ID" --name "$preview_name" --json >/dev/null
+"${RWX_CLI}" sandbox background stop --id "$SANDBOX_RUN_ID" --key "$preview_name" --json >/dev/null
 
 echo "PASS: sandbox background process, push, restart, logs, and tunnel cleanup"

--- a/test/integration/sandbox-configured-background.sh
+++ b/test/integration/sandbox-configured-background.sh
@@ -19,7 +19,7 @@ configured_logs=""
 for _ in {1..30}; do
   configured_logs=$("${RWX_CLI}" sandbox background logs \
     --id "$SANDBOX_RUN_ID" \
-    --name "$configured_name") || true
+    --key "$configured_name") || true
   if [[ "$configured_logs" == *"$configured_log_marker"* ]]; then
     break
   fi
@@ -34,7 +34,7 @@ fi
 
 configured_restart_result=$("${RWX_CLI}" sandbox background restart \
   --id "$SANDBOX_RUN_ID" \
-  --name "$configured_name" \
+  --key "$configured_name" \
   --json)
 
 if [ "$(echo "$configured_restart_result" | jq -r '.Status')" != "running" ]; then
@@ -50,7 +50,7 @@ configured_start_count=0
 for _ in {1..30}; do
   configured_logs=$("${RWX_CLI}" sandbox background logs \
     --id "$SANDBOX_RUN_ID" \
-    --name "$configured_name") || true
+    --key "$configured_name") || true
   configured_start_count=$(grep -c "$configured_log_marker" <<< "$configured_logs" || true)
   if [ "$configured_start_count" -ge 2 ]; then
     break


### PR DESCRIPTION
It started to feel awkward using `--name` instead of `--key`, specifically when interacting with configured background processes that are configured with a `key`.

I went for deprecating just to avoid coordinating updating internal skills w/ this PR. Separately I'll update the external scripts/skills that are currently using --name and then remove the deprecation in favor of removal. 