### PR TITLE
Use sandbox-side port readiness checks

### DIFF
--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -32,6 +32,7 @@ const (
 	sandboxDirectiveProcessStop    = "__rwx_sandbox_process_stop__"
 	sandboxDirectiveProcessStatus  = "__rwx_sandbox_process_status__"
 	sandboxDirectiveProcessLogs    = "__rwx_sandbox_process_logs__"
+	sandboxDirectivePortReady      = "__rwx_sandbox_port_ready__"
 	sandboxBackgroundNameSizeLimit = 255
 	rwxCLISSHUser                  = "rwx-cli"
 	// Reuse one fixed ref (force-pushed) rather than a unique ref per push so the
@@ -795,19 +796,20 @@ func (s Service) LogsSandboxBackground(cfg SandboxBackgroundLogsConfig) (*Sandbo
 }
 
 type sandboxProcessResponse struct {
-	Key         string `json:"key"`
-	Status      string `json:"status"`
-	TargetPort  int    `json:"targetPort"`
-	PID         int    `json:"pid"`
-	PGID        int    `json:"pgid"`
-	StartedAt   string `json:"startedAt"`
-	CompletedAt string `json:"completedAt"`
-	ExitCode    *int   `json:"exitCode"`
-	Signal      string `json:"signal"`
-	StdoutPath  string `json:"stdoutPath"`
-	StderrPath  string `json:"stderrPath"`
-	LogPath     string `json:"logPath"`
-	LogsID      string `json:"logsId,omitempty"`
+	Key                    string `json:"key"`
+	Status                 string `json:"status"`
+	SupportsPortReadyCheck bool   `json:"supportsPortReadyCheck"`
+	TargetPort             int    `json:"targetPort"`
+	PID                    int    `json:"pid"`
+	PGID                   int    `json:"pgid"`
+	StartedAt              string `json:"startedAt"`
+	CompletedAt            string `json:"completedAt"`
+	ExitCode               *int   `json:"exitCode"`
+	Signal                 string `json:"signal"`
+	StdoutPath             string `json:"stdoutPath"`
+	StderrPath             string `json:"stderrPath"`
+	LogPath                string `json:"logPath"`
+	LogsID                 string `json:"logsId,omitempty"`
 }
 
 func (s Service) executeSandboxProcessDirective(directive string, request any, action string) (sandboxProcessResponse, error) {
@@ -862,7 +864,32 @@ func (s Service) finishSandboxBackground(sandbox *syncedSandbox, process sandbox
 		result.URL = fmt.Sprintf("%s://127.0.0.1:%d", tunnel.Scheme, tunnel.LocalPort)
 
 		deadline := time.Now().Add(30 * time.Second)
-		for !s.SSHTunnelManager.IsReady(tunnel.LocalPort) {
+		portReadyDirectiveSupported := process.SupportsPortReadyCheck
+		for {
+			ready := false
+			if portReadyDirectiveSupported {
+				exitCode, readyErr := s.SSHClient.ExecuteCommand(fmt.Sprintf("%s %d", sandboxDirectivePortReady, process.TargetPort))
+				if readyErr != nil {
+					return nil, errors.Wrap(readyErr, "failed to check sandbox process port readiness")
+				}
+				switch exitCode {
+				case 0:
+					ready = true
+				case 1:
+					ready = false
+				case 127:
+					portReadyDirectiveSupported = false
+				default:
+					return nil, fmt.Errorf("sandbox agent failed to check port %d readiness (exit code %d)", process.TargetPort, exitCode)
+				}
+			}
+			if !portReadyDirectiveSupported {
+				ready = s.SSHTunnelManager.IsReady(tunnel.LocalPort)
+			}
+			if ready {
+				break
+			}
+
 			status, statusErr := s.executeSandboxProcessDirective(sandboxDirectiveProcessStatus, struct {
 				Key string `json:"key"`
 			}{Key: process.Key}, "get status for")

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1296,6 +1296,49 @@ func TestService_BackgroundSandbox(t *testing.T) {
 		}
 	})
 
+	t.Run("waits for authoritative sandbox-side port readiness", func(t *testing.T) {
+		setup, commands := setupBackground(t)
+		setup.mockTunnel.MockOpen = func(cfg rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
+			return rwxssh.TunnelResult{LocalPort: 8310, Scheme: cfg.Scheme}, nil
+		}
+		setup.mockTunnel.MockIsReady = func(int) bool {
+			require.Fail(t, "local tunnel readiness must not be used when the agent supports port checks")
+
+			return false
+		}
+		readyChecks := 0
+		setup.mockSSH.MockExecuteCommand = func(command string) (int, error) {
+			*commands = append(*commands, command)
+			if strings.HasPrefix(command, "__rwx_sandbox_port_ready__ ") {
+				readyChecks++
+				if readyChecks == 1 {
+					return 1, nil
+				}
+
+				return 0, nil
+			}
+
+			return 0, nil
+		}
+		setup.mockSSH.MockExecuteCommandWithSeparateOutput = func(command string) (int, string, string, error) {
+			switch {
+			case strings.HasPrefix(command, "__rwx_sandbox_process_start__ "):
+				return 0, `{"key":"web","status":"running","supportsPortReadyCheck":true,"targetPort":3100}`, "", nil
+			case strings.HasPrefix(command, "__rwx_sandbox_process_status__ "):
+				return 0, `{"key":"web","status":"running","targetPort":3100}`, "", nil
+			default:
+				return 0, "", "", nil
+			}
+		}
+
+		_, err := setup.service.BackgroundSandbox(cli.BackgroundSandboxConfig{
+			Command: []string{"bin/server"}, Name: "web", TargetPort: 3100, RunID: "run-background", Json: true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 2, readyChecks)
+	})
+
 	t.Run("starts without a tunnel when no port is requested", func(t *testing.T) {
 		setup, commands := setupBackground(t)
 		var closeConfig rwxssh.TunnelCloseConfig


### PR DESCRIPTION
Hardens a flake I was seeing occasionally. The CLI could report a sandbox background port as ready while the sandbox-side connection was still pending, causing an immediate request to fail with connection reset by peer.

With this PR, when available, the CLI will use an authoritative sandbox-side TCP readiness check. It falls back to the existing check when unavailable.

The flake happened when the condition appeared valid when checked, but was not valid when used.