### PR TITLE
Scope sandbox integration cleanup to owned runs

### DIFF
--- a/test/integration/sandbox-background-exec-reset.sh
+++ b/test/integration/sandbox-background-exec-reset.sh
@@ -19,12 +19,19 @@ preview_url=$(echo "$background_result" | jq -r '.URL')
 
 curl --fail --silent --show-error --max-time 10 "$preview_url" >/dev/null
 
-"${RWX_CLI}" sandbox exec \
+exec_result=$("${RWX_CLI}" sandbox exec \
+  --json \
   --reset \
   --init ref=main \
   --init "cli=${COMMIT_SHA}" \
   "${SCRIPT_DIR}/definitions/sandbox-background.yml" \
-  -- true
+  -- true)
+SANDBOX_RUN_ID=$(echo "$exec_result" | jq -r '.RunID // empty')
+if [ -z "$SANDBOX_RUN_ID" ]; then
+  echo "exec --reset did not return a run ID"
+  echo "$exec_result"
+  exit 1
+fi
 
 if curl --fail --silent --max-time 2 "$preview_url" >/dev/null 2>&1; then
   echo "ERROR: Preview tunnel remained reachable after exec --reset"

--- a/test/integration/sandbox-exec-reset.sh
+++ b/test/integration/sandbox-exec-reset.sh
@@ -18,7 +18,19 @@ if [ "$marker" != "sentinel" ]; then
 fi
 
 # exec --reset should stop the existing sandbox, start a fresh one, and run the command
-"${RWX_CLI}" sandbox exec --reset --init ref=main --init "cli=${COMMIT_SHA}" "${SCRIPT_DIR}/definitions/sandbox.yml" -- sh -c 'echo "exec-reset-complete"'
+exec_result=$("${RWX_CLI}" sandbox exec \
+  --json \
+  --reset \
+  --init ref=main \
+  --init "cli=${COMMIT_SHA}" \
+  "${SCRIPT_DIR}/definitions/sandbox.yml" \
+  -- sh -c 'echo "exec-reset-complete" >&2')
+SANDBOX_RUN_ID=$(echo "$exec_result" | jq -r '.RunID // empty')
+if [ -z "$SANDBOX_RUN_ID" ]; then
+  echo "exec --reset did not return a run ID"
+  echo "$exec_result"
+  exit 1
+fi
 
 # In the fresh sandbox, the sentinel file should not exist
 exit_code=0

--- a/test/integration/sandbox-helpers.sh
+++ b/test/integration/sandbox-helpers.sh
@@ -35,5 +35,11 @@ start_sandbox() {
 }
 
 stop_sandbox() {
-  "${RWX_CLI}" sandbox stop
+  if [ -z "${SANDBOX_RUN_ID:-}" ]; then
+    echo "No sandbox run ID available to stop" >&2
+    return 1
+  fi
+  # Parallel tests can discover each other's sandboxes, so cleanup must target
+  # only the run created by this test.
+  "${RWX_CLI}" sandbox stop --id "$SANDBOX_RUN_ID"
 }

--- a/test/integration/sandbox-reset.sh
+++ b/test/integration/sandbox-reset.sh
@@ -26,6 +26,7 @@ if [ -z "$new_run_id" ]; then
   echo "$reset_output"
   exit 1
 fi
+export SANDBOX_RUN_ID="$new_run_id"
 
 # After reset, the marker file should not exist in the fresh sandbox
 exit_code=0

--- a/test/integration/sandbox-unpushed-commits.sh
+++ b/test/integration/sandbox-unpushed-commits.sh
@@ -22,11 +22,22 @@ git commit -m "unpushed local commit"
 echo "uncommitted edit" > uncommitted-test.txt
 uncommitted_sha=$(sha1sum uncommitted-test.txt | awk '{print $1}')
 
-"${RWX_CLI}" sandbox exec \
+exec_exit_code=0
+exec_result=$("${RWX_CLI}" sandbox exec \
+  --json \
   "${SCRIPT_DIR}/definitions/sandbox.yml" \
   --init ref=main \
   --init "cli=${COMMIT_SHA}" \
-  -- sh -c 'test "$(cat unpushed-commit-test.txt)" = "unpushed commit content" && test "$(cat uncommitted-test.txt)" = "uncommitted edit"'
+  -- sh -c 'test "$(cat unpushed-commit-test.txt)" = "unpushed commit content" && test "$(cat uncommitted-test.txt)" = "uncommitted edit"') || exec_exit_code=$?
+SANDBOX_RUN_ID=$(echo "$exec_result" | jq -r '.RunID // empty')
+if [ -z "$SANDBOX_RUN_ID" ]; then
+  echo "sandbox exec did not return a run ID"
+  echo "$exec_result"
+  exit 1
+fi
+if [ "$exec_exit_code" -ne 0 ]; then
+  exit "$exec_exit_code"
+fi
 
 post_exec_sha=$(sha1sum uncommitted-test.txt | awk '{print $1}')
 if [ "$uncommitted_sha" != "$post_exec_sha" ]; then


### PR DESCRIPTION
Noticed some seemingly unrelated flakiness to the changes I was making...

`sandbox-list` and other sandbox integration tests run concurrently, each with its own sandbox. 

`sandbox-list` calls `rwx sandbox list --json`, which discovers active sandboxes created by other tests and records them locally.

When `sandbox-list` finishes, its cleanup runs `rwx sandbox stop` without a run ID, so it can stop both its own sandbox and other sandboxes unexpectedly.

The fix makes each test stop only its own `SANDBOX_RUN_ID`, preventing the unintentional shut-down mid-test.