### PR TITLE
Add sandbox tunnel command

### DIFF
--- a/cmd/rwx/sandbox.go
+++ b/cmd/rwx/sandbox.go
@@ -346,6 +346,38 @@ var sandboxBackgroundRestartCmd = &cobra.Command{
 	},
 }
 
+var sandboxTunnelCmd = &cobra.Command{
+	Use:    "tunnel",
+	Short:  "Expose a sandbox background process through a local tunnel",
+	Hidden: true,
+	Args:   cobra.NoArgs,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return requireExperimentalSandboxAccess()
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		useJson := useJsonOutput()
+		result, err := service.TunnelSandbox(cli.TunnelSandboxConfig{
+			Key:        sandboxTunnelKey,
+			TargetPort: sandboxTunnelPort,
+			LocalPort:  sandboxTunnelLocalPort,
+			Scheme:     sandboxTunnelScheme,
+			RunID:      sandboxRunID,
+			Json:       useJson,
+		})
+		if err != nil {
+			return err
+		}
+		if useJson {
+			output, err := json.Marshal(result)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(os.Stdout, string(output))
+		}
+		return nil
+	},
+}
+
 var sandboxBackgroundStopCmd = &cobra.Command{
 	Use:    "stop",
 	Short:  "Stop a sandbox background process",
@@ -568,6 +600,10 @@ var (
 	sandboxBackgroundLocalPort int
 	sandboxBackgroundScheme    string
 	sandboxBackgroundFollow    bool
+	sandboxTunnelKey           string
+	sandboxTunnelPort          int
+	sandboxTunnelLocalPort     int
+	sandboxTunnelScheme        string
 	sandboxInitParams          []string
 )
 
@@ -587,6 +623,7 @@ func init() {
 	sandboxBackgroundCmd.AddCommand(sandboxBackgroundStopCmd)
 	sandboxBackgroundCmd.AddCommand(sandboxBackgroundLogsCmd)
 	sandboxCmd.AddCommand(sandboxBackgroundCmd)
+	sandboxCmd.AddCommand(sandboxTunnelCmd)
 	sandboxCmd.AddCommand(sandboxListCmd)
 	sandboxCmd.AddCommand(sandboxStopCmd)
 	sandboxCmd.AddCommand(sandboxResetCmd)
@@ -631,6 +668,19 @@ func init() {
 	} {
 		command.MarkFlagsOneRequired("name", "key")
 		command.MarkFlagsMutuallyExclusive("name", "key")
+	}
+
+	// tunnel flags
+	sandboxTunnelCmd.Flags().StringVar(&sandboxRunID, "id", "", "Use specific run ID")
+	sandboxTunnelCmd.Flags().StringVar(&sandboxTunnelKey, "key", "", "Key of the managed sandbox process to expose")
+	sandboxTunnelCmd.Flags().IntVar(&sandboxTunnelPort, "port", 0, "Sandbox port to forward locally")
+	sandboxTunnelCmd.Flags().IntVar(&sandboxTunnelLocalPort, "local-port", 0, "Local port to use (default: allocate or reuse one)")
+	sandboxTunnelCmd.Flags().StringVar(&sandboxTunnelScheme, "scheme", "", "URL scheme for the forwarded port: http or https (default: http)")
+	if err := sandboxTunnelCmd.MarkFlagRequired("key"); err != nil {
+		panic(err)
+	}
+	if err := sandboxTunnelCmd.MarkFlagRequired("port"); err != nil {
+		panic(err)
 	}
 
 	// stop flags

--- a/cmd/rwx/sandbox_test.go
+++ b/cmd/rwx/sandbox_test.go
@@ -78,6 +78,19 @@ func TestSandboxBackgroundNameAndKeyFlags(t *testing.T) {
 	}
 }
 
+func TestSandboxTunnelCommandIsHidden(t *testing.T) {
+	require.True(t, sandboxTunnelCmd.Hidden)
+	require.Equal(t, "tunnel", sandboxTunnelCmd.Use)
+	require.NotNil(t, sandboxTunnelCmd.Flags().Lookup("id"))
+	require.NotNil(t, sandboxTunnelCmd.Flags().Lookup("key"))
+	require.NotNil(t, sandboxTunnelCmd.Flags().Lookup("port"))
+	require.NotNil(t, sandboxTunnelCmd.Flags().Lookup("local-port"))
+	require.NotNil(t, sandboxTunnelCmd.Flags().Lookup("scheme"))
+	require.Nil(t, sandboxTunnelCmd.Flags().Lookup("name"))
+	require.NoError(t, sandboxTunnelCmd.Args(sandboxTunnelCmd, nil))
+	require.Error(t, sandboxTunnelCmd.Args(sandboxTunnelCmd, []string{"web"}))
+}
+
 func TestExperimentalSandboxCommandsRequireOptIn(t *testing.T) {
 	commands := []*cobra.Command{
 		sandboxPushCmd,
@@ -85,6 +98,7 @@ func TestExperimentalSandboxCommandsRequireOptIn(t *testing.T) {
 		sandboxBackgroundRestartCmd,
 		sandboxBackgroundStopCmd,
 		sandboxBackgroundLogsCmd,
+		sandboxTunnelCmd,
 	}
 
 	for _, value := range []string{"", "false", "TRUE", "1"} {

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -93,6 +93,15 @@ type SandboxBackgroundConfig struct {
 	Json  bool
 }
 
+type TunnelSandboxConfig struct {
+	Key        string
+	TargetPort int
+	LocalPort  int
+	Scheme     string
+	RunID      string
+	Json       bool
+}
+
 type SandboxBackgroundLogsConfig struct {
 	Context context.Context
 	Name    string
@@ -157,6 +166,15 @@ type SandboxBackgroundResult struct {
 	StderrPath  string
 	LogPath     string `json:"logPath,omitempty"`
 	LogsID      string `json:"-"`
+}
+
+type SandboxTunnelResult struct {
+	RunID      string
+	Key        string
+	TargetPort int
+	LocalPort  int
+	Scheme     string
+	URL        string
 }
 
 type sandboxOperationConfig struct {
@@ -556,25 +574,12 @@ func (s Service) BackgroundSandbox(cfg BackgroundSandboxConfig) (*SandboxBackgro
 	if err := validateSandboxBackgroundName(cfg.Name); err != nil {
 		return nil, err
 	}
-	if cfg.TargetPort < 0 || cfg.TargetPort > 65535 {
-		return nil, fmt.Errorf("background process port must be between 1 and 65535")
-	}
-	if cfg.LocalPort < 0 || cfg.LocalPort > 65535 {
-		return nil, fmt.Errorf("local background process port must be between 1 and 65535")
-	}
-	if cfg.LocalPort != 0 && cfg.TargetPort == 0 {
-		return nil, fmt.Errorf("--local-port requires --port")
-	}
-	if cfg.Scheme != "" && cfg.TargetPort == 0 {
-		return nil, fmt.Errorf("--scheme requires --port")
-	}
-	if cfg.TargetPort != 0 {
-		if cfg.Scheme == "" {
-			cfg.Scheme = "http"
-		}
-		if cfg.Scheme != "http" && cfg.Scheme != "https" {
-			return nil, fmt.Errorf("--scheme must be http or https")
-		}
+	var err error
+	cfg.Scheme, err = validateSandboxTunnelOptions(
+		cfg.TargetPort, cfg.LocalPort, cfg.Scheme, "background process", "local background process", false,
+	)
+	if err != nil {
+		return nil, err
 	}
 	if len(cfg.Command) == 0 {
 		return nil, fmt.Errorf("background process command is required")
@@ -606,6 +611,88 @@ func (s Service) BackgroundSandbox(cfg BackgroundSandboxConfig) (*SandboxBackgro
 	process.Key = cfg.Name
 	process.TargetPort = cfg.TargetPort
 	return s.finishSandboxBackground(sandbox, process, cfg.LocalPort, cfg.Scheme, cfg.Json, "Started")
+}
+
+func (s Service) TunnelSandbox(cfg TunnelSandboxConfig) (*SandboxTunnelResult, error) {
+	if err := validateSandboxKey(cfg.Key, "tunnel key"); err != nil {
+		return nil, err
+	}
+	var err error
+	cfg.Scheme, err = validateSandboxTunnelOptions(
+		cfg.TargetPort, cfg.LocalPort, cfg.Scheme, "sandbox", "local tunnel", true,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	sandbox, err := s.prepareSandboxOperation(sandboxOperationConfig{
+		RunID:           cfg.RunID,
+		Json:            cfg.Json,
+		RequireExisting: true,
+		SkipSync:        true,
+		LockWaitMessage: "Waiting for another sandbox operation to complete...",
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer sandbox.close()
+
+	startCommand := fmt.Sprintf("rwx sandbox background --key %s -- <command>", cfg.Key)
+	process, err := s.executeSandboxProcessDirective(sandboxDirectiveProcessStatus, struct {
+		Key string `json:"key"`
+	}{Key: cfg.Key}, "get status for")
+	if err != nil {
+		return nil, fmt.Errorf("unable to use background process %q: %w\n\nStart it with:\n  %s", cfg.Key, err, startCommand)
+	}
+	if process.Status != "running" {
+		return nil, fmt.Errorf(
+			"background process %q is not running (status: %s)\n\nStart it with:\n  %s",
+			cfg.Key, process.Status, startCommand,
+		)
+	}
+
+	stateDirectory, err := sandboxTunnelStateDirectory()
+	if err != nil {
+		return nil, err
+	}
+	tunnel, err := s.SSHTunnelManager.Open(rwxssh.TunnelConfig{
+		Key: cfg.Key, RunID: sandbox.runID, Address: sandbox.connectionInfo.Address,
+		PrivateUserKey: sandbox.connectionInfo.PrivateUserKey, PublicHostKey: sandbox.connectionInfo.PublicHostKey,
+		LocalPort: cfg.LocalPort, TargetPort: cfg.TargetPort, Scheme: cfg.Scheme, StateDirectory: stateDirectory,
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := &SandboxTunnelResult{
+		RunID:      sandbox.runID,
+		Key:        cfg.Key,
+		TargetPort: cfg.TargetPort,
+		LocalPort:  tunnel.LocalPort,
+		Scheme:     tunnel.Scheme,
+		URL:        fmt.Sprintf("%s://127.0.0.1:%d", tunnel.Scheme, tunnel.LocalPort),
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	portReadyDirectiveSupported := process.SupportsPortReadyCheck
+	for {
+		ready, directiveSupported, readyErr := s.sandboxPortReady(cfg.TargetPort, tunnel.LocalPort, portReadyDirectiveSupported)
+		if readyErr != nil {
+			return nil, readyErr
+		}
+		portReadyDirectiveSupported = directiveSupported
+		if ready {
+			break
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out waiting for sandbox port %d on %s; the tunnel is still running", cfg.TargetPort, result.URL)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	if !cfg.Json {
+		fmt.Fprintf(s.Stdout, "Tunnel %q: %s\n", cfg.Key, result.URL)
+	}
+	return result, nil
 }
 
 func (s Service) RestartSandboxBackground(cfg SandboxBackgroundConfig) (*SandboxBackgroundResult, error) {
@@ -866,26 +953,11 @@ func (s Service) finishSandboxBackground(sandbox *syncedSandbox, process sandbox
 		deadline := time.Now().Add(30 * time.Second)
 		portReadyDirectiveSupported := process.SupportsPortReadyCheck
 		for {
-			ready := false
-			if portReadyDirectiveSupported {
-				exitCode, readyErr := s.SSHClient.ExecuteCommand(fmt.Sprintf("%s %d", sandboxDirectivePortReady, process.TargetPort))
-				if readyErr != nil {
-					return nil, errors.Wrap(readyErr, "failed to check sandbox process port readiness")
-				}
-				switch exitCode {
-				case 0:
-					ready = true
-				case 1:
-					ready = false
-				case 127:
-					portReadyDirectiveSupported = false
-				default:
-					return nil, fmt.Errorf("sandbox agent failed to check port %d readiness (exit code %d)", process.TargetPort, exitCode)
-				}
+			ready, directiveSupported, readyErr := s.sandboxPortReady(process.TargetPort, tunnel.LocalPort, portReadyDirectiveSupported)
+			if readyErr != nil {
+				return nil, readyErr
 			}
-			if !portReadyDirectiveSupported {
-				ready = s.SSHTunnelManager.IsReady(tunnel.LocalPort)
-			}
+			portReadyDirectiveSupported = directiveSupported
 			if ready {
 				break
 			}
@@ -932,6 +1004,26 @@ func (s Service) finishSandboxBackground(sandbox *syncedSandbox, process sandbox
 	return result, nil
 }
 
+func (s Service) sandboxPortReady(targetPort, localPort int, directiveSupported bool) (bool, bool, error) {
+	if directiveSupported {
+		exitCode, _, _, err := s.SSHClient.ExecuteCommandWithSeparateOutput(fmt.Sprintf("%s %d", sandboxDirectivePortReady, targetPort))
+		if err != nil {
+			return false, directiveSupported, errors.Wrap(err, "failed to check sandbox port readiness")
+		}
+		switch exitCode {
+		case 0:
+			return true, true, nil
+		case 1:
+			return false, true, nil
+		case 127:
+			directiveSupported = false
+		default:
+			return false, directiveSupported, fmt.Errorf("sandbox agent failed to check port %d readiness (exit code %d)", targetPort, exitCode)
+		}
+	}
+	return s.SSHTunnelManager.IsReady(localPort), directiveSupported, nil
+}
+
 func sandboxBackgroundResult(runID string, process sandboxProcessResponse) *SandboxBackgroundResult {
 	return &SandboxBackgroundResult{
 		RunID: runID, Name: process.Key, Status: process.Status, TargetPort: process.TargetPort,
@@ -942,20 +1034,50 @@ func sandboxBackgroundResult(runID string, process sandboxProcessResponse) *Sand
 }
 
 func validateSandboxBackgroundName(name string) error {
-	if name == "" {
-		return fmt.Errorf("background process name is required")
+	return validateSandboxKey(name, "background process name")
+}
+
+func validateSandboxKey(key, description string) error {
+	if key == "" {
+		return fmt.Errorf("%s is required", description)
 	}
-	if len(name) > sandboxBackgroundNameSizeLimit {
-		return fmt.Errorf("background process name must be at most %d bytes", sandboxBackgroundNameSizeLimit)
+	if len(key) > sandboxBackgroundNameSizeLimit {
+		return fmt.Errorf("%s must be at most %d bytes", description, sandboxBackgroundNameSizeLimit)
 	}
-	for _, char := range name {
+	for _, char := range key {
 		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
 			(char >= '0' && char <= '9') || char == '-' || char == '_' {
 			continue
 		}
-		return fmt.Errorf("background process name may contain only letters, numbers, underscores, and hyphens")
+		return fmt.Errorf("%s may contain only letters, numbers, underscores, and hyphens", description)
 	}
 	return nil
+}
+
+func validateSandboxTunnelOptions(
+	targetPort, localPort int,
+	scheme, targetDescription, localDescription string,
+	requireTargetPort bool,
+) (string, error) {
+	if targetPort < 0 || targetPort > 65535 || (requireTargetPort && targetPort == 0) {
+		return "", fmt.Errorf("%s port must be between 1 and 65535", targetDescription)
+	}
+	if localPort < 0 || localPort > 65535 {
+		return "", fmt.Errorf("%s port must be between 1 and 65535", localDescription)
+	}
+	if localPort != 0 && targetPort == 0 {
+		return "", fmt.Errorf("--local-port requires --port")
+	}
+	if scheme != "" && targetPort == 0 {
+		return "", fmt.Errorf("--scheme requires --port")
+	}
+	if targetPort != 0 && scheme == "" {
+		scheme = "http"
+	}
+	if scheme != "" && scheme != "http" && scheme != "https" {
+		return "", fmt.Errorf("--scheme must be http or https")
+	}
+	return scheme, nil
 }
 
 func sandboxTunnelStateDirectory() (string, error) {

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -1307,25 +1307,19 @@ func TestService_BackgroundSandbox(t *testing.T) {
 			return false
 		}
 		readyChecks := 0
-		setup.mockSSH.MockExecuteCommand = func(command string) (int, error) {
-			*commands = append(*commands, command)
-			if strings.HasPrefix(command, "__rwx_sandbox_port_ready__ ") {
-				readyChecks++
-				if readyChecks == 1 {
-					return 1, nil
-				}
-
-				return 0, nil
-			}
-
-			return 0, nil
-		}
 		setup.mockSSH.MockExecuteCommandWithSeparateOutput = func(command string) (int, string, string, error) {
 			switch {
 			case strings.HasPrefix(command, "__rwx_sandbox_process_start__ "):
 				return 0, `{"key":"web","status":"running","supportsPortReadyCheck":true,"targetPort":3100}`, "", nil
 			case strings.HasPrefix(command, "__rwx_sandbox_process_status__ "):
 				return 0, `{"key":"web","status":"running","targetPort":3100}`, "", nil
+			case strings.HasPrefix(command, "__rwx_sandbox_port_ready__ "):
+				*commands = append(*commands, command)
+				readyChecks++
+				if readyChecks == 1 {
+					return 1, "", "", nil
+				}
+				return 0, "", "", nil
 			default:
 				return 0, "", "", nil
 			}
@@ -1614,6 +1608,158 @@ rwx sandbox exec -- <command> syncs local changes before it runs.
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "No active sandbox found")
 		require.Contains(t, err.Error(), "rwx sandbox start")
+	})
+}
+
+func TestService_TunnelSandbox(t *testing.T) {
+	setupTunnel := func(t *testing.T) (*testSetup, *[]string) {
+		t.Helper()
+		setup := setupTest(t)
+		setup.mockGit.MockGetHeadError = fmt.Errorf("git should not be consulted")
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(id, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(string, ssh.ClientConfig) error { return nil }
+		commands := []string{}
+		setup.mockSSH.MockExecuteCommand = func(command string) (int, error) {
+			commands = append(commands, command)
+			return 0, nil
+		}
+		setup.mockSSH.MockExecuteCommandWithOutput = func(command string) (int, string, error) {
+			commands = append(commands, command)
+			if strings.HasPrefix(command, "__rwx_sandbox_process_status__ ") {
+				return 0, `{"key":"web","status":"running","supportsPortReadyCheck":true}`, nil
+			}
+			return 0, "", nil
+		}
+		return setup, &commands
+	}
+
+	t.Run("opens a named tunnel for a running managed process without mutating it", func(t *testing.T) {
+		setup, commands := setupTunnel(t)
+		var tunnelConfig rwxssh.TunnelConfig
+		setup.mockTunnel.MockOpen = func(cfg rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
+			tunnelConfig = cfg
+			return rwxssh.TunnelResult{LocalPort: 8301, Scheme: cfg.Scheme}, nil
+		}
+
+		result, err := setup.service.TunnelSandbox(cli.TunnelSandboxConfig{
+			Key:        "web",
+			TargetPort: 3001,
+			LocalPort:  8301,
+			Scheme:     "https",
+			RunID:      "run-sandbox",
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "run-sandbox", result.RunID)
+		require.Equal(t, "web", result.Key)
+		require.Equal(t, 3001, result.TargetPort)
+		require.Equal(t, 8301, result.LocalPort)
+		require.Equal(t, "https", result.Scheme)
+		require.Equal(t, "https://127.0.0.1:8301", result.URL)
+		require.Equal(t, "web", tunnelConfig.Key)
+		require.Equal(t, "run-sandbox", tunnelConfig.RunID)
+		require.Equal(t, "192.168.1.1:22", tunnelConfig.Address)
+		require.Equal(t, 3001, tunnelConfig.TargetPort)
+		require.Equal(t, 8301, tunnelConfig.LocalPort)
+		require.Equal(t, "https", tunnelConfig.Scheme)
+		require.Contains(t, *commands, "__rwx_sandbox_port_ready__ 3001")
+		require.True(t, slices.ContainsFunc(*commands, func(command string) bool {
+			return strings.HasPrefix(command, "__rwx_sandbox_process_status__ ")
+		}))
+		for _, command := range *commands {
+			require.NotContains(t, command, "checkout -f")
+			require.NotContains(t, command, "__rwx_sandbox_process_start__")
+			require.NotContains(t, command, "__rwx_sandbox_process_restart__")
+			require.NotContains(t, command, "__rwx_sandbox_process_stop__")
+		}
+	})
+
+	t.Run("falls back to local tunnel readiness when the process lacks sandbox-side support", func(t *testing.T) {
+		setup, commands := setupTunnel(t)
+		setup.mockSSH.MockExecuteCommandWithOutput = func(command string) (int, string, error) {
+			*commands = append(*commands, command)
+			if strings.HasPrefix(command, "__rwx_sandbox_process_status__ ") {
+				return 0, `{"key":"web","status":"running"}`, nil
+			}
+			return 0, "", nil
+		}
+		setup.mockTunnel.MockOpen = func(cfg rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
+			return rwxssh.TunnelResult{LocalPort: 8301, Scheme: cfg.Scheme}, nil
+		}
+		localReadyChecks := 0
+		setup.mockTunnel.MockIsReady = func(localPort int) bool {
+			localReadyChecks++
+			return true
+		}
+
+		_, err := setup.service.TunnelSandbox(cli.TunnelSandboxConfig{
+			Key: "web", TargetPort: 3001, RunID: "run-sandbox", Json: true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 1, localReadyChecks)
+	})
+
+	t.Run("explains how to start a missing managed process", func(t *testing.T) {
+		setup, _ := setupTunnel(t)
+		setup.mockSSH.MockExecuteCommandWithSeparateOutput = func(command string) (int, string, string, error) {
+			if strings.HasPrefix(command, "__rwx_sandbox_process_status__ ") {
+				return 1, "", `sandbox process "missing" was not found`, nil
+			}
+			return 0, "", "", nil
+		}
+		setup.mockTunnel.MockOpen = func(rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
+			require.Fail(t, "a missing process must not open a tunnel")
+			return rwxssh.TunnelResult{}, nil
+		}
+
+		_, err := setup.service.TunnelSandbox(cli.TunnelSandboxConfig{
+			Key: "missing", TargetPort: 3001, RunID: "run-sandbox", Json: true,
+		})
+
+		require.ErrorContains(t, err, `unable to use background process "missing"`)
+		require.ErrorContains(t, err, `sandbox process "missing" was not found`)
+		require.ErrorContains(t, err, "Start it with:\n  rwx sandbox background --key missing -- <command>")
+	})
+
+	t.Run("does not tunnel to a stopped managed process", func(t *testing.T) {
+		setup, commands := setupTunnel(t)
+		setup.mockSSH.MockExecuteCommandWithOutput = func(command string) (int, string, error) {
+			*commands = append(*commands, command)
+			if strings.HasPrefix(command, "__rwx_sandbox_process_status__ ") {
+				return 0, `{"key":"web","status":"stopped"}`, nil
+			}
+			return 0, "", nil
+		}
+		setup.mockTunnel.MockOpen = func(rwxssh.TunnelConfig) (rwxssh.TunnelResult, error) {
+			require.Fail(t, "a stopped process must not open a tunnel")
+			return rwxssh.TunnelResult{}, nil
+		}
+
+		_, err := setup.service.TunnelSandbox(cli.TunnelSandboxConfig{
+			Key: "web", TargetPort: 3001, RunID: "run-sandbox", Json: true,
+		})
+
+		require.ErrorContains(t, err, `background process "web" is not running (status: stopped)`)
+		require.ErrorContains(t, err, "Start it with:\n  rwx sandbox background --key web -- <command>")
+	})
+
+	t.Run("validates the tunnel key and sandbox port", func(t *testing.T) {
+		setup := setupTest(t)
+
+		_, err := setup.service.TunnelSandbox(cli.TunnelSandboxConfig{Key: "../web", TargetPort: 3000})
+		require.EqualError(t, err, "tunnel key may contain only letters, numbers, underscores, and hyphens")
+
+		_, err = setup.service.TunnelSandbox(cli.TunnelSandboxConfig{Key: "web"})
+		require.EqualError(t, err, "sandbox port must be between 1 and 65535")
 	})
 }
 

--- a/test/integration/sandbox-configured-background.sh
+++ b/test/integration/sandbox-configured-background.sh
@@ -15,6 +15,48 @@ trap stop_sandbox EXIT
 "${RWX_CLI}" sandbox exec --id "$SANDBOX_RUN_ID" -- \
   python3 -c 'import urllib.request; assert urllib.request.urlopen("http://127.0.0.1:3001", timeout=10).status == 200'
 
+if missing_tunnel_output=$("${RWX_CLI}" sandbox tunnel \
+  --id "$SANDBOX_RUN_ID" \
+  --key missing-web \
+  --port 3001 2>&1); then
+  echo "tunneling to a missing background process unexpectedly succeeded"
+  exit 1
+fi
+
+if [[ "$missing_tunnel_output" != *"rwx sandbox background --key missing-web -- <command>"* ]]; then
+  echo "missing background process error did not explain how to start one"
+  echo "$missing_tunnel_output"
+  exit 1
+fi
+
+configured_tunnel_result=$("${RWX_CLI}" sandbox tunnel \
+  --id "$SANDBOX_RUN_ID" \
+  --key "$configured_name" \
+  --port 3001 \
+  --json)
+configured_tunnel_url=$(echo "$configured_tunnel_result" | jq -r '.URL')
+
+if [ -z "$configured_tunnel_url" ] || [ "$configured_tunnel_url" = "null" ]; then
+  echo "configured background tunnel did not return a URL"
+  echo "$configured_tunnel_result"
+  exit 1
+fi
+
+curl --fail --silent --show-error --max-time 10 "$configured_tunnel_url" >/dev/null
+
+reattached_tunnel_url=$("${RWX_CLI}" sandbox tunnel \
+  --id "$SANDBOX_RUN_ID" \
+  --key "$configured_name" \
+  --port 3001 \
+  --json | jq -r '.URL')
+
+if [ "$reattached_tunnel_url" != "$configured_tunnel_url" ]; then
+  echo "reopening configured background tunnel changed its URL"
+  echo "before: $configured_tunnel_url"
+  echo "after:  $reattached_tunnel_url"
+  exit 1
+fi
+
 configured_logs=""
 for _ in {1..30}; do
   configured_logs=$("${RWX_CLI}" sandbox background logs \
@@ -28,6 +70,12 @@ done
 
 if [[ "$configured_logs" != *"$configured_log_marker"* ]]; then
   echo "configured background logs did not include the startup marker"
+  echo "$configured_logs"
+  exit 1
+fi
+
+if [ "$(grep -c "$configured_log_marker" <<< "$configured_logs" || true)" -ne 1 ]; then
+  echo "opening a tunnel unexpectedly restarted the configured background process"
   echo "$configured_logs"
   exit 1
 fi


### PR DESCRIPTION
`rwx sandbox background --key <key> --port <port> -- <command>` starts or restarts a sandbox background process and opens a local tunnel in one command. However, when writing documentation it occurred to me there wasn't a way to add a tunnel after the fact.

Some projects will have a stable enough start-up they may want to predefine the background process. Similarly, you may want to start an adhoc process and only later expose it over the tunnel.

This PR adds support for this via `rwx sandbox tunnel --key <key> --port <port>`. I expect this to be a point of extension going forward.