### PR TITLE
Use ref pattern instead of branch pattern in help text

### DIFF
--- a/cmd/rwx/vaults.go
+++ b/cmd/rwx/vaults.go
@@ -246,7 +246,7 @@ func init() {
 	vaultsCreateCmd.Flags().StringVar(&createVaultName, "name", "", "the name of the vault to create")
 	_ = vaultsCreateCmd.MarkFlagRequired("name")
 	vaultsCreateCmd.Flags().BoolVar(&createVaultUnlocked, "unlocked", false, "whether the vault should be unlocked")
-	vaultsCreateCmd.Flags().StringSliceVar(&createVaultRepoPerms, "repository-permission", nil, "repository permission in the format REPO_SLUG:BRANCH_PATTERN (repeatable)")
+	vaultsCreateCmd.Flags().StringSliceVar(&createVaultRepoPerms, "repository-permission", nil, "repository permission in the format REPO_SLUG:REF_PATTERN (repeatable)")
 	vaultsCmd.AddCommand(vaultsCreateCmd)
 
 	// vaults secrets set

--- a/internal/cli/service_vaults.go
+++ b/internal/cli/service_vaults.go
@@ -23,7 +23,7 @@ func (c CreateVaultConfig) Validate() error {
 
 	for _, rp := range c.RepositoryPermissions {
 		if !strings.Contains(rp, ":") {
-			return errors.New(fmt.Sprintf("invalid repository permission %q: must be in the format REPO_SLUG:BRANCH_PATTERN", rp))
+			return errors.New(fmt.Sprintf("invalid repository permission %q: must be in the format REPO_SLUG:REF_PATTERN", rp))
 		}
 	}
 

--- a/internal/cli/service_vaults_test.go
+++ b/internal/cli/service_vaults_test.go
@@ -53,18 +53,20 @@ func TestService_CreateVault(t *testing.T) {
 		s.mockAPI.MockCreateVault = func(cfg api.CreateVaultConfig) (*api.CreateVaultResult, error) {
 			require.Equal(t, "my-vault", cfg.Name)
 			require.True(t, cfg.Unlocked)
-			require.Len(t, cfg.RepositoryPermissions, 2)
+			require.Len(t, cfg.RepositoryPermissions, 3)
 			require.Equal(t, "my-repo", cfg.RepositoryPermissions[0].RepositorySlug)
 			require.Equal(t, "main", cfg.RepositoryPermissions[0].BranchPattern)
 			require.Equal(t, "other-repo", cfg.RepositoryPermissions[1].RepositorySlug)
-			require.Equal(t, "release/*", cfg.RepositoryPermissions[1].BranchPattern)
+			require.Equal(t, "refs/heads/release/*", cfg.RepositoryPermissions[1].BranchPattern)
+			require.Equal(t, "tagged-repo", cfg.RepositoryPermissions[2].RepositorySlug)
+			require.Equal(t, "refs/tags/v*", cfg.RepositoryPermissions[2].BranchPattern)
 			return &api.CreateVaultResult{}, nil
 		}
 
 		result, err := s.service.CreateVault(cli.CreateVaultConfig{
 			Name:                  "my-vault",
 			Unlocked:              true,
-			RepositoryPermissions: []string{"my-repo:main", "other-repo:release/*"},
+			RepositoryPermissions: []string{"my-repo:main", "other-repo:refs/heads/release/*", "tagged-repo:refs/tags/v*"},
 		})
 
 		require.NoError(t, err)
@@ -81,7 +83,7 @@ func TestService_CreateVault(t *testing.T) {
 
 		require.Nil(t, result)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "REPO_SLUG:BRANCH_PATTERN")
+		require.Contains(t, err.Error(), "REPO_SLUG:REF_PATTERN")
 	})
 
 	t.Run("validates name is required", func(t *testing.T) {


### PR DESCRIPTION
Seems like this may have unnecessarily confused a customer's agent into thinking vault repository permissions didn't work with their tag based workflow.