### PR TITLE
Add jj run patching and sandbox support

### DIFF
--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -65,21 +65,9 @@ tasks:
       git lfs install --skip-repo
 
   - key: jj
-    run: |
-      case "$(uname -m)" in
-        x86_64) jj_arch=x86_64 ;;
-        aarch64 | arm64) jj_arch=aarch64 ;;
-        *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
-      esac
-
-      jj_version="${{ tasks.tool-versions.values.jj }}"
-      jj_dir="$(mktemp -d)"
-      curl -sSfL "https://github.com/jj-vcs/jj/releases/download/v${jj_version}/jj-v${jj_version}-${jj_arch}-unknown-linux-musl.tar.gz" \
-        | tar -xz -C "$jj_dir"
-      sudo install -m 0755 "$jj_dir/jj" /usr/local/bin/jj
-      rm -rf "$jj_dir"
-
-      jj --version
+    call: jj/install 1.0.0
+    with:
+      version: ${{ tasks.tool-versions.values.jj }}
 
   - key: lsp-code
     call: git/clone 2.1.0

--- a/.rwx/ci.yml
+++ b/.rwx/ci.yml
@@ -64,6 +64,23 @@ tasks:
 
       git lfs install --skip-repo
 
+  - key: jj
+    run: |
+      case "$(uname -m)" in
+        x86_64) jj_arch=x86_64 ;;
+        aarch64 | arm64) jj_arch=aarch64 ;;
+        *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+      esac
+
+      jj_version="${{ tasks.tool-versions.values.jj }}"
+      jj_dir="$(mktemp -d)"
+      curl -sSfL "https://github.com/jj-vcs/jj/releases/download/v${jj_version}/jj-v${jj_version}-${jj_arch}-unknown-linux-musl.tar.gz" \
+        | tar -xz -C "$jj_dir"
+      sudo install -m 0755 "$jj_dir/jj" /usr/local/bin/jj
+      rm -rf "$jj_dir"
+
+      jj --version
+
   - key: lsp-code
     call: git/clone 2.1.0
     with:
@@ -85,7 +102,7 @@ tasks:
     run: cp ${{ tasks.lsp-build.tasks.build.artifacts.bundle }} internal/lsp/bundle/server.js
 
   - key: unit-tests
-    use: [go-deps, rwx-cli, gotestsum, git]
+    use: [go-deps, rwx-cli, gotestsum, git, jj]
     run: |
       gotestsum \
         --jsonfile tmp/go-test.json \

--- a/.rwx/integration-sandbox.yml
+++ b/.rwx/integration-sandbox.yml
@@ -55,6 +55,23 @@ tasks:
 
       git lfs install --skip-repo
 
+  - key: jj
+    run: |
+      case "$(uname -m)" in
+        x86_64) jj_arch=x86_64 ;;
+        aarch64 | arm64) jj_arch=aarch64 ;;
+        *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+      esac
+
+      jj_version="${{ tasks.tool-versions.values.jj }}"
+      jj_dir="$(mktemp -d)"
+      curl -sSfL "https://github.com/jj-vcs/jj/releases/download/v${jj_version}/jj-v${jj_version}-${jj_arch}-unknown-linux-musl.tar.gz" \
+        | tar -xz -C "$jj_dir"
+      sudo install -m 0755 "$jj_dir/jj" /usr/local/bin/jj
+      rm -rf "$jj_dir"
+
+      jj --version
+
   - key: lsp-code
     call: git/clone 2.1.0
     with:
@@ -90,7 +107,7 @@ tasks:
         fi
         printf '%s\n' \
           "- key: ${key}" \
-          "  use: [rwx-cli, git]" \
+          "  use: [rwx-cli, git, jj]" \
           "  run: ./${script}" \
           "  env:" \
           '    RWX_ACCESS_TOKEN: \${{ vaults.rwx_cli_development.service-accounts.rwx-cli-ci.token }}' \

--- a/.rwx/integration-sandbox.yml
+++ b/.rwx/integration-sandbox.yml
@@ -56,21 +56,9 @@ tasks:
       git lfs install --skip-repo
 
   - key: jj
-    run: |
-      case "$(uname -m)" in
-        x86_64) jj_arch=x86_64 ;;
-        aarch64 | arm64) jj_arch=aarch64 ;;
-        *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
-      esac
-
-      jj_version="${{ tasks.tool-versions.values.jj }}"
-      jj_dir="$(mktemp -d)"
-      curl -sSfL "https://github.com/jj-vcs/jj/releases/download/v${jj_version}/jj-v${jj_version}-${jj_arch}-unknown-linux-musl.tar.gz" \
-        | tar -xz -C "$jj_dir"
-      sudo install -m 0755 "$jj_dir/jj" /usr/local/bin/jj
-      rm -rf "$jj_dir"
-
-      jj --version
+    call: jj/install 1.0.0
+    with:
+      version: ${{ tasks.tool-versions.values.jj }}
 
   - key: lsp-code
     call: git/clone 2.1.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,4 +2,4 @@ golang 1.26.4
 golangci-lint 2.12.2
 ginkgo 2.32.0
 nodejs 24.18.0
-jj 0.44.0
+jj 0.45.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,4 @@ golang 1.26.4
 golangci-lint 2.12.2
 ginkgo 2.32.0
 nodejs 24.18.0
+jj 0.44.0

--- a/cmd/rwx/results.go
+++ b/cmd/rwx/results.go
@@ -141,10 +141,8 @@ list of JSON fields, see https://rwx.com/docs/results or run:
 				fmt.Println(string(resultJson))
 			} else {
 				if runIDFromGit && ResultsBranch == "" && ResultsRepo == "" && result.Commit != "" {
-					if head := service.VCSClient.GetHead(); head != "" {
-						if note := vcs.CommitMismatchNote(head, result.Commit); note != "" {
-							fmt.Println(note)
-						}
+					if note := CommitDriftNote(service.VCSClient, result.Commit); note != "" {
+						fmt.Println(note)
 					}
 				}
 				if result.TaskURL != "" {
@@ -206,6 +204,16 @@ func handleResultsTaskKeyError(err error) error {
 	}
 
 	return err
+}
+
+// CommitDriftNote warns when the branch's latest run was not made from the last
+// local commit.
+func CommitDriftNote(client vcs.Client, runCommit string) string {
+	last, err := client.GetLastCommit()
+	if err != nil || last == "" {
+		return ""
+	}
+	return vcs.CommitMismatchNote(last, runCommit)
 }
 
 func HandleAmbiguousDefinitionPathError(err error, branch, repo string) error {

--- a/cmd/rwx/results_test.go
+++ b/cmd/rwx/results_test.go
@@ -6,6 +6,7 @@ import (
 	rwx "github.com/rwx-cloud/rwx/cmd/rwx"
 	"github.com/rwx-cloud/rwx/internal/api"
 	"github.com/rwx-cloud/rwx/internal/errors"
+	"github.com/rwx-cloud/rwx/internal/mocks"
 	"github.com/stretchr/testify/require"
 )
 
@@ -147,5 +148,27 @@ func TestMergeEnrichedResults(t *testing.T) {
 		merged := rwx.MergeEnrichedResults(base, map[string]any{})
 
 		require.Equal(t, map[string]any{"RunID": "abc123", "ResultStatus": "failed"}, merged)
+	})
+}
+
+func TestCommitDriftNote(t *testing.T) {
+	const runCommit = "1111111111111111111111111111111111111111"
+	const local = "2222222222222222222222222222222222222222"
+
+	t.Run("is silent when the run was made from the last commit", func(t *testing.T) {
+		client := &mocks.VCS{MockGetLastCommit: runCommit}
+		require.Empty(t, rwx.CommitDriftNote(client, runCommit))
+	})
+
+	t.Run("warns when the last commit differs from the run's", func(t *testing.T) {
+		client := &mocks.VCS{MockGetLastCommit: local}
+		note := rwx.CommitDriftNote(client, runCommit)
+		require.Contains(t, note, "you're currently on commit "+local[:7])
+		require.Contains(t, note, "was for commit "+runCommit[:7])
+	})
+
+	t.Run("is silent when the last commit cannot be resolved", func(t *testing.T) {
+		require.Empty(t, rwx.CommitDriftNote(&mocks.VCS{}, runCommit))
+		require.Empty(t, rwx.CommitDriftNote(&mocks.VCS{MockGetLastCommitError: errors.New("nope")}, runCommit))
 	})
 }

--- a/internal/cli/sandbox_storage.go
+++ b/internal/cli/sandbox_storage.go
@@ -360,7 +360,7 @@ func (s *SandboxStorage) AllSessions() map[string]SandboxSession {
 
 // BranchLocator reports the current position in a repository: a branch name
 // when there is one, and otherwise a short stable identifier for the anonymous
-// position, as on a detached HEAD.
+// position (a detached HEAD under git, no bookmark at or below @ under jj).
 type BranchLocator interface {
 	GetBranch() string
 	GetShortHead() string

--- a/internal/cli/service_run.go
+++ b/internal/cli/service_run.go
@@ -185,8 +185,8 @@ func (s Service) InitiateRun(cfg InitiateRunConfig) (*api.InitiateRunResult, err
 			originUrl = s.VCSClient.GetOriginUrl()
 		}
 	} else if !vcsInstalled {
-		// Name the executable the backend reports missing rather than assuming
-		// git, since a backend may depend on more than one.
+		// Name the executable that's actually missing: the jj backend shells out
+		// to git for the object store, so either one can be the culprit.
 		errorMessage = fmt.Sprintf("%s is not installed", missingDependency)
 	} else if !insideRepository {
 		errorMessage = "You are not in a source code repository"

--- a/internal/cli/service_run_patch_test.go
+++ b/internal/cli/service_run_patch_test.go
@@ -159,7 +159,7 @@ func TestService_InitiatingRunPatch(t *testing.T) {
 
 	t.Run("when the backend names a different missing dependency", func(t *testing.T) {
 		s := setupTest(t)
-		s.mockVCS.MockMissingDependency = "some-vcs"
+		s.mockVCS.MockMissingDependency = "jj"
 		s.mockVCS.MockIsInsideWorkTree = false
 
 		rwxDir := filepath.Join(s.tmp, ".rwx")
@@ -177,7 +177,7 @@ func TestService_InitiatingRunPatch(t *testing.T) {
 		}
 		s.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
 			require.False(t, cfg.Patch.GitInstalled)
-			require.Equal(t, "some-vcs is not installed", cfg.Patch.ErrorMessage)
+			require.Equal(t, "jj is not installed", cfg.Patch.ErrorMessage)
 			return &api.InitiateRunResult{
 				RunID:  "785ce4e8-17b9-4c8b-8869-a55e95adffe7",
 				RunURL: "https://cloud.rwx.com/mint/rwx/runs/785ce4e8-17b9-4c8b-8869-a55e95adffe7",

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -1090,10 +1090,10 @@ func (s Service) prepareSandboxOperation(cfg sandboxOperationConfig) (*syncedSan
 	}
 	branch := GetCurrentBranch(s.VCSClient)
 
-	var localHeadForSync string
+	// Fail before a sandbox is selected or created when there is nothing to
+	// push. The head itself is resolved again at sync time.
 	if !cfg.SkipSync {
-		localHeadForSync, err = s.VCSClient.GetHeadCommit()
-		if err != nil {
+		if _, err := s.VCSClient.GetHeadCommit(); err != nil {
 			return nil, errors.Wrap(err, "sandbox push requires a repository with a resolvable working copy")
 		}
 	}
@@ -1441,7 +1441,7 @@ func (s Service) prepareSandboxOperation(cfg sandboxOperationConfig) (*syncedSan
 
 	// Sync local changes to sandbox.
 	syncPushStart := time.Now()
-	patchBytes, err := s.syncLocalChangesToSandbox(cfg.Json, isNewSandbox, localHeadForSync, connInfo)
+	patchBytes, err := s.syncLocalChangesToSandbox(cfg.Json, isNewSandbox, connInfo)
 	result.syncPushMs = time.Since(syncPushStart).Milliseconds()
 	result.syncPushPatchBytes = patchBytes
 	if err != nil {
@@ -2069,7 +2069,14 @@ func (s Service) pullChangesFromSandbox(cwd string, jsonMode bool) ([]string, in
 	return files, patchBytes, nil
 }
 
-func (s Service) syncLocalChangesToSandbox(jsonMode bool, isNewSandbox bool, localHead string, connInfo *api.SandboxConnectionInfo) (int, error) {
+func (s Service) syncLocalChangesToSandbox(jsonMode bool, isNewSandbox bool, connInfo *api.SandboxConnectionInfo) (int, error) {
+	// Booting a sandbox or waiting on its lock can take minutes, and under jj
+	// every edit in that window rewrites @, so resolve the head now rather than
+	// pinning the sandbox to a working copy the user has moved past.
+	localHead, err := s.VCSClient.GetHeadCommit()
+	if err != nil {
+		return 0, errors.Wrap(err, "sandbox push requires a repository with a resolvable working copy")
+	}
 	if localHead == "" {
 		return 0, fmt.Errorf("sandbox push requires a repository with a resolvable working copy")
 	}

--- a/internal/cli/service_sandbox.go
+++ b/internal/cli/service_sandbox.go
@@ -2180,7 +2180,7 @@ func (s Service) syncLocalChangesToSandbox(jsonMode bool, isNewSandbox bool, con
 		return patchBytes, syncPushErr
 	}
 
-	if err := s.snapshotSandboxSyncRefForExec(isNewSandbox, patches.Files); err != nil {
+	if err := s.snapshotSandboxSyncRef(isNewSandbox, patches.Files); err != nil {
 		syncPushErr = err
 		return patchBytes, syncPushErr
 	}
@@ -2507,31 +2507,25 @@ func (s Service) applyPatchToSandbox(command string, patch []byte) error {
 	return nil
 }
 
-// snapshotSandboxSyncRefForExec records the post-sync baseline. A new sandbox
-// stages only local dirty paths so server pre-applied files aren't baked into
-// the baseline; a reused sandbox already matches local state.
-func (s Service) snapshotSandboxSyncRefForExec(isNewSandbox bool, paths []string) error {
+// snapshotSandboxSyncRef records the baseline a later pull diffs against. A
+// reused sandbox already matches local state. A new sandbox may hold files its
+// setup tasks created, so only the local dirty paths are staged; with none,
+// which is always the case under jj, the baseline is the checked-out tree.
+func (s Service) snapshotSandboxSyncRef(isNewSandbox bool, localPaths []string) error {
+	stage := "/usr/bin/git add -A && "
 	if isNewSandbox {
-		return s.snapshotSandboxSyncRefForPaths(paths)
-	}
-	return s.snapshotSandboxSyncRef()
-}
-
-func (s Service) snapshotSandboxSyncRef() error {
-	return s.snapshotSandboxSyncRefForPaths(nil)
-}
-
-func (s Service) snapshotSandboxSyncRefForPaths(paths []string) error {
-	script := `index_tree=$(/usr/bin/git write-tree) || exit 1; /usr/bin/git update-ref -d refs/rwx-sync 2>/dev/null || true; `
-	if len(paths) > 0 {
-		quoted := make([]string, len(paths))
-		for i, path := range paths {
-			quoted[i] = quoteShellArg(path)
+		stage = ""
+		if len(localPaths) > 0 {
+			quoted := make([]string, len(localPaths))
+			for i, path := range localPaths {
+				quoted[i] = quoteShellArg(path)
+			}
+			stage = "/usr/bin/git update-index --add --remove -- " + strings.Join(quoted, " ") + " && "
 		}
-		script += "/usr/bin/git update-index --add --remove -- " + strings.Join(quoted, " ") + " && "
-	} else if paths == nil {
-		script += "/usr/bin/git add -A && "
 	}
+
+	script := `index_tree=$(/usr/bin/git write-tree) || exit 1; /usr/bin/git update-ref -d refs/rwx-sync 2>/dev/null || true; `
+	script += stage
 	script += `/usr/bin/git -c user.name=rwx -c user.email=rwx -c core.hooksPath=/dev/null commit --allow-empty --no-verify -m rwx-sync >/dev/null 2>&1 && /usr/bin/git update-ref refs/rwx-sync HEAD && /usr/bin/git reset --mixed HEAD~1 >/dev/null 2>&1 && /usr/bin/git read-tree "$index_tree"`
 
 	_, _ = s.SSHClient.ExecuteCommand("__rwx_sandbox_sync_start__")

--- a/internal/cli/service_sandbox_test.go
+++ b/internal/cli/service_sandbox_test.go
@@ -3006,6 +3006,97 @@ func TestService_ExecSandbox_Sync(t *testing.T) {
 		require.NotContains(t, order[snapshotIndex], "/usr/bin/git add -A &&")
 	})
 
+	// The jj shape: the working copy is pushed as a commit with no dirty patch,
+	// so the baseline is the checked-out tree and the pushed commit is the one
+	// the working copy holds now.
+	t.Run("new sandbox with no dirty paths syncs the head resolved at sync time and stages nothing", func(t *testing.T) {
+		setup := setupTest(t)
+
+		configFile := setup.absConfig(".rwx/sandbox.yml")
+		require.NoError(t, os.WriteFile(configFile, []byte("base:\n  image: ubuntu:24.04\ntasks:\n  - key: sandbox\n    run: rwx-sandbox\n"), 0o644))
+		staleHead := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		currentHead := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+		headCalls := 0
+		setup.mockVCS.MockGetHeadCommit = func() (string, error) {
+			headCalls++
+			if headCalls == 1 {
+				return staleHead, nil
+			}
+			return currentHead, nil
+		}
+		setup.mockVCS.MockGetBranch = "feature/new-sandbox"
+		setup.mockVCS.MockGetCommit = "base"
+		setup.mockVCS.MockGetOriginUrl = "git@github.com:example/repo.git"
+		setup.mockVCS.MockGeneratePatchFile = vcs.PatchFile{}
+
+		setup.mockAPI.MockListSandboxRuns = func() (*api.ListSandboxRunsResult, error) {
+			return &api.ListSandboxRunsResult{Runs: []api.RunSummary{}}, nil
+		}
+		setup.mockAPI.MockInitiateRun = func(cfg api.InitiateRunConfig) (*api.InitiateRunResult, error) {
+			return &api.InitiateRunResult{
+				RunID:  "run-new",
+				RunURL: "https://cloud.rwx.com/runs/run-new",
+			}, nil
+		}
+		setup.mockAPI.MockCreateSandboxToken = func(cfg api.CreateSandboxTokenConfig) (*api.CreateSandboxTokenResult, error) {
+			return &api.CreateSandboxTokenResult{Token: "new-token"}, nil
+		}
+		setup.mockAPI.MockGetPackageVersions = func() (*api.PackageVersionsResult, error) {
+			return &api.PackageVersionsResult{}, nil
+		}
+		setup.mockAPI.MockGetSandboxConnectionInfo = func(runID, token string) (api.SandboxConnectionInfo, error) {
+			return api.SandboxConnectionInfo{
+				Sandboxable:    true,
+				Address:        "192.168.1.1:22",
+				PrivateUserKey: sandboxPrivateTestKey,
+				PublicHostKey:  sandboxPublicTestKey,
+			}, nil
+		}
+		setup.mockSSH.MockConnect = func(addr string, _ ssh.ClientConfig) error { return nil }
+
+		var order []string
+		setup.mockSSH.MockExecuteCommand = func(cmd string) (int, error) {
+			switch {
+			case strings.Contains(cmd, "rev-parse --verify -q refs/rwx-sync"):
+				return 1, nil
+			case strings.Contains(cmd, "cat-file -e"):
+				return 0, nil
+			}
+			order = append(order, cmd)
+			return 0, nil
+		}
+		setup.mockSSH.MockExecuteCommandWithOutput = func(cmd string) (int, string, error) {
+			return 0, "", nil
+		}
+		setup.mockSSH.MockExecuteCommandWithStdinAndCombinedOutput = func(command string, stdin io.Reader) (int, string, error) {
+			order = append(order, command)
+			return 0, "", nil
+		}
+
+		result, err := setup.service.ExecSandbox(cli.ExecSandboxConfig{
+			ConfigFile: configFile,
+			Command:    []string{"true"},
+			Json:       true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "run-new", result.RunID)
+		require.GreaterOrEqual(t, headCalls, 2, "the head must be resolved again once the sandbox is ready")
+
+		checkoutIndex := sandboxCommandIndex(order, "checkout -f")
+		require.NotEqual(t, -1, checkoutIndex)
+		require.Contains(t, order[checkoutIndex], currentHead)
+		require.NotContains(t, order[checkoutIndex], staleHead)
+
+		require.Equal(t, -1, sandboxCommandIndex(order, "/usr/bin/git apply"), "nothing to apply without dirty patches")
+
+		snapshotIndex := sandboxCommandIndex(order, "update-ref refs/rwx-sync HEAD")
+		require.NotEqual(t, -1, snapshotIndex)
+		require.NotContains(t, order[snapshotIndex], "/usr/bin/git add -A", "setup-created files must stay out of the baseline")
+		require.NotContains(t, order[snapshotIndex], "/usr/bin/git update-index")
+	})
+
 	t.Run("first exec after sandbox start removes pre-applied new files before sync", func(t *testing.T) {
 		setup := setupTest(t)
 

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -58,14 +58,6 @@ func (c *Client) GetBranch() string {
 	return branch
 }
 
-func (c *Client) GetHead() string {
-	head, err := c.GetHeadCommit()
-	if err != nil {
-		return ""
-	}
-	return head
-}
-
 func (c *Client) GetHeadCommit() (string, error) {
 	cmd := exec.Command(c.Binary, "rev-parse", "--verify", "HEAD^{commit}")
 	cmd.Dir = c.Dir
@@ -121,7 +113,7 @@ func (c *Client) GetCommit() (string, error) {
 	// Check if remote exists — for detached HEAD, fall back to raw HEAD
 	if c.GetRemoteUrl(remote) == "" {
 		if c.GetBranch() == "" {
-			return c.GetHead(), nil
+			return c.GetHeadCommit()
 		}
 		return "", fmt.Errorf("no git remote named '%s' is configured (set RWX_GIT_REMOTE to use a different remote)", remote)
 	}
@@ -140,7 +132,7 @@ func (c *Client) GetCommit() (string, error) {
 
 	// Empty output means HEAD is on an origin ref (no divergence) - return HEAD
 	if output == "" {
-		return c.GetHead(), nil
+		return c.GetHeadCommit()
 	}
 
 	// First line starting with "-" is the boundary (closest merge-base)
@@ -154,7 +146,7 @@ func (c *Client) GetCommit() (string, error) {
 	if c.GetBranch() == "" {
 		// Detached HEAD with no remote ancestor — fall back to raw HEAD so
 		// the caller can still attempt the operation (sync will patch on top).
-		return c.GetHead(), nil
+		return c.GetHeadCommit()
 	}
 	return "", fmt.Errorf("current branch has no commits in common with the '%s' remote (set RWX_GIT_REMOTE to use a different remote)", remote)
 }

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -3,9 +3,7 @@ package git
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/rwx-cloud/rwx/internal/vcs/vcstypes"
@@ -115,7 +113,7 @@ func (c *Client) GetCommit() (string, error) {
 		if c.GetBranch() == "" {
 			return c.GetHeadCommit()
 		}
-		return "", fmt.Errorf("no git remote named '%s' is configured (set RWX_GIT_REMOTE to use a different remote)", remote)
+		return "", vcstypes.MissingRemoteError(remote)
 	}
 
 	// Find commits on HEAD that aren't on any remote ref, with boundary markers.
@@ -148,7 +146,7 @@ func (c *Client) GetCommit() (string, error) {
 		// the caller can still attempt the operation (sync will patch on top).
 		return c.GetHeadCommit()
 	}
-	return "", fmt.Errorf("current branch has no commits in common with the '%s' remote (set RWX_GIT_REMOTE to use a different remote)", remote)
+	return "", vcstypes.NoCommonAncestorError("current branch", remote)
 }
 
 func (c *Client) GetOriginUrl() string {
@@ -253,32 +251,8 @@ func (c *Client) GeneratePatchFile(destDir string, pathspec []string) (vcstypes.
 	if patchErr != nil {
 		return vcstypes.PatchFile{}, patchErr
 	}
-	if !data.OK {
-		return vcstypes.PatchFile{}, fmt.Errorf("unable to generate patch data")
-	}
 
-	if data.LFS.Count > 0 {
-		return vcstypes.PatchFile{LFSChangedFiles: data.LFS}, nil
-	}
-
-	if len(data.Patch) == 0 {
-		return vcstypes.PatchFile{UntrackedFiles: data.Untracked}, nil
-	}
-
-	outputPath := filepath.Join(destDir, data.SHA)
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
-		return vcstypes.PatchFile{}, fmt.Errorf("unable to create patch directory: %w", err)
-	}
-
-	if err := os.WriteFile(outputPath, data.Patch, 0644); err != nil {
-		return vcstypes.PatchFile{}, fmt.Errorf("unable to write patch file: %w", err)
-	}
-
-	return vcstypes.PatchFile{
-		Written:        true,
-		Path:           outputPath,
-		UntrackedFiles: data.Untracked,
-	}, nil
+	return data.WriteFile(destDir)
 }
 
 // AddUntrackedFilesForPatch temporarily adds untracked files with intent-to-add
@@ -331,19 +305,12 @@ func (c *Client) GeneratePatch(pathspec []string) ([]byte, *vcstypes.LFSChangedF
 	defer cleanup()
 
 	data, patchErr := c.generatePatchData(pathspec)
-	if patchErr != nil || !data.OK {
+	if patchErr != nil {
 		return nil, nil, nil
 	}
 
-	if data.LFS.Count > 0 {
-		return nil, &data.LFS, nil
-	}
-
-	if len(data.Patch) == 0 {
-		return nil, nil, nil
-	}
-
-	return data.Patch, nil, nil
+	patch, lfs := data.Bytes()
+	return patch, lfs, nil
 }
 
 func (c *Client) GenerateDirtyPatches() (vcstypes.DirtyPatches, error) {
@@ -485,27 +452,13 @@ func (c *Client) lfsFilesForPaths(files []string) (vcstypes.LFSChangedFilesMetad
 }
 
 func (c *Client) PushRef(opts vcstypes.PushRefOptions) error {
-	if opts.Remote == "" {
-		return fmt.Errorf("no remote provided")
-	}
-	if opts.Refspec == "" {
-		return fmt.Errorf("no refspec provided")
+	if err := opts.Validate(); err != nil {
+		return err
 	}
 
 	cmd := exec.Command(c.Binary, "push", opts.Remote, opts.Refspec)
 	cmd.Dir = c.Dir
-	if len(opts.Env) > 0 {
-		cmd.Env = append(os.Environ(), opts.Env...)
-	}
-	if out, err := cmd.CombinedOutput(); err != nil {
-		output := strings.TrimSpace(string(out))
-		if output != "" {
-			return fmt.Errorf("git push failed: %s", output)
-		}
-		return fmt.Errorf("git push failed: %w", err)
-	}
-
-	return nil
+	return vcstypes.RunPush(cmd, opts.Env)
 }
 
 // IsAncestor returns true if candidateSHA is an ancestor of (or equal to) headRef.

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -87,6 +87,11 @@ func (c *Client) GetHeadCommit() (string, error) {
 	return head, nil
 }
 
+// GetLastCommit is HEAD; git's working copy is not a commit.
+func (c *Client) GetLastCommit() (string, error) {
+	return c.GetHeadCommit()
+}
+
 func (c *Client) GetShortHead() string {
 	cmd := exec.Command(c.Binary, "rev-parse", "--short", "HEAD")
 	cmd.Dir = c.Dir

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -693,7 +693,8 @@ func TestIsAncestor(t *testing.T) {
 	t.Run("returns false when candidate is descendant of HEAD", func(t *testing.T) {
 		repo, firstSHA := repoFixture(t, "testdata/IsAncestor-linear")
 		client := &git.Client{Binary: "git", Dir: repo}
-		headSHA := client.GetHead()
+		headSHA, err := client.GetHeadCommit()
+		require.NoError(t, err)
 		require.False(t, client.IsAncestor(headSHA, firstSHA))
 	})
 

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -504,14 +504,10 @@ func (c *Client) GeneratePatch(pathspec []string) ([]byte, *vcstypes.LFSChangedF
 	return data.Patch, nil, nil
 }
 
-// GenerateDirtyPatches has no dirty state to report: every edit is snapshotted
-// into @, so uncommitted work reaches the sandbox inside the pushed commit. The
-// GetHeadCommit call fails closed rather than reporting a false clean tree.
+// GenerateDirtyPatches has nothing to report: every edit is snapshotted into @,
+// so uncommitted work travels in the pushed commit. Snapshotting here would only
+// rewrite @ past the commit just pushed.
 func (c *Client) GenerateDirtyPatches() (vcstypes.DirtyPatches, error) {
-	if _, err := c.GetHeadCommit(); err != nil {
-		return vcstypes.DirtyPatches{}, err
-	}
-
 	return vcstypes.DirtyPatches{}, nil
 }
 

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -21,9 +21,17 @@ type Client struct {
 	// Nil discards them.
 	Stderr io.Writer
 
-	// jj repeats the snapshot refusal on every command that snapshots, and one
-	// CLI invocation snapshots several times, so the warning is forwarded once.
+	// jj repeats the refusal on every snapshot, so it is forwarded once.
 	snapshotRefusalReported bool
+
+	// Resolved once per invocation, failures included.
+	rootResolved    bool
+	root            string
+	storeResolved   bool
+	store           store
+	storeErr        error
+	remotesResolved bool
+	remotes         map[string]string
 }
 
 const (
@@ -133,11 +141,13 @@ func (c *Client) IsInsideWorkTree() bool {
 }
 
 func (c *Client) GetTopLevel() string {
-	out, _, err := c.runStale("root")
-	if err != nil {
-		return ""
+	if !c.rootResolved {
+		c.rootResolved = true
+		if out, _, err := c.runStale("root"); err == nil {
+			c.root = firstLine(out)
+		}
 	}
-	return firstLine(out)
+	return c.root
 }
 
 func (c *Client) applyDir() string {
@@ -277,6 +287,11 @@ func (c *Client) GetRemoteUrl(remote string) string {
 }
 
 func (c *Client) remoteUrls() map[string]string {
+	if c.remotesResolved {
+		return c.remotes
+	}
+	c.remotesResolved = true
+
 	out, _, err := c.runStale("git", "remote", "list")
 	if err != nil {
 		return nil
@@ -290,18 +305,25 @@ func (c *Client) remoteUrls() map[string]string {
 		}
 	}
 
+	c.remotes = remotes
 	return remotes
 }
 
-// store locates the git repository backing a jj repo, along with the work tree
-// its commands should run in. Resolving it costs a `jj root` plus a couple of
-// file reads, so callers that inspect many files resolve it once and reuse it.
+// store is the git repository backing a jj repo and the work tree to run git in.
 type store struct {
 	gitDir   string
 	workTree string
 }
 
 func (c *Client) resolveStore() (store, error) {
+	if !c.storeResolved {
+		c.storeResolved = true
+		c.store, c.storeErr = c.locateStore()
+	}
+	return c.store, c.storeErr
+}
+
+func (c *Client) locateStore() (store, error) {
 	root := c.GetTopLevel()
 	if root == "" {
 		return store{}, fmt.Errorf("not inside a jj repository")

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -264,7 +264,7 @@ func (c *Client) GetCommit() (string, error) {
 		if c.GetBranch() == "" {
 			return c.GetHeadCommit()
 		}
-		return "", fmt.Errorf("no git remote named '%s' is configured (set RWX_GIT_REMOTE to use a different remote)", remote)
+		return "", vcstypes.MissingRemoteError(remote)
 	}
 
 	// root() is an ancestor of everything, so without excluding it unrelated
@@ -281,10 +281,11 @@ func (c *Client) GetCommit() (string, error) {
 
 	base := firstLine(out)
 	if base == "" {
-		if c.GetBranch() == "" {
+		branch := c.GetBranch()
+		if branch == "" {
 			return c.GetHeadCommit()
 		}
-		return "", fmt.Errorf("bookmark '%s' has no commits in common with the '%s' remote (set RWX_GIT_REMOTE to use a different remote)", c.GetBranch(), remote)
+		return "", vcstypes.NoCommonAncestorError(fmt.Sprintf("bookmark '%s'", branch), remote)
 	}
 
 	return base, nil
@@ -493,49 +494,18 @@ func (c *Client) GeneratePatchFile(destDir string, pathspec []string) (vcstypes.
 	if patchErr != nil {
 		return vcstypes.PatchFile{}, patchErr
 	}
-	if !data.OK {
-		return vcstypes.PatchFile{}, fmt.Errorf("unable to generate patch data")
-	}
 
-	if data.LFS.Count > 0 {
-		return vcstypes.PatchFile{LFSChangedFiles: data.LFS}, nil
-	}
-
-	if len(data.Patch) == 0 {
-		return vcstypes.PatchFile{UntrackedFiles: data.Untracked}, nil
-	}
-
-	outputPath := filepath.Join(destDir, data.SHA)
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
-		return vcstypes.PatchFile{}, fmt.Errorf("unable to create patch directory: %w", err)
-	}
-
-	if err := os.WriteFile(outputPath, data.Patch, 0644); err != nil {
-		return vcstypes.PatchFile{}, fmt.Errorf("unable to write patch file: %w", err)
-	}
-
-	return vcstypes.PatchFile{
-		Written:        true,
-		Path:           outputPath,
-		UntrackedFiles: data.Untracked,
-	}, nil
+	return data.WriteFile(destDir)
 }
 
 func (c *Client) GeneratePatch(pathspec []string) ([]byte, *vcstypes.LFSChangedFilesMetadata, error) {
 	data, patchErr := c.generatePatchData(pathspec)
-	if patchErr != nil || !data.OK {
+	if patchErr != nil {
 		return nil, nil, nil
 	}
 
-	if data.LFS.Count > 0 {
-		return nil, &data.LFS, nil
-	}
-
-	if len(data.Patch) == 0 {
-		return nil, nil, nil
-	}
-
-	return data.Patch, nil, nil
+	patch, lfs := data.Bytes()
+	return patch, lfs, nil
 }
 
 // GenerateDirtyPatches has nothing to report: every edit is snapshotted into @,
@@ -587,11 +557,8 @@ func (c *Client) hasConflict(rev string) bool {
 }
 
 func (c *Client) PushRef(opts vcstypes.PushRefOptions) error {
-	if opts.Remote == "" {
-		return fmt.Errorf("no remote provided")
-	}
-	if opts.Refspec == "" {
-		return fmt.Errorf("no refspec provided")
+	if err := opts.Validate(); err != nil {
+		return err
 	}
 
 	st, err := c.resolveStore()
@@ -604,25 +571,12 @@ func (c *Client) PushRef(opts vcstypes.PushRefOptions) error {
 			return fmt.Errorf("cannot push %s: %s", src, conflictMessage)
 		}
 
-		if err := c.storeCmdIn(st, "cat-file", "-e", src+"^{commit}").Run(); err != nil {
+		if !c.HasCommit(src) {
 			return fmt.Errorf("cannot push %s: the commit is not in the git store backing this jj repository", src)
 		}
 	}
 
-	cmd := c.storeCmdIn(st, "push", opts.Remote, opts.Refspec)
-	if len(opts.Env) > 0 {
-		cmd.Env = append(os.Environ(), opts.Env...)
-	}
-
-	if out, err := cmd.CombinedOutput(); err != nil {
-		output := strings.TrimSpace(string(out))
-		if output != "" {
-			return fmt.Errorf("git push failed: %s", output)
-		}
-		return fmt.Errorf("git push failed: %w", err)
-	}
-
-	return nil
+	return vcstypes.RunPush(c.storeCmdIn(st, "push", opts.Remote, opts.Refspec), opts.Env)
 }
 
 func (c *Client) ApplyPatch(patch []byte) *exec.Cmd {

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -3,7 +3,9 @@ package jj
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -231,6 +233,82 @@ func (c *Client) remoteUrls() map[string]string {
 	}
 
 	return remotes
+}
+
+// store locates the git repository backing a jj repo, along with the work tree
+// its commands should run in. Resolving it costs a `jj root` plus a couple of
+// file reads, so callers that inspect many files resolve it once and reuse it.
+type store struct {
+	gitDir   string
+	workTree string
+}
+
+func (c *Client) resolveStore() (store, error) {
+	root := c.GetTopLevel()
+	if root == "" {
+		return store{}, fmt.Errorf("not inside a jj repository")
+	}
+
+	gitDir, err := gitDirForRoot(root)
+	if err != nil {
+		return store{}, err
+	}
+
+	return store{gitDir: gitDir, workTree: root}, nil
+}
+
+func gitDirForRoot(root string) (string, error) {
+	repoDir := filepath.Join(root, ".jj", "repo")
+	if info, err := os.Stat(repoDir); err == nil && !info.IsDir() {
+		data, err := os.ReadFile(repoDir)
+		if err != nil {
+			return "", fmt.Errorf("unable to read %s: %w", repoDir, err)
+		}
+		target := strings.TrimSpace(string(data))
+		if target == "" {
+			return "", fmt.Errorf("%s is empty", repoDir)
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(root, ".jj", target)
+		}
+		repoDir = target
+	}
+
+	storeDir := filepath.Join(repoDir, "store")
+	data, err := os.ReadFile(filepath.Join(storeDir, "git_target"))
+	if err != nil {
+		return "", fmt.Errorf("unable to locate the git store for this jj repository: %w", err)
+	}
+
+	target := strings.TrimSpace(string(data))
+	if target == "" {
+		return "", fmt.Errorf("unable to locate the git store for this jj repository")
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(storeDir, target)
+	}
+
+	return filepath.Clean(target), nil
+}
+
+// storeCmdIn builds a git command against the backing store.
+func (c *Client) storeCmdIn(st store, args ...string) *exec.Cmd {
+	cmd := exec.Command(c.GitBinary, append([]string{"--git-dir", st.gitDir}, args...)...)
+	cmd.Dir = st.workTree
+	return cmd
+}
+
+func (c *Client) HasCommit(sha string) bool {
+	if sha == "" {
+		return false
+	}
+
+	st, err := c.resolveStore()
+	if err != nil {
+		return false
+	}
+
+	return c.storeCmdIn(st, "cat-file", "-e", sha+"^{commit}").Run() == nil
 }
 
 // IsAncestor takes revsets, so a GetShortHead change id still matches after @

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -217,10 +217,11 @@ func (c *Client) GetHeadCommit() (string, error) {
 	return head, nil
 }
 
-// GetShortHead reports a change id, not a commit id: it keys sandbox sessions,
-// and jj rewrites @ on every snapshot, so a commit-id key would strand a sandbox
+// GetShortHead reports a change id, not a commit id. It keys sandbox sessions,
+// and jj rewrites @ on every snapshot, so a commit id would strand the sandbox
 // on every edit. Change ids survive the rewrite and still resolve as revsets,
-// which is what the sandbox ancestry fallback needs.
+// though only under jj: a git-backed invocation on the same colocated checkout
+// will not find the session.
 func (c *Client) GetShortHead() string {
 	out, _, err := c.resolve(workingCopy, `change_id.short(7) ++ "\n"`)
 	if err != nil {

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -2,6 +2,7 @@ package jj
 
 import (
 	"bytes"
+	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -13,7 +14,8 @@ type Client struct {
 }
 
 const (
-	workingCopy = "@"
+	workingCopy      = "@"
+	commitIDTemplate = `commit_id ++ "\n"`
 )
 
 func (c *Client) exec(globals, args []string) (string, string, error) {
@@ -29,8 +31,16 @@ func (c *Client) exec(globals, args []string) (string, string, error) {
 	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
 }
 
+func (c *Client) run(args ...string) (string, string, error) {
+	return c.exec(nil, args)
+}
+
 func (c *Client) runStale(args ...string) (string, string, error) {
 	return c.exec([]string{"--ignore-working-copy"}, args)
+}
+
+func (c *Client) resolve(revset, template string) (string, string, error) {
+	return c.run("log", "-r", revset, "--no-graph", "-T", template)
 }
 
 func firstLine(s string) string {
@@ -63,4 +73,22 @@ func (c *Client) GetTopLevel() string {
 		return ""
 	}
 	return firstLine(out)
+}
+
+func (c *Client) GetHeadCommit() (string, error) {
+	out, stderr, err := c.resolve(workingCopy, commitIDTemplate)
+	if err != nil {
+		msg := stderr
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("unable to resolve HEAD: %s", msg)
+	}
+
+	head := firstLine(out)
+	if head == "" {
+		return "", fmt.Errorf("unable to resolve HEAD")
+	}
+
+	return head, nil
 }

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -43,6 +43,10 @@ func (c *Client) resolve(revset, template string) (string, string, error) {
 	return c.run("log", "-r", revset, "--no-graph", "-T", template)
 }
 
+func (c *Client) resolveStale(revset, template string) (string, string, error) {
+	return c.runStale("log", "-r", revset, "--no-graph", "-T", template)
+}
+
 func firstLine(s string) string {
 	for _, line := range strings.Split(s, "\n") {
 		if trimmed := strings.TrimSpace(line); trimmed != "" {
@@ -50,6 +54,13 @@ func firstLine(s string) string {
 		}
 	}
 	return ""
+}
+
+func toRevset(ref string) string {
+	if ref == "HEAD" {
+		return workingCopy
+	}
+	return ref
 }
 
 // The jj backend reaches the object store through git, so both are required.
@@ -91,4 +102,32 @@ func (c *Client) GetHeadCommit() (string, error) {
 	}
 
 	return head, nil
+}
+
+// GetShortHead reports a change id, not a commit id: it keys sandbox sessions,
+// and jj rewrites @ on every snapshot, so a commit-id key would strand a sandbox
+// on every edit. Change ids survive the rewrite and still resolve as revsets,
+// which is what the sandbox ancestry fallback needs.
+func (c *Client) GetShortHead() string {
+	out, _, err := c.resolve(workingCopy, `change_id.short(7) ++ "\n"`)
+	if err != nil {
+		return ""
+	}
+	return firstLine(out)
+}
+
+// IsAncestor takes revsets, so a GetShortHead change id still matches after @
+// has been rewritten.
+func (c *Client) IsAncestor(candidateSHA, headRef string) bool {
+	if candidateSHA == "" || headRef == "" {
+		return false
+	}
+
+	revset := fmt.Sprintf("(%s) & ::(%s)", toRevset(candidateSHA), toRevset(headRef))
+	out, _, err := c.resolveStale(revset, commitIDTemplate)
+	if err != nil {
+		return false
+	}
+
+	return firstLine(out) != ""
 }

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -1,0 +1,66 @@
+package jj
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+)
+
+type Client struct {
+	Binary    string
+	GitBinary string
+	Dir       string
+}
+
+const (
+	workingCopy = "@"
+)
+
+func (c *Client) exec(globals, args []string) (string, string, error) {
+	full := append([]string{"--no-pager", "--color=never", "--quiet"}, globals...)
+	cmd := exec.Command(c.Binary, append(full, args...)...)
+	cmd.Dir = c.Dir
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
+}
+
+func (c *Client) runStale(args ...string) (string, string, error) {
+	return c.exec([]string{"--ignore-working-copy"}, args)
+}
+
+func firstLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// The jj backend reaches the object store through git, so both are required.
+func (c *Client) MissingDependency() string {
+	if _, err := exec.LookPath(c.Binary); err != nil {
+		return "jj"
+	}
+	if _, err := exec.LookPath(c.GitBinary); err != nil {
+		return "git"
+	}
+	return ""
+}
+
+func (c *Client) IsInsideWorkTree() bool {
+	return c.GetTopLevel() != ""
+}
+
+func (c *Client) GetTopLevel() string {
+	out, _, err := c.runStale("root")
+	if err != nil {
+		return ""
+	}
+	return firstLine(out)
+}

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -110,6 +110,13 @@ func (c *Client) GetTopLevel() string {
 	return firstLine(out)
 }
 
+func (c *Client) applyDir() string {
+	if root := c.GetTopLevel(); root != "" {
+		return root
+	}
+	return c.Dir
+}
+
 // GetBranch reports the nearest bookmark at or below @, since `jj commit` leaves
 // the bookmark behind as @ moves above it. When @ merges several bookmarked
 // lines, one that exists on the configured remote wins, then the first by name.
@@ -535,4 +542,28 @@ func (c *Client) PushRef(opts vcstypes.PushRefOptions) error {
 	}
 
 	return nil
+}
+
+func (c *Client) ApplyPatch(patch []byte) *exec.Cmd {
+	return c.applyPatchCmd(patch, "apply", "--allow-empty", "-")
+}
+
+func (c *Client) ApplyPatchReject(patch []byte) *exec.Cmd {
+	return c.applyPatchCmd(patch, "apply", "--reject", "--allow-empty", "-")
+}
+
+// A non-colocated workspace has no .git of its own, and without one git apply
+// ignores .gitattributes, so git is pointed at the backing store.
+func (c *Client) applyPatchCmd(patch []byte, args ...string) *exec.Cmd {
+	var cmd *exec.Cmd
+	if st, err := c.resolveStore(); err == nil {
+		cmd = exec.Command(c.GitBinary, append([]string{"--git-dir", st.gitDir, "--work-tree", st.workTree}, args...)...)
+		cmd.Dir = st.workTree
+	} else {
+		cmd = exec.Command(c.GitBinary, args...)
+		cmd.Dir = c.applyDir()
+	}
+
+	cmd.Stdin = bytes.NewReader(patch)
+	return cmd
 }

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -298,6 +298,139 @@ func (c *Client) storeCmdIn(st store, args ...string) *exec.Cmd {
 	return cmd
 }
 
+func withPathspec(args []string, pathspec []string) []string {
+	if len(pathspec) == 0 {
+		return args
+	}
+	args = append(args, "--")
+	return append(args, pathspec...)
+}
+
+func (c *Client) diffNames(st store, base, head string, pathspec []string, extra ...string) ([]string, *vcstypes.PatchError) {
+	args := append([]string{"diff", "-z", "--name-only"}, extra...)
+	args = append(args, base, head)
+
+	out, err := c.storeCmdIn(st, withPathspec(args, pathspec)...).Output()
+	if err != nil {
+		return nil, vcstypes.NewPatchError("diff_name_only", "git diff --name-only", err, "")
+	}
+
+	return vcstypes.SplitNULPaths(out), nil
+}
+
+func (c *Client) lfsFilesForPaths(st store, files []string) (vcstypes.LFSChangedFilesMetadata, *vcstypes.PatchError) {
+	return vcstypes.LFSFilesForPaths(files, func(args ...string) (*exec.Cmd, error) {
+		// A non-colocated store is bare, so check-attr needs a work tree to find
+		// .gitattributes.
+		return c.storeCmdIn(st, append([]string{"--work-tree", st.workTree}, args...)...), nil
+	})
+}
+
+func (c *Client) generatePatchData(pathspec []string) (vcstypes.PatchResult, *vcstypes.PatchError) {
+	base, err := c.GetCommit()
+	if base == "" || err != nil {
+		return vcstypes.PatchResult{}, nil
+	}
+
+	head, err := c.GetHeadCommit()
+	if err != nil || head == "" {
+		return vcstypes.PatchResult{}, nil
+	}
+
+	st, err := c.resolveStore()
+	if err != nil {
+		return vcstypes.PatchResult{}, vcstypes.NewPatchError("diff_name_only", "git diff --name-only", err, "")
+	}
+
+	files, patchErr := c.diffNames(st, base, head, pathspec)
+	if patchErr != nil {
+		return vcstypes.PatchResult{}, patchErr
+	}
+
+	lfsChanged, patchErr := c.lfsFilesForPaths(st, files)
+	if patchErr != nil {
+		return vcstypes.PatchResult{}, patchErr
+	}
+
+	if lfsChanged.Count > 0 {
+		return vcstypes.PatchResult{SHA: base, LFS: lfsChanged, OK: true}, nil
+	}
+
+	// jj tracks the whole working copy, so there is no untracked set to report.
+	// The files added between base and @ are the closest equivalent: they are
+	// the paths the patch creates, which is what callers use the field for.
+	added, patchErr := c.diffNames(st, base, head, pathspec, "--diff-filter=A")
+	if patchErr != nil {
+		return vcstypes.PatchResult{}, patchErr
+	}
+
+	patchArgs := []string{"diff", base, head, "-p", "--binary"}
+	patch, err := c.storeCmdIn(st, withPathspec(patchArgs, pathspec)...).Output()
+	if err != nil {
+		return vcstypes.PatchResult{}, vcstypes.NewPatchError("diff_patch", "git diff -p --binary", err, "")
+	}
+
+	return vcstypes.PatchResult{
+		Patch: patch,
+		SHA:   base,
+		Untracked: vcstypes.UntrackedFilesMetadata{
+			Files: added,
+			Count: len(added),
+		},
+		OK: true,
+	}, nil
+}
+
+func (c *Client) GeneratePatchFile(destDir string, pathspec []string) (vcstypes.PatchFile, error) {
+	data, patchErr := c.generatePatchData(pathspec)
+	if patchErr != nil {
+		return vcstypes.PatchFile{}, patchErr
+	}
+	if !data.OK {
+		return vcstypes.PatchFile{}, fmt.Errorf("unable to generate patch data")
+	}
+
+	if data.LFS.Count > 0 {
+		return vcstypes.PatchFile{LFSChangedFiles: data.LFS}, nil
+	}
+
+	if len(data.Patch) == 0 {
+		return vcstypes.PatchFile{UntrackedFiles: data.Untracked}, nil
+	}
+
+	outputPath := filepath.Join(destDir, data.SHA)
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		return vcstypes.PatchFile{}, fmt.Errorf("unable to create patch directory: %w", err)
+	}
+
+	if err := os.WriteFile(outputPath, data.Patch, 0644); err != nil {
+		return vcstypes.PatchFile{}, fmt.Errorf("unable to write patch file: %w", err)
+	}
+
+	return vcstypes.PatchFile{
+		Written:        true,
+		Path:           outputPath,
+		UntrackedFiles: data.Untracked,
+	}, nil
+}
+
+func (c *Client) GeneratePatch(pathspec []string) ([]byte, *vcstypes.LFSChangedFilesMetadata, error) {
+	data, patchErr := c.generatePatchData(pathspec)
+	if patchErr != nil || !data.OK {
+		return nil, nil, nil
+	}
+
+	if data.LFS.Count > 0 {
+		return nil, &data.LFS, nil
+	}
+
+	if len(data.Patch) == 0 {
+		return nil, nil, nil
+	}
+
+	return data.Patch, nil, nil
+}
+
 func (c *Client) HasCommit(sha string) bool {
 	if sha == "" {
 		return false

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
+
+	"github.com/rwx-cloud/rwx/internal/vcs/vcstypes"
 )
 
 type Client struct {
@@ -16,6 +19,11 @@ type Client struct {
 const (
 	workingCopy      = "@"
 	commitIDTemplate = `commit_id ++ "\n"`
+	// nearestBookmarks names the closest bookmarked commits at or below @. jj does
+	// not advance bookmarks, so @ usually sits one or more commits above the
+	// bookmark it belongs to.
+	nearestBookmarks      = "heads(::@ & bookmarks())"
+	bookmarkNamesTemplate = `local_bookmarks.map(|b| b.name()).join("\n") ++ "\n"`
 )
 
 func (c *Client) exec(globals, args []string) (string, string, error) {
@@ -56,11 +64,25 @@ func firstLine(s string) string {
 	return ""
 }
 
+func nonEmptyLines(s string) []string {
+	var lines []string
+	for _, line := range strings.Split(s, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			lines = append(lines, trimmed)
+		}
+	}
+	return lines
+}
+
 func toRevset(ref string) string {
 	if ref == "HEAD" {
 		return workingCopy
 	}
 	return ref
+}
+
+func quoteRevsetString(s string) string {
+	return `"` + strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(s) + `"`
 }
 
 // The jj backend reaches the object store through git, so both are required.
@@ -84,6 +106,36 @@ func (c *Client) GetTopLevel() string {
 		return ""
 	}
 	return firstLine(out)
+}
+
+// GetBranch reports the nearest bookmark at or below @, since `jj commit` leaves
+// the bookmark behind as @ moves above it. When @ merges several bookmarked
+// lines, one that exists on the configured remote wins, then the first by name.
+func (c *Client) GetBranch() string {
+	out, _, err := c.resolveStale(nearestBookmarks, bookmarkNamesTemplate)
+	if err != nil {
+		return ""
+	}
+
+	names := nonEmptyLines(out)
+	if len(names) <= 1 {
+		return firstLine(out)
+	}
+
+	sort.Strings(names)
+	remote := vcstypes.ConfiguredRemote()
+	for _, name := range names {
+		if c.bookmarkExistsOnRemote(name, remote) {
+			return name
+		}
+	}
+	return names[0]
+}
+
+func (c *Client) bookmarkExistsOnRemote(name, remote string) bool {
+	revset := fmt.Sprintf("remote_bookmarks(exact:%s, remote=exact:%s)", quoteRevsetString(name), quoteRevsetString(remote))
+	out, _, err := c.resolveStale(revset, commitIDTemplate)
+	return err == nil && firstLine(out) != ""
 }
 
 func (c *Client) GetHeadCommit() (string, error) {

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -464,29 +464,13 @@ func (c *Client) generatePatchData(pathspec []string) (vcstypes.PatchResult, *vc
 		return vcstypes.PatchResult{SHA: base, LFS: lfsChanged, OK: true}, nil
 	}
 
-	// jj tracks the whole working copy, so there is no untracked set to report.
-	// The files added between base and @ are the closest equivalent: they are
-	// the paths the patch creates, which is what callers use the field for.
-	added, patchErr := c.diffNames(st, base, head, pathspec, "--diff-filter=A")
-	if patchErr != nil {
-		return vcstypes.PatchResult{}, patchErr
-	}
-
 	patchArgs := []string{"diff", base, head, "-p", "--binary"}
 	patch, err := c.storeCmdIn(st, withPathspec(patchArgs, pathspec)...).Output()
 	if err != nil {
 		return vcstypes.PatchResult{}, vcstypes.NewPatchError("diff_patch", "git diff -p --binary", err, "")
 	}
 
-	return vcstypes.PatchResult{
-		Patch: patch,
-		SHA:   base,
-		Untracked: vcstypes.UntrackedFilesMetadata{
-			Files: added,
-			Count: len(added),
-		},
-		OK: true,
-	}, nil
+	return vcstypes.PatchResult{Patch: patch, SHA: base, OK: true}, nil
 }
 
 func (c *Client) GeneratePatchFile(destDir string, pathspec []string) (vcstypes.PatchFile, error) {

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -168,6 +168,46 @@ func (c *Client) GetShortHead() string {
 	return firstLine(out)
 }
 
+// GetCommit reads stale: snapshotting rewrites @ but not its ancestors, so the
+// base resolves without mutating the repository. Only the fallbacks that answer
+// with @ itself snapshot.
+func (c *Client) GetCommit() (string, error) {
+	if out, _, err := c.resolveStale(workingCopy, commitIDTemplate); err != nil || firstLine(out) == "" {
+		return "", nil
+	}
+
+	remote := vcstypes.ConfiguredRemote()
+	if c.GetRemoteUrl(remote) == "" {
+		// No bookmark is jj's detached HEAD: answer with @, as the git backend does.
+		if c.GetBranch() == "" {
+			return c.GetHeadCommit()
+		}
+		return "", fmt.Errorf("no git remote named '%s' is configured (set RWX_GIT_REMOTE to use a different remote)", remote)
+	}
+
+	// root() is an ancestor of everything, so without excluding it unrelated
+	// histories would resolve to the virtual root instead of failing.
+	revset := fmt.Sprintf("heads((::@ & ::remote_bookmarks(remote=exact:%s)) ~ root())", quoteRevsetString(remote))
+	out, stderr, err := c.resolveStale(revset, commitIDTemplate)
+	if err != nil {
+		msg := stderr
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("jj log failed: %s", msg)
+	}
+
+	base := firstLine(out)
+	if base == "" {
+		if c.GetBranch() == "" {
+			return c.GetHeadCommit()
+		}
+		return "", fmt.Errorf("bookmark '%s' has no commits in common with the '%s' remote (set RWX_GIT_REMOTE to use a different remote)", c.GetBranch(), remote)
+	}
+
+	return base, nil
+}
+
 func (c *Client) GetOriginUrl() string {
 	return c.GetRemoteUrl(vcstypes.ConfiguredRemote())
 }

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -3,6 +3,7 @@ package jj
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +17,13 @@ type Client struct {
 	Binary    string
 	GitBinary string
 	Dir       string
+	// Stderr receives warnings jj reports while still exiting successfully.
+	// Nil discards them.
+	Stderr io.Writer
+
+	// jj repeats the snapshot refusal on every command that snapshots, and one
+	// CLI invocation snapshots several times, so the warning is forwarded once.
+	snapshotRefusalReported bool
 }
 
 const (
@@ -38,7 +46,29 @@ func (c *Client) exec(globals, args []string) (string, string, error) {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 
-	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
+	trimmedStderr := strings.TrimSpace(stderr.String())
+	c.reportSnapshotRefusals(trimmedStderr)
+
+	return strings.TrimSpace(stdout.String()), trimmedStderr, err
+}
+
+// jj skips files over snapshot.max-new-file-size and still exits 0, so unless
+// this is forwarded the file silently vanishes from every patch.
+const snapshotRefusalPrefix = "Refused to snapshot some files"
+
+func (c *Client) reportSnapshotRefusals(stderr string) {
+	if c.Stderr == nil || c.snapshotRefusalReported || !strings.Contains(stderr, snapshotRefusalPrefix) {
+		return
+	}
+	c.snapshotRefusalReported = true
+
+	for _, line := range strings.Split(stderr, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "Hint:") {
+			break
+		}
+		fmt.Fprintln(c.Stderr, line)
+	}
+	fmt.Fprintln(c.Stderr, "These files are excluded from RWX patches and sandbox syncs. Raise jj's snapshot.max-new-file-size or add them to .gitignore.")
 }
 
 func (c *Client) run(args ...string) (string, string, error) {

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -441,6 +441,17 @@ func (c *Client) GeneratePatch(pathspec []string) ([]byte, *vcstypes.LFSChangedF
 	return data.Patch, nil, nil
 }
 
+// GenerateDirtyPatches has no dirty state to report: every edit is snapshotted
+// into @, so uncommitted work reaches the sandbox inside the pushed commit. The
+// GetHeadCommit call fails closed rather than reporting a false clean tree.
+func (c *Client) GenerateDirtyPatches() (vcstypes.DirtyPatches, error) {
+	if _, err := c.GetHeadCommit(); err != nil {
+		return vcstypes.DirtyPatches{}, err
+	}
+
+	return vcstypes.DirtyPatches{}, nil
+}
+
 func (c *Client) HasCommit(sha string) bool {
 	if sha == "" {
 		return false

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -37,11 +37,12 @@ type Client struct {
 const (
 	workingCopy      = "@"
 	commitIDTemplate = `commit_id ++ "\n"`
-	// nearestBookmarks names the closest bookmarked commits at or below @. jj does
-	// not advance bookmarks, so @ usually sits one or more commits above the
-	// bookmark it belongs to.
+	// jj does not advance bookmarks, so @ usually sits above the bookmark it
+	// belongs to.
 	nearestBookmarks      = "heads(::@ & bookmarks())"
 	bookmarkNamesTemplate = `local_bookmarks.map(|b| b.name()).join("\n") ++ "\n"`
+	// One "<remote> <name>" line per remote bookmark; neither side contains a space.
+	remoteBookmarksTemplate = `remote_bookmarks.map(|b| b.remote() ++ " " ++ b.name()).join("\n") ++ "\n"`
 )
 
 func (c *Client) exec(globals, args []string) (string, string, error) {
@@ -172,19 +173,30 @@ func (c *Client) GetBranch() string {
 	}
 
 	sort.Strings(names)
-	remote := vcstypes.ConfiguredRemote()
+	onRemote := c.remoteBookmarkNames(vcstypes.ConfiguredRemote())
 	for _, name := range names {
-		if c.bookmarkExistsOnRemote(name, remote) {
+		if onRemote[name] {
 			return name
 		}
 	}
 	return names[0]
 }
 
-func (c *Client) bookmarkExistsOnRemote(name, remote string) bool {
-	revset := fmt.Sprintf("remote_bookmarks(exact:%s, remote=exact:%s)", quoteRevsetString(name), quoteRevsetString(remote))
-	out, _, err := c.resolveStale(revset, commitIDTemplate)
-	return err == nil && firstLine(out) != ""
+func (c *Client) remoteBookmarkNames(remote string) map[string]bool {
+	revset := fmt.Sprintf("remote_bookmarks(remote=exact:%s)", quoteRevsetString(remote))
+	out, _, err := c.resolveStale(revset, remoteBookmarksTemplate)
+	if err != nil {
+		return nil
+	}
+
+	names := map[string]bool{}
+	for _, line := range nonEmptyLines(out) {
+		// A commit may carry the same bookmark from several remotes.
+		if lineRemote, name, ok := strings.Cut(line, " "); ok && lineRemote == remote {
+			names[name] = true
+		}
+	}
+	return names
 }
 
 func (c *Client) GetHeadCommit() (string, error) {

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -207,6 +207,27 @@ func (c *Client) GetShortHead() string {
 	return firstLine(out)
 }
 
+// GetLastCommit skips an empty @: a clean working copy is an empty commit above
+// the last described change, and no run was made for it. This snapshots, since
+// whether @ is empty depends on the working copy.
+func (c *Client) GetLastCommit() (string, error) {
+	out, stderr, err := c.resolve("latest(::@ ~ empty())", commitIDTemplate)
+	if err != nil {
+		msg := stderr
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("unable to resolve the last commit: %s", msg)
+	}
+
+	last := firstLine(out)
+	if last == "" {
+		return "", fmt.Errorf("unable to resolve the last commit")
+	}
+
+	return last, nil
+}
+
 // GetCommit reads stale: snapshotting rewrites @ but not its ancestors, so the
 // base resolves without mutating the repository. Only the fallbacks that answer
 // with @ itself snapshot.

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -168,6 +168,31 @@ func (c *Client) GetShortHead() string {
 	return firstLine(out)
 }
 
+func (c *Client) GetOriginUrl() string {
+	return c.GetRemoteUrl(vcstypes.ConfiguredRemote())
+}
+
+func (c *Client) GetRemoteUrl(remote string) string {
+	return c.remoteUrls()[remote]
+}
+
+func (c *Client) remoteUrls() map[string]string {
+	out, _, err := c.runStale("git", "remote", "list")
+	if err != nil {
+		return nil
+	}
+
+	remotes := map[string]string{}
+	for _, line := range strings.Split(out, "\n") {
+		name, url, ok := strings.Cut(strings.TrimSpace(line), " ")
+		if ok {
+			remotes[name] = strings.TrimSpace(url)
+		}
+	}
+
+	return remotes
+}
+
 // IsAncestor takes revsets, so a GetShortHead change id still matches after @
 // has been rewritten.
 func (c *Client) IsAncestor(candidateSHA, headRef string) bool {

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -291,11 +291,16 @@ func gitDirForRoot(root string) (string, error) {
 	return filepath.Clean(target), nil
 }
 
-// storeCmdIn builds a git command against the backing store.
 func (c *Client) storeCmdIn(st store, args ...string) *exec.Cmd {
 	cmd := exec.Command(c.GitBinary, append([]string{"--git-dir", st.gitDir}, args...)...)
 	cmd.Dir = st.workTree
 	return cmd
+}
+
+// pushSource returns the source side of a refspec, or "" for a delete refspec.
+func pushSource(refspec string) string {
+	src, _, _ := strings.Cut(refspec, ":")
+	return strings.TrimPrefix(src, "+")
 }
 
 func withPathspec(args []string, pathspec []string) []string {
@@ -491,4 +496,43 @@ func (c *Client) hasConflict(rev string) bool {
 		return false
 	}
 	return firstLine(out) == "true"
+}
+
+func (c *Client) PushRef(opts vcstypes.PushRefOptions) error {
+	if opts.Remote == "" {
+		return fmt.Errorf("no remote provided")
+	}
+	if opts.Refspec == "" {
+		return fmt.Errorf("no refspec provided")
+	}
+
+	st, err := c.resolveStore()
+	if err != nil {
+		return err
+	}
+
+	if src := pushSource(opts.Refspec); src != "" {
+		if c.hasConflict(src) {
+			return fmt.Errorf("cannot push %s: %s", src, conflictMessage)
+		}
+
+		if err := c.storeCmdIn(st, "cat-file", "-e", src+"^{commit}").Run(); err != nil {
+			return fmt.Errorf("cannot push %s: the commit is not in the git store backing this jj repository", src)
+		}
+	}
+
+	cmd := c.storeCmdIn(st, "push", opts.Remote, opts.Refspec)
+	if len(opts.Env) > 0 {
+		cmd.Env = append(os.Environ(), opts.Env...)
+	}
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		output := strings.TrimSpace(string(out))
+		if output != "" {
+			return fmt.Errorf("git push failed: %s", output)
+		}
+		return fmt.Errorf("git push failed: %w", err)
+	}
+
+	return nil
 }

--- a/internal/jj/client.go
+++ b/internal/jj/client.go
@@ -337,6 +337,16 @@ func (c *Client) generatePatchData(pathspec []string) (vcstypes.PatchResult, *vc
 		return vcstypes.PatchResult{}, nil
 	}
 
+	// See conflictMessage: diffing would add the .jjconflict-* trees.
+	if c.hasConflict(head) {
+		return vcstypes.PatchResult{}, &vcstypes.PatchError{
+			Command:  "jj_conflict",
+			Display:  "jj working copy",
+			Stderr:   conflictMessage,
+			ExitCode: -1,
+		}
+	}
+
 	st, err := c.resolveStore()
 	if err != nil {
 		return vcstypes.PatchResult{}, vcstypes.NewPatchError("diff_name_only", "git diff --name-only", err, "")
@@ -458,4 +468,16 @@ func (c *Client) IsAncestor(candidateSHA, headRef string) bool {
 	}
 
 	return firstLine(out) != ""
+}
+
+// jj writes a conflicted commit to the git store as .jjconflict-* trees plus a
+// JJ-CONFLICT-README, not as the user's files, so it must not leave the machine.
+const conflictMessage = "the jj working copy has unresolved conflicts, which git cannot represent; run `jj resolve` first"
+
+func (c *Client) hasConflict(rev string) bool {
+	out, _, err := c.resolveStale(toRevset(rev), `conflict ++ "\n"`)
+	if err != nil {
+		return false
+	}
+	return firstLine(out) == "true"
 }

--- a/internal/jj/client_test.go
+++ b/internal/jj/client_test.go
@@ -295,12 +295,42 @@ func TestGetShortHeadSurvivesWorkingCopyEdits(t *testing.T) {
 		require.NotEqual(t, beforeCommit, afterCommit, "jj rewrites @ on every snapshot")
 		require.Equal(t, beforeShort, f.client.GetShortHead(), "the session key must survive the rewrite")
 
-		// The rewritten commit is not a descendant of the one it replaced, which
-		// is exactly why the commit id cannot key the session...
+		// The rewritten commit is not a descendant of the one it replaced, but the
+		// change id still resolves to it.
 		require.False(t, f.client.IsAncestor(beforeCommit, afterCommit))
-		// ...while the change id still resolves to the current working copy, so
-		// the sandbox ancestry fallback keeps matching the existing session.
 		require.True(t, f.client.IsAncestor(beforeShort, "HEAD"))
+	})
+}
+
+// A fresh clone has an empty @ above the pushed commit, which must not answer.
+func TestGetLastCommit(t *testing.T) {
+	t.Run("skips an empty working copy", func(t *testing.T) {
+		eachLayout(t, "clone", func(t *testing.T, f fixture) {
+			last, err := f.client.GetLastCommit()
+			require.NoError(t, err)
+			require.Equal(t, f.baseSHA, last)
+			require.NotEqual(t, headCommit(t, f.client), last)
+		})
+	})
+
+	t.Run("is the working copy once it has changes", func(t *testing.T) {
+		eachLayout(t, "clone", func(t *testing.T, f fixture) {
+			require.NoError(t, os.WriteFile(filepath.Join(f.root, "base.txt"), []byte("hello\nedited\n"), 0o644))
+
+			last, err := f.client.GetLastCommit()
+			require.NoError(t, err)
+			require.Equal(t, headCommit(t, f.client), last)
+			require.NotEqual(t, f.baseSHA, last)
+		})
+	})
+
+	t.Run("skips an empty working copy above local work", func(t *testing.T) {
+		eachLayout(t, "clone-local-commit", func(t *testing.T, f fixture) {
+			last, err := f.client.GetLastCommit()
+			require.NoError(t, err)
+			require.NotEqual(t, f.baseSHA, last, "the local commit is the last committed state")
+			require.NotEqual(t, headCommit(t, f.client), last)
+		})
 	})
 }
 

--- a/internal/jj/client_test.go
+++ b/internal/jj/client_test.go
@@ -421,6 +421,18 @@ func TestGetCommitDoesNotSnapshotTheWorkingCopy(t *testing.T) {
 	})
 }
 
+func TestHasCommit(t *testing.T) {
+	eachLayout(t, "clone-local-work", func(t *testing.T, f fixture) {
+		head, err := f.client.GetHeadCommit()
+		require.NoError(t, err)
+
+		require.True(t, f.client.HasCommit(head))
+		require.True(t, f.client.HasCommit(f.baseSHA))
+		require.False(t, f.client.HasCommit("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"))
+		require.False(t, f.client.HasCommit(""))
+	})
+}
+
 func TestIsAncestor(t *testing.T) {
 	eachLayout(t, "clone-local-work", func(t *testing.T, f fixture) {
 		head, err := f.client.GetHeadCommit()

--- a/internal/jj/client_test.go
+++ b/internal/jj/client_test.go
@@ -169,6 +169,10 @@ func TestGetHead(t *testing.T) {
 		head, err := f.client.GetHeadCommit()
 		require.NoError(t, err)
 		require.Len(t, head, 40)
+
+		short := f.client.GetShortHead()
+		require.Len(t, short, 7)
+		require.NotEqual(t, head[:7], short, "GetShortHead reports a change id, not a commit id")
 	})
 }
 
@@ -182,5 +186,43 @@ func TestGetHeadCommitTracksWorkingCopy(t *testing.T) {
 		after, err := f.client.GetHeadCommit()
 		require.NoError(t, err)
 		require.NotEqual(t, before, after, "jj snapshots the working copy into @")
+	})
+}
+
+// GetShortHead keys sandbox sessions, so it has to survive @ being rewritten.
+func TestGetShortHeadSurvivesWorkingCopyEdits(t *testing.T) {
+	eachLayout(t, "clone", func(t *testing.T, f fixture) {
+		beforeCommit, err := f.client.GetHeadCommit()
+		require.NoError(t, err)
+		beforeShort := f.client.GetShortHead()
+		require.NotEmpty(t, beforeShort)
+
+		require.NoError(t, os.WriteFile(filepath.Join(f.root, "base.txt"), []byte("hello\nedited\n"), 0o644))
+
+		afterCommit, err := f.client.GetHeadCommit()
+		require.NoError(t, err)
+		require.NotEqual(t, beforeCommit, afterCommit, "jj rewrites @ on every snapshot")
+		require.Equal(t, beforeShort, f.client.GetShortHead(), "the session key must survive the rewrite")
+
+		// The rewritten commit is not a descendant of the one it replaced, which
+		// is exactly why the commit id cannot key the session...
+		require.False(t, f.client.IsAncestor(beforeCommit, afterCommit))
+		// ...while the change id still resolves to the current working copy, so
+		// the sandbox ancestry fallback keeps matching the existing session.
+		require.True(t, f.client.IsAncestor(beforeShort, "HEAD"))
+	})
+}
+
+func TestIsAncestor(t *testing.T) {
+	eachLayout(t, "clone-local-work", func(t *testing.T, f fixture) {
+		head, err := f.client.GetHeadCommit()
+		require.NoError(t, err)
+
+		require.True(t, f.client.IsAncestor(f.baseSHA, head))
+		require.True(t, f.client.IsAncestor(f.baseSHA, "HEAD"))
+		require.False(t, f.client.IsAncestor(head, f.baseSHA))
+		require.False(t, f.client.IsAncestor("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", head))
+		require.False(t, f.client.IsAncestor("", head))
+		require.False(t, f.client.IsAncestor(f.baseSHA, ""))
 	})
 }

--- a/internal/jj/client_test.go
+++ b/internal/jj/client_test.go
@@ -716,3 +716,62 @@ func originRef(t *testing.T, origin string) string {
 	}
 	return strings.TrimSpace(string(out))
 }
+
+func TestApplyPatch(t *testing.T) {
+	t.Run("applies to the working copy", func(t *testing.T) {
+		eachLayout(t, "clone", func(t *testing.T, f fixture) {
+			patch := []byte("diff --git a/base.txt b/base.txt\n" +
+				"--- a/base.txt\n" +
+				"+++ b/base.txt\n" +
+				"@@ -1 +1,2 @@\n" +
+				" hello\n" +
+				"+applied\n")
+
+			out, err := f.client.ApplyPatch(patch).CombinedOutput()
+			require.NoError(t, err, "git apply failed: %s", out)
+
+			contents, err := os.ReadFile(filepath.Join(f.root, "base.txt"))
+			require.NoError(t, err)
+			require.Equal(t, "hello\napplied\n", string(contents))
+
+			head, err := f.client.GetHeadCommit()
+			require.NoError(t, err)
+			require.True(t, f.client.HasCommit(head), "jj snapshots the applied patch into @")
+		})
+	})
+
+	t.Run("honors .gitattributes", func(t *testing.T) {
+		eachLayout(t, "clone", func(t *testing.T, f fixture) {
+			require.NoError(t, os.WriteFile(filepath.Join(f.root, ".gitattributes"), []byte("*.txt text eol=crlf\n"), 0o644))
+
+			patch := []byte("diff --git a/base.txt b/base.txt\n" +
+				"--- a/base.txt\n" +
+				"+++ b/base.txt\n" +
+				"@@ -1 +1 @@\n" +
+				"-hello\n" +
+				"+converted\n")
+
+			out, err := f.client.ApplyPatch(patch).CombinedOutput()
+			require.NoError(t, err, "git apply failed: %s", out)
+
+			body, err := os.ReadFile(filepath.Join(f.root, "base.txt"))
+			require.NoError(t, err)
+			require.Equal(t, "converted\r\n", string(body))
+		})
+	})
+
+	t.Run("writes .rej files for hunks that do not apply", func(t *testing.T) {
+		eachLayout(t, "clone", func(t *testing.T, f fixture) {
+			patch := []byte("diff --git a/base.txt b/base.txt\n" +
+				"--- a/base.txt\n" +
+				"+++ b/base.txt\n" +
+				"@@ -1 +1,2 @@\n" +
+				" nonmatching\n" +
+				"+applied\n")
+
+			_, err := f.client.ApplyPatchReject(patch).CombinedOutput()
+			require.Error(t, err)
+			require.FileExists(t, filepath.Join(f.root, "base.txt.rej"))
+		})
+	})
+}

--- a/internal/jj/client_test.go
+++ b/internal/jj/client_test.go
@@ -502,6 +502,19 @@ func TestGeneratePatch(t *testing.T) {
 			require.Equal(t, []string{"seed.bin"}, lfs.Files)
 		})
 	})
+
+	t.Run("refuses a conflicted working copy", func(t *testing.T) {
+		eachLayout(t, "clone-conflicted-merge", func(t *testing.T, f fixture) {
+			patch, lfs, err := f.client.GeneratePatch(nil)
+			require.NoError(t, err)
+			require.Nil(t, lfs)
+			require.Empty(t, patch, "nothing from the conflicted store may leak into a patch")
+
+			_, err = f.client.GeneratePatchFile(filepath.Join(f.tempDir, "patches"), nil)
+			require.ErrorContains(t, err, "unresolved conflicts")
+			require.ErrorContains(t, err, "jj resolve")
+		})
+	})
 }
 
 func TestGeneratePatchRoundTripsThroughGitApply(t *testing.T) {

--- a/internal/jj/client_test.go
+++ b/internal/jj/client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/rwx-cloud/rwx/internal/jj"
+	"github.com/rwx-cloud/rwx/internal/vcs/vcstypes"
 	"github.com/stretchr/testify/require"
 )
 
@@ -652,4 +653,66 @@ func TestIsAncestor(t *testing.T) {
 		require.False(t, f.client.IsAncestor("", head))
 		require.False(t, f.client.IsAncestor(f.baseSHA, ""))
 	})
+}
+
+func TestPushRef(t *testing.T) {
+	t.Run("pushes the working copy commit", func(t *testing.T) {
+		eachLayout(t, "clone-local-work", func(t *testing.T, f fixture) {
+			head, err := f.client.GetHeadCommit()
+			require.NoError(t, err)
+
+			opts := vcstypes.PushRefOptions{Remote: f.origin, Refspec: "+" + head + ":refs/rwx/test"}
+			require.NoError(t, f.client.PushRef(opts))
+
+			require.Equal(t, head, originRef(t, f.origin))
+		})
+	})
+
+	t.Run("validates its options", func(t *testing.T) {
+		eachLayout(t, "clone", func(t *testing.T, f fixture) {
+			require.ErrorContains(t, f.client.PushRef(vcstypes.PushRefOptions{Refspec: "a:b"}), "no remote provided")
+			require.ErrorContains(t, f.client.PushRef(vcstypes.PushRefOptions{Remote: f.origin}), "no refspec provided")
+		})
+	})
+
+	t.Run("rejects a commit missing from the store", func(t *testing.T) {
+		eachLayout(t, "clone", func(t *testing.T, f fixture) {
+			missing := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+			err := f.client.PushRef(vcstypes.PushRefOptions{
+				Remote:  f.origin,
+				Refspec: "+" + missing + ":refs/rwx/test",
+			})
+			require.ErrorContains(t, err, "not in the git store")
+			require.ErrorContains(t, err, missing)
+		})
+	})
+
+	t.Run("rejects a conflicted working copy", func(t *testing.T) {
+		eachLayout(t, "clone-conflicted-merge", func(t *testing.T, f fixture) {
+			head, err := f.client.GetHeadCommit()
+			require.NoError(t, err)
+
+			body, err := os.ReadFile(filepath.Join(f.root, "base.txt"))
+			require.NoError(t, err)
+			require.Contains(t, string(body), "<<<<<<<", "fixture should leave the working copy conflicted")
+
+			err = f.client.PushRef(vcstypes.PushRefOptions{Remote: f.origin, Refspec: "+" + head + ":refs/rwx/test"})
+			require.ErrorContains(t, err, "unresolved conflicts")
+			require.ErrorContains(t, err, "jj resolve")
+
+			require.Empty(t, originRef(t, f.origin), "nothing should have been pushed")
+		})
+	})
+}
+
+// originRef resolves the ref PushRef targets, or "" when it was never created.
+func originRef(t *testing.T, origin string) string {
+	t.Helper()
+
+	out, err := exec.Command("git", "-C", origin, "rev-parse", "refs/rwx/test").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }

--- a/internal/jj/client_test.go
+++ b/internal/jj/client_test.go
@@ -154,6 +154,7 @@ func TestGetTopLevel(t *testing.T) {
 		client := newClient(t.TempDir())
 		require.False(t, client.IsInsideWorkTree())
 		require.Empty(t, client.GetTopLevel())
+		require.Empty(t, client.GetBranch())
 	})
 }
 
@@ -162,6 +163,45 @@ func TestMissingDependency(t *testing.T) {
 
 	require.Equal(t, "jj", (&jj.Client{Binary: "jj-not-installed", GitBinary: "git"}).MissingDependency())
 	require.Equal(t, "git", (&jj.Client{Binary: "jj", GitBinary: "git-not-installed"}).MissingDependency())
+}
+
+func TestGetBranch(t *testing.T) {
+	t.Run("returns the bookmark on the working copy", func(t *testing.T) {
+		eachLayout(t, "clone-bookmark-on-working-copy", func(t *testing.T, f fixture) {
+			require.Equal(t, "feature", f.client.GetBranch())
+		})
+	})
+
+	// `main` stays on the base commit as @ moves ahead of it.
+	t.Run("returns the nearest bookmark below the working copy", func(t *testing.T) {
+		eachLayout(t, "clone-local-work", func(t *testing.T, f fixture) {
+			require.Equal(t, "main", f.client.GetBranch())
+		})
+	})
+
+	// `feature` sits on the described change, closer to @ than `main`.
+	t.Run("prefers the closest bookmark", func(t *testing.T) {
+		eachLayout(t, "clone-bookmark-on-ancestor", func(t *testing.T, f fixture) {
+			require.Equal(t, "feature", f.client.GetBranch())
+		})
+	})
+
+	// @ merges two bookmarked lines, neither closer than the other. `aaa-local`
+	// sorts first but only `topic` exists on the remote.
+	t.Run("prefers a bookmark that exists on the remote when the nearest are tied", func(t *testing.T) {
+		eachLayout(t, "clone-merged-bookmarks", func(t *testing.T, f fixture) {
+			require.Equal(t, "topic", f.client.GetBranch())
+
+			t.Setenv("RWX_GIT_REMOTE", "nonexistent")
+			require.Equal(t, "aaa-local", f.client.GetBranch(), "falls back to name order without a remote match")
+		})
+	})
+
+	t.Run("is empty when the repository has no bookmarks", func(t *testing.T) {
+		eachLayout(t, "init-local-commit", func(t *testing.T, f fixture) {
+			require.Empty(t, f.client.GetBranch())
+		})
+	})
 }
 
 func TestGetHead(t *testing.T) {

--- a/internal/jj/client_test.go
+++ b/internal/jj/client_test.go
@@ -595,6 +595,18 @@ func TestGeneratePatchFile(t *testing.T) {
 	})
 }
 
+func TestGenerateDirtyPatches(t *testing.T) {
+	eachLayout(t, "clone-local-work", func(t *testing.T, f fixture) {
+		patches, err := f.client.GenerateDirtyPatches()
+		require.NoError(t, err)
+		require.Empty(t, patches.Staged)
+		require.Empty(t, patches.Unstaged)
+		require.Nil(t, patches.Files)
+		require.Nil(t, patches.NewFiles)
+		require.Equal(t, 0, patches.Size())
+	})
+}
+
 // A secondary workspace's .jj/repo is a file pointing at the primary one.
 func TestSecondaryWorkspace(t *testing.T) {
 	eachLayout(t, "clone-secondary-workspace", func(t *testing.T, f fixture) {

--- a/internal/jj/client_test.go
+++ b/internal/jj/client_test.go
@@ -1,0 +1,165 @@
+package jj_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rwx-cloud/rwx/internal/jj"
+	"github.com/stretchr/testify/require"
+)
+
+func requireJJ(t *testing.T) {
+	t.Helper()
+
+	if _, err := exec.LookPath("jj"); err != nil {
+		t.Skip("jj is not installed")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not installed")
+	}
+}
+
+type fixture struct {
+	tempDir string
+	root    string
+	origin  string
+	baseSHA string
+	client  *jj.Client
+}
+
+// isolateVCSEnv keeps jj and git from reading the developer's real
+// configuration. jj gets an empty config file rather than /dev/null, whose
+// handling as a character device varies.
+func isolateVCSEnv(t *testing.T, dir string) {
+	t.Helper()
+
+	jjConfig := filepath.Join(dir, "jj-config.toml")
+	require.NoError(t, os.WriteFile(jjConfig, nil, 0o644))
+
+	t.Setenv("JJ_USER", "Test User")
+	t.Setenv("JJ_EMAIL", "test@example.com")
+	t.Setenv("JJ_CONFIG", jjConfig)
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	t.Setenv("GIT_AUTHOR_NAME", "Test User")
+	t.Setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "Test User")
+	t.Setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+	t.Setenv("RWX_GIT_REMOTE", "")
+	t.Setenv("RWX_VCS", "")
+}
+
+func newClient(dir string) *jj.Client {
+	return &jj.Client{Binary: "jj", GitBinary: "git", Dir: dir}
+}
+
+// repoFixture runs the named testdata script in a scratch directory and returns
+// the repository it built. Reading the script also registers it with the go test
+// cache, so editing a fixture invalidates any cached result.
+func repoFixture(t *testing.T, name string, colocated bool) fixture {
+	t.Helper()
+	requireJJ(t)
+
+	tempDir := t.TempDir()
+	isolateVCSEnv(t, tempDir)
+
+	colocate := "--no-colocate"
+	if colocated {
+		colocate = "--colocate"
+	}
+	t.Setenv("COLOCATE", colocate)
+
+	script, err := os.ReadFile(filepath.Join("testdata", name))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, name), script, 0o755))
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("bash", name)
+	cmd.Dir = tempDir
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("fixture %s failed: %v\nstdout: %s\nstderr: %s", name, err, &stdout, &stderr)
+	}
+
+	root := filepath.Join(tempDir, "repo")
+	return fixture{
+		tempDir: tempDir,
+		root:    root,
+		origin:  filepath.Join(tempDir, "origin"),
+		baseSHA: lastWord(stdout.String()),
+		client:  newClient(root),
+	}
+}
+
+// lastWord reads the base commit a fixture printed, or "" when it printed none.
+func lastWord(out string) string {
+	words := strings.Fields(out)
+	if len(words) == 0 {
+		return ""
+	}
+	return words[len(words)-1]
+}
+
+// eachLayout runs fn against both jj layouts: a workspace with its own git store
+// and a colocated one sharing a .git with the working copy.
+func eachLayout(t *testing.T, fixturePath string, fn func(t *testing.T, f fixture)) {
+	t.Helper()
+
+	for _, layout := range []struct {
+		name      string
+		colocated bool
+	}{
+		{"non-colocated", false},
+		{"colocated", true},
+	} {
+		t.Run(layout.name, func(t *testing.T) {
+			fn(t, repoFixture(t, fixturePath, layout.colocated))
+		})
+	}
+}
+
+func requireSamePath(t *testing.T, want, got string) {
+	t.Helper()
+
+	resolvedWant, err := filepath.EvalSymlinks(want)
+	require.NoError(t, err)
+	resolvedGot, err := filepath.EvalSymlinks(got)
+	require.NoError(t, err)
+	require.Equal(t, resolvedWant, resolvedGot)
+}
+
+func TestGetTopLevel(t *testing.T) {
+	t.Run("finds the workspace root", func(t *testing.T) {
+		eachLayout(t, "clone", func(t *testing.T, f fixture) {
+			requireSamePath(t, f.root, f.client.GetTopLevel())
+			require.True(t, f.client.IsInsideWorkTree())
+			require.Empty(t, f.client.MissingDependency())
+		})
+	})
+
+	t.Run("finds it from a subdirectory", func(t *testing.T) {
+		eachLayout(t, "clone", func(t *testing.T, f fixture) {
+			requireSamePath(t, f.root, newClient(filepath.Join(f.root, "nested")).GetTopLevel())
+		})
+	})
+
+	t.Run("is empty outside a repository", func(t *testing.T) {
+		requireJJ(t)
+
+		client := newClient(t.TempDir())
+		require.False(t, client.IsInsideWorkTree())
+		require.Empty(t, client.GetTopLevel())
+	})
+}
+
+func TestMissingDependency(t *testing.T) {
+	requireJJ(t)
+
+	require.Equal(t, "jj", (&jj.Client{Binary: "jj-not-installed", GitBinary: "git"}).MissingDependency())
+	require.Equal(t, "git", (&jj.Client{Binary: "jj", GitBinary: "git-not-installed"}).MissingDependency())
+}

--- a/internal/jj/client_test.go
+++ b/internal/jj/client_test.go
@@ -238,8 +238,20 @@ func TestGetRemoteUrl(t *testing.T) {
 			t.Setenv("RWX_GIT_REMOTE", "upstream")
 
 			requireSamePath(t, f.origin, f.client.GetOriginUrl())
+
+			sha, err := f.client.GetCommit()
+			require.NoError(t, err)
+			require.Equal(t, f.baseSHA, sha)
 		})
 	})
+}
+
+func headCommit(t *testing.T, client *jj.Client) string {
+	t.Helper()
+
+	head, err := client.GetHeadCommit()
+	require.NoError(t, err)
+	return head
 }
 
 func TestGetHead(t *testing.T) {
@@ -288,6 +300,124 @@ func TestGetShortHeadSurvivesWorkingCopyEdits(t *testing.T) {
 		// ...while the change id still resolves to the current working copy, so
 		// the sandbox ancestry fallback keeps matching the existing session.
 		require.True(t, f.client.IsAncestor(beforeShort, "HEAD"))
+	})
+}
+
+func TestGetCommit(t *testing.T) {
+	t.Run("returns the remote commit when the working copy is clean", func(t *testing.T) {
+		eachLayout(t, "clone", func(t *testing.T, f fixture) {
+			sha, err := f.client.GetCommit()
+			require.NoError(t, err)
+			require.Equal(t, f.baseSHA, sha)
+		})
+	})
+
+	t.Run("returns the remote commit when ahead of the remote", func(t *testing.T) {
+		eachLayout(t, "clone-local-work", func(t *testing.T, f fixture) {
+			sha, err := f.client.GetCommit()
+			require.NoError(t, err)
+			require.Equal(t, f.baseSHA, sha)
+		})
+	})
+
+	t.Run("returns the shared commit when behind the remote", func(t *testing.T) {
+		eachLayout(t, "clone-behind-origin", func(t *testing.T, f fixture) {
+			sha, err := f.client.GetCommit()
+			require.NoError(t, err)
+			require.Equal(t, f.baseSHA, sha)
+		})
+	})
+
+	t.Run("returns the fork point when both sides have moved on", func(t *testing.T) {
+		eachLayout(t, "clone-diverged-from-origin", func(t *testing.T, f fixture) {
+			sha, err := f.client.GetCommit()
+			require.NoError(t, err)
+			require.Equal(t, f.baseSHA, sha)
+		})
+	})
+
+	t.Run("returns the fork point for work left behind a bookmark", func(t *testing.T) {
+		eachLayout(t, "clone-bookmark-on-ancestor", func(t *testing.T, f fixture) {
+			sha, err := f.client.GetCommit()
+			require.NoError(t, err)
+			require.Equal(t, f.baseSHA, sha)
+		})
+	})
+
+	t.Run("falls back to the working copy in a repository with no remotes", func(t *testing.T) {
+		eachLayout(t, "init-uncommitted", func(t *testing.T, f fixture) {
+			sha, err := f.client.GetCommit()
+			require.NoError(t, err)
+			require.Equal(t, headCommit(t, f.client), sha)
+		})
+	})
+
+	// No bookmark below @ is jj's detached HEAD, where the git backend answers
+	// with HEAD rather than erroring. Never the virtual root.
+	t.Run("falls back to the working copy without a common ancestor", func(t *testing.T) {
+		eachLayout(t, "init-unrelated-origin", func(t *testing.T, f fixture) {
+			sha, err := f.client.GetCommit()
+			require.NoError(t, err)
+			require.Equal(t, headCommit(t, f.client), sha)
+			require.NotEqual(t, strings.Repeat("0", 40), sha)
+		})
+	})
+
+	// A bookmark below @ is a named position, so the misconfiguration is
+	// reported, as git does on a branch.
+	t.Run("errors without a common ancestor when a bookmark names the change", func(t *testing.T) {
+		eachLayout(t, "init-unrelated-origin-bookmark", func(t *testing.T, f fixture) {
+			sha, err := f.client.GetCommit()
+			require.ErrorContains(t, err, "no commits in common")
+			require.ErrorContains(t, err, "feature")
+			require.Empty(t, sha)
+		})
+	})
+
+	t.Run("errors on a bookmarked line when no remote is named origin", func(t *testing.T) {
+		eachLayout(t, "clone-remote-named-upstream", func(t *testing.T, f fixture) {
+			_, err := f.client.GetCommit()
+			require.ErrorContains(t, err, "no git remote named 'origin' is configured")
+		})
+	})
+}
+
+// staleHead reads @ without letting jj snapshot.
+func staleHead(t *testing.T, root string) string {
+	t.Helper()
+
+	cmd := exec.Command("jj", "--no-pager", "--color=never", "--quiet", "--ignore-working-copy",
+		"log", "-r", "@", "--no-graph", "-T", "commit_id")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "jj log failed: %s", out)
+	return strings.TrimSpace(string(out))
+}
+
+// Reporting commands such as `rwx results` call GetCommit and nothing else, so
+// it must not rewrite @.
+func TestGetCommitDoesNotSnapshotTheWorkingCopy(t *testing.T) {
+	eachLayout(t, "clone-local-work", func(t *testing.T, f fixture) {
+		_, err := f.client.GetHeadCommit()
+		require.NoError(t, err)
+
+		require.NoError(t, os.WriteFile(filepath.Join(f.root, "base.txt"), []byte("uncommitted\n"), 0o644))
+		before := staleHead(t, f.root)
+
+		base, err := f.client.GetCommit()
+		require.NoError(t, err)
+		require.Equal(t, f.baseSHA, base)
+		require.Equal(t, before, staleHead(t, f.root), "GetCommit must leave @ alone")
+
+		// The base is unchanged by the snapshot, which is what makes the stale
+		// read safe.
+		head, err := f.client.GetHeadCommit()
+		require.NoError(t, err)
+		require.NotEqual(t, before, head, "GetHeadCommit does snapshot")
+
+		after, err := f.client.GetCommit()
+		require.NoError(t, err)
+		require.Equal(t, base, after)
 	})
 }
 

--- a/internal/jj/client_test.go
+++ b/internal/jj/client_test.go
@@ -421,6 +421,188 @@ func TestGetCommitDoesNotSnapshotTheWorkingCopy(t *testing.T) {
 	})
 }
 
+func TestGeneratePatch(t *testing.T) {
+	t.Run("covers local commits and working copy changes", func(t *testing.T) {
+		eachLayout(t, "clone-local-work", func(t *testing.T, f fixture) {
+			patch, lfs, err := f.client.GeneratePatch(nil)
+			require.NoError(t, err)
+			require.Nil(t, lfs)
+
+			text := string(patch)
+			require.Contains(t, text, "+committed")
+			require.Contains(t, text, "+working copy")
+			require.Contains(t, text, "b/added.txt")
+			require.Contains(t, text, "b/nested/more/x.txt")
+			require.Contains(t, text, "a/sub.txt")
+			require.Contains(t, text, "deleted file mode")
+		})
+	})
+
+	t.Run("includes local commits with a clean working copy", func(t *testing.T) {
+		eachLayout(t, "clone-local-commit", func(t *testing.T, f fixture) {
+			patch, _, err := f.client.GeneratePatch(nil)
+			require.NoError(t, err)
+			require.Contains(t, string(patch), "+committed")
+		})
+	})
+
+	t.Run("includes files that only exist in the working copy", func(t *testing.T) {
+		eachLayout(t, "clone-new-file", func(t *testing.T, f fixture) {
+			patch, _, err := f.client.GeneratePatch(nil)
+			require.NoError(t, err)
+			require.Contains(t, string(patch), "b/added.txt")
+			require.Contains(t, string(patch), "+brand new")
+		})
+	})
+
+	t.Run("is empty when the working copy matches the remote", func(t *testing.T) {
+		eachLayout(t, "clone", func(t *testing.T, f fixture) {
+			patch, lfs, err := f.client.GeneratePatch(nil)
+			require.NoError(t, err)
+			require.Nil(t, lfs)
+			require.Empty(t, patch)
+		})
+	})
+
+	t.Run("omits ignored files", func(t *testing.T) {
+		eachLayout(t, "clone-ignored-file", func(t *testing.T, f fixture) {
+			patch, _, err := f.client.GeneratePatch(nil)
+			require.NoError(t, err)
+			require.Contains(t, string(patch), "+tracked change")
+			require.NotContains(t, string(patch), "b/ignored.txt")
+			require.NotContains(t, string(patch), "do not send")
+		})
+	})
+
+	t.Run("honors pathspec exclusions", func(t *testing.T) {
+		eachLayout(t, "clone-local-work", func(t *testing.T, f fixture) {
+			patch, _, err := f.client.GeneratePatch([]string{":/", ":(top,exclude)added.txt"})
+			require.NoError(t, err)
+			require.NotContains(t, string(patch), "b/added.txt")
+			require.Contains(t, string(patch), "b/base.txt")
+		})
+	})
+
+	t.Run("keeps paths relative to the repository root", func(t *testing.T) {
+		eachLayout(t, "clone-local-work", func(t *testing.T, f fixture) {
+			patch, _, err := newClient(filepath.Join(f.root, "nested")).GeneratePatch(nil)
+			require.NoError(t, err)
+			require.Contains(t, string(patch), "b/base.txt")
+			require.Contains(t, string(patch), "b/nested/more/x.txt")
+		})
+	})
+
+	t.Run("reports LFS-tracked changes instead of a patch", func(t *testing.T) {
+		eachLayout(t, "clone-lfs-file", func(t *testing.T, f fixture) {
+			patch, lfs, err := f.client.GeneratePatch(nil)
+			require.NoError(t, err)
+			require.Nil(t, patch)
+			require.NotNil(t, lfs)
+			require.Equal(t, 1, lfs.Count)
+			require.Equal(t, []string{"seed.bin"}, lfs.Files)
+		})
+	})
+}
+
+func TestGeneratePatchRoundTripsThroughGitApply(t *testing.T) {
+	eachLayout(t, "clone-local-work-binary", func(t *testing.T, f fixture) {
+		readWorkingCopy := func(rel string) []byte {
+			contents, err := os.ReadFile(filepath.Join(f.root, rel))
+			require.NoError(t, err)
+			return contents
+		}
+		wantModifiedBinary := readWorkingCopy("seed.bin")
+		wantNewBinary := readWorkingCopy("fresh.bin")
+
+		patch, lfs, err := f.client.GeneratePatch(nil)
+		require.NoError(t, err)
+		require.Nil(t, lfs)
+		require.Contains(t, string(patch), "GIT binary patch", "binary files need literal patch data to survive")
+
+		verify := filepath.Join(f.tempDir, "verify")
+		out, err := exec.Command("git", "clone", "-q", f.origin, verify).CombinedOutput()
+		require.NoError(t, err, "git clone failed: %s", out)
+
+		checkout := exec.Command("git", "checkout", "-q", f.baseSHA)
+		checkout.Dir = verify
+		out, err = checkout.CombinedOutput()
+		require.NoError(t, err, "git checkout failed: %s", out)
+
+		apply := exec.Command("git", "apply", "--allow-empty", "-")
+		apply.Dir = verify
+		apply.Stdin = bytes.NewReader(patch)
+		out, err = apply.CombinedOutput()
+		require.NoError(t, err, "git apply failed: %s", out)
+
+		requireFile := func(rel string, want []byte) {
+			got, err := os.ReadFile(filepath.Join(verify, rel))
+			require.NoError(t, err)
+			require.Equal(t, want, got, "mismatch for %s", rel)
+		}
+		requireFile("base.txt", []byte("hello\ncommitted\nworking copy\n"))
+		requireFile("added.txt", []byte("added\n"))
+		requireFile("nested/more/x.txt", []byte("deeper\n"))
+		requireFile("seed.bin", wantModifiedBinary)
+		requireFile("fresh.bin", wantNewBinary)
+		require.NoFileExists(t, filepath.Join(verify, "sub.txt"))
+	})
+}
+
+func TestGeneratePatchFile(t *testing.T) {
+	t.Run("writes a patch named for the base commit", func(t *testing.T) {
+		eachLayout(t, "clone-local-work", func(t *testing.T, f fixture) {
+			destDir := filepath.Join(f.tempDir, "patches")
+			patchFile, err := f.client.GeneratePatchFile(destDir, nil)
+			require.NoError(t, err)
+			require.True(t, patchFile.Written)
+			require.Equal(t, filepath.Join(destDir, f.baseSHA), patchFile.Path)
+
+			contents, err := os.ReadFile(patchFile.Path)
+			require.NoError(t, err)
+			require.Contains(t, string(contents), "+working copy")
+		})
+	})
+
+	t.Run("writes nothing when there are no changes", func(t *testing.T) {
+		eachLayout(t, "clone", func(t *testing.T, f fixture) {
+			patchFile, err := f.client.GeneratePatchFile(filepath.Join(f.tempDir, "patches"), nil)
+			require.NoError(t, err)
+			require.False(t, patchFile.Written)
+			require.Empty(t, patchFile.Path)
+		})
+	})
+
+	t.Run("reports LFS-tracked changes", func(t *testing.T) {
+		eachLayout(t, "clone-lfs-file", func(t *testing.T, f fixture) {
+			patchFile, err := f.client.GeneratePatchFile(filepath.Join(f.tempDir, "patches"), nil)
+			require.NoError(t, err)
+			require.False(t, patchFile.Written)
+			require.Equal(t, 1, patchFile.LFSChangedFiles.Count)
+		})
+	})
+}
+
+// A secondary workspace's .jj/repo is a file pointing at the primary one.
+func TestSecondaryWorkspace(t *testing.T) {
+	eachLayout(t, "clone-secondary-workspace", func(t *testing.T, f fixture) {
+		workspace := filepath.Join(f.tempDir, "workspace")
+		client := newClient(workspace)
+
+		requireSamePath(t, workspace, client.GetTopLevel())
+
+		require.NoError(t, os.WriteFile(filepath.Join(workspace, "added.txt"), []byte("from the workspace\n"), 0o644))
+
+		sha, err := client.GetCommit()
+		require.NoError(t, err)
+		require.Equal(t, f.baseSHA, sha)
+
+		patch, _, err := client.GeneratePatch(nil)
+		require.NoError(t, err)
+		require.Contains(t, string(patch), "b/added.txt")
+		require.Contains(t, string(patch), "+from the workspace")
+	})
+}
+
 func TestHasCommit(t *testing.T) {
 	eachLayout(t, "clone-local-work", func(t *testing.T, f fixture) {
 		head, err := f.client.GetHeadCommit()

--- a/internal/jj/client_test.go
+++ b/internal/jj/client_test.go
@@ -775,3 +775,28 @@ func TestApplyPatch(t *testing.T) {
 		})
 	})
 }
+
+// Files over snapshot.max-new-file-size vanish from every patch, so jj's
+// warning has to reach the user.
+func TestSnapshotRefusalIsReported(t *testing.T) {
+	eachLayout(t, "clone", func(t *testing.T, f fixture) {
+		var warnings bytes.Buffer
+		f.client.Stderr = &warnings
+
+		big := make([]byte, 2*1024*1024)
+		require.NoError(t, os.WriteFile(filepath.Join(f.root, "big.bin"), big, 0o644))
+
+		_, err := f.client.GetHeadCommit()
+		require.NoError(t, err, "the refusal must not fail the command")
+
+		require.Contains(t, warnings.String(), "big.bin")
+		require.Contains(t, warnings.String(), "excluded from RWX patches")
+
+		patch, _, err := f.client.GeneratePatch(nil)
+		require.NoError(t, err)
+		require.NotContains(t, string(patch), "big.bin", "the skipped file really is missing from the patch")
+
+		// jj repeated the refusal on the second snapshot; the user hears it once.
+		require.Equal(t, 1, strings.Count(warnings.String(), "Refused to snapshot"))
+	})
+}

--- a/internal/jj/client_test.go
+++ b/internal/jj/client_test.go
@@ -163,3 +163,24 @@ func TestMissingDependency(t *testing.T) {
 	require.Equal(t, "jj", (&jj.Client{Binary: "jj-not-installed", GitBinary: "git"}).MissingDependency())
 	require.Equal(t, "git", (&jj.Client{Binary: "jj", GitBinary: "git-not-installed"}).MissingDependency())
 }
+
+func TestGetHead(t *testing.T) {
+	eachLayout(t, "clone", func(t *testing.T, f fixture) {
+		head, err := f.client.GetHeadCommit()
+		require.NoError(t, err)
+		require.Len(t, head, 40)
+	})
+}
+
+func TestGetHeadCommitTracksWorkingCopy(t *testing.T) {
+	eachLayout(t, "clone", func(t *testing.T, f fixture) {
+		before, err := f.client.GetHeadCommit()
+		require.NoError(t, err)
+
+		require.NoError(t, os.WriteFile(filepath.Join(f.root, "base.txt"), []byte("hello\nchanged\n"), 0o644))
+
+		after, err := f.client.GetHeadCommit()
+		require.NoError(t, err)
+		require.NotEqual(t, before, after, "jj snapshots the working copy into @")
+	})
+}

--- a/internal/jj/client_test.go
+++ b/internal/jj/client_test.go
@@ -204,6 +204,44 @@ func TestGetBranch(t *testing.T) {
 	})
 }
 
+func TestGetRemoteUrl(t *testing.T) {
+	t.Run("resolves origin", func(t *testing.T) {
+		eachLayout(t, "clone", func(t *testing.T, f fixture) {
+			requireSamePath(t, f.origin, f.client.GetOriginUrl())
+			requireSamePath(t, f.origin, f.client.GetRemoteUrl("origin"))
+			require.Empty(t, f.client.GetRemoteUrl("upstream"))
+		})
+	})
+
+	t.Run("picks origin out of several remotes", func(t *testing.T) {
+		eachLayout(t, "clone-many-remotes", func(t *testing.T, f fixture) {
+			requireSamePath(t, f.origin, f.client.GetOriginUrl())
+			require.NotEmpty(t, f.client.GetRemoteUrl("upstream"))
+		})
+	})
+
+	t.Run("is empty without any remote", func(t *testing.T) {
+		eachLayout(t, "init-uncommitted", func(t *testing.T, f fixture) {
+			require.Empty(t, f.client.GetOriginUrl())
+		})
+	})
+
+	t.Run("is empty when no remote is named origin", func(t *testing.T) {
+		eachLayout(t, "clone-remote-named-upstream", func(t *testing.T, f fixture) {
+			require.Empty(t, f.client.GetOriginUrl())
+			require.NotEmpty(t, f.client.GetRemoteUrl("upstream"))
+		})
+	})
+
+	t.Run("honors RWX_GIT_REMOTE", func(t *testing.T) {
+		eachLayout(t, "clone-remote-named-upstream", func(t *testing.T, f fixture) {
+			t.Setenv("RWX_GIT_REMOTE", "upstream")
+
+			requireSamePath(t, f.origin, f.client.GetOriginUrl())
+		})
+	})
+}
+
 func TestGetHead(t *testing.T) {
 	eachLayout(t, "clone", func(t *testing.T, f fixture) {
 		head, err := f.client.GetHeadCommit()

--- a/internal/jj/testdata/clone
+++ b/internal/jj/testdata/clone
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+mkdir nested
+printf 'nested\n' > nested/deep.txt
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on.
+git rev-parse HEAD
+cd ..
+
+jj git clone $COLOCATE origin repo

--- a/internal/jj/testdata/clone-behind-origin
+++ b/internal/jj/testdata/clone-behind-origin
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on: the newest commit the
+# clone and the remote still share once the remote moves on below.
+git rev-parse HEAD
+cd ..
+
+jj git clone $COLOCATE origin repo
+
+cd origin
+printf 'hello\nremote moved on\n' > base.txt
+git commit -qam "remote commit"
+cd ..
+
+cd repo
+jj git fetch

--- a/internal/jj/testdata/clone-bookmark-on-ancestor
+++ b/internal/jj/testdata/clone-bookmark-on-ancestor
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on.
+git rev-parse HEAD
+cd ..
+
+jj git clone $COLOCATE origin repo
+cd repo
+
+# jj does not advance bookmarks, so committing leaves `feature` behind on @'s
+# ancestor rather than carrying it along.
+jj bookmark set feature -r @
+printf 'hello\nfeature work\n' > base.txt
+jj commit -m "feature work"

--- a/internal/jj/testdata/clone-bookmark-on-working-copy
+++ b/internal/jj/testdata/clone-bookmark-on-working-copy
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on.
+git rev-parse HEAD
+cd ..
+
+jj git clone $COLOCATE origin repo
+cd repo
+
+# `main` stays on @'s parent, so only `feature` names the working copy itself.
+jj bookmark set feature -r @

--- a/internal/jj/testdata/clone-conflicted-merge
+++ b/internal/jj/testdata/clone-conflicted-merge
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on.
+git rev-parse HEAD
+cd ..
+
+jj git clone $COLOCATE origin repo
+cd repo
+
+head_commit() {
+  jj log -r @ --no-graph -T commit_id
+}
+
+# Two siblings edit the same line; merging both leaves @ conflicted.
+jj new main -m side-a
+printf 'aaa\n' > base.txt
+side_a=$(head_commit)
+
+jj new main -m side-b
+printf 'bbb\n' > base.txt
+side_b=$(head_commit)
+
+jj new "$side_a" "$side_b" -m merge

--- a/internal/jj/testdata/clone-diverged-from-origin
+++ b/internal/jj/testdata/clone-diverged-from-origin
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on: the fork point, which is
+# neither the remote's head nor the working copy once both move on below.
+git rev-parse HEAD
+cd ..
+
+jj git clone $COLOCATE origin repo
+
+cd origin
+printf 'hello\nremote moved on\n' > base.txt
+git commit -qam "remote commit"
+cd ..
+
+cd repo
+jj git fetch
+printf 'hello\nlocal work\n' > base.txt
+jj commit -m "local work"

--- a/internal/jj/testdata/clone-ignored-file
+++ b/internal/jj/testdata/clone-ignored-file
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on.
+git rev-parse HEAD
+cd ..
+
+jj git clone $COLOCATE origin repo
+cd repo
+
+printf 'ignored.txt\n' > .gitignore
+printf 'do not send\n' > ignored.txt
+printf 'hello\ntracked change\n' > base.txt

--- a/internal/jj/testdata/clone-lfs-file
+++ b/internal/jj/testdata/clone-lfs-file
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+printf '\000\001\002\377\376bin\000\n' > seed.bin
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on.
+git rev-parse HEAD
+cd ..
+
+jj git clone $COLOCATE origin repo
+cd repo
+
+printf '*.bin filter=lfs diff=lfs merge=lfs -text\n' > .gitattributes
+printf '\000\001\002\377\376bin\000\001\n' > seed.bin

--- a/internal/jj/testdata/clone-local-commit
+++ b/internal/jj/testdata/clone-local-commit
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on.
+git rev-parse HEAD
+cd ..
+
+jj git clone $COLOCATE origin repo
+cd repo
+
+# A local commit and nothing uncommitted after it.
+printf 'hello\ncommitted\n' > base.txt
+jj commit -m "local work"

--- a/internal/jj/testdata/clone-local-work
+++ b/internal/jj/testdata/clone-local-work
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+printf 'sub content\n' > sub.txt
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on.
+git rev-parse HEAD
+cd ..
+
+jj git clone $COLOCATE origin repo
+cd repo
+
+printf 'hello\ncommitted\n' > base.txt
+jj commit -m "local work"
+
+# Uncommitted on top of that: a modification, two new files, a deletion.
+printf 'hello\ncommitted\nworking copy\n' > base.txt
+printf 'added\n' > added.txt
+mkdir -p nested/more
+printf 'deeper\n' > nested/more/x.txt
+rm sub.txt

--- a/internal/jj/testdata/clone-local-work-binary
+++ b/internal/jj/testdata/clone-local-work-binary
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+printf 'sub content\n' > sub.txt
+printf '\000\001\002\377\376bin\000\n' > seed.bin
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on.
+git rev-parse HEAD
+cd ..
+
+jj git clone $COLOCATE origin repo
+cd repo
+
+printf 'hello\ncommitted\n' > base.txt
+jj commit -m "local work"
+
+# Uncommitted on top of that: text and binary modifications, new text and
+# binary files, a deletion.
+printf 'hello\ncommitted\nworking copy\n' > base.txt
+printf 'added\n' > added.txt
+mkdir -p nested/more
+printf 'deeper\n' > nested/more/x.txt
+printf '\000\001\002\377\376bin\000\177\000\n' > seed.bin
+printf '\336\255\276\357\000\001' > fresh.bin
+rm sub.txt

--- a/internal/jj/testdata/clone-many-remotes
+++ b/internal/jj/testdata/clone-many-remotes
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on.
+git rev-parse HEAD
+cd ..
+
+git init -q --bare -b main other
+
+jj git clone $COLOCATE origin repo
+cd repo
+jj git remote add upstream ../other

--- a/internal/jj/testdata/clone-merged-bookmarks
+++ b/internal/jj/testdata/clone-merged-bookmarks
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+git add -A
+git commit -qm "base commit"
+
+git checkout -qb topic
+printf 'topic\n' > topic.txt
+git add -A
+git commit -qm "topic commit"
+git checkout -q main
+
+# The base commit patches are expected to be based on.
+git rev-parse HEAD
+cd ..
+
+jj git clone $COLOCATE origin repo
+cd repo
+
+# Two bookmarked lines above main, neither an ancestor of the other: `topic`
+# exists on the remote, `aaa-local` does not but sorts first.
+jj bookmark track topic@origin
+jj new main -m side
+printf 'side\n' > side.txt
+jj bookmark create aaa-local -r @
+
+# @ merges both, so both bookmarks are equally near.
+jj new aaa-local topic -m merge

--- a/internal/jj/testdata/clone-new-file
+++ b/internal/jj/testdata/clone-new-file
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on.
+git rev-parse HEAD
+cd ..
+
+jj git clone $COLOCATE origin repo
+
+# The only change is a file that exists nowhere in the history.
+printf 'brand new\n' > repo/added.txt

--- a/internal/jj/testdata/clone-remote-named-upstream
+++ b/internal/jj/testdata/clone-remote-named-upstream
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on.
+git rev-parse HEAD
+cd ..
+
+# The clone's only remote is named `upstream`, so nothing answers to `origin`.
+jj git clone $COLOCATE --remote upstream origin repo

--- a/internal/jj/testdata/clone-secondary-workspace
+++ b/internal/jj/testdata/clone-secondary-workspace
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'hello\n' > base.txt
+git add -A
+git commit -qm "base commit"
+
+# The base commit patches are expected to be based on.
+git rev-parse HEAD
+cd ..
+
+jj git clone $COLOCATE origin repo
+cd repo
+
+# A secondary workspace has no .jj/repo directory of its own — only a file
+# pointing back at this one's.
+jj workspace add ../workspace

--- a/internal/jj/testdata/init-local-commit
+++ b/internal/jj/testdata/init-local-commit
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+# A standalone repository: no remote, and no bookmark anywhere in it.
+jj git init $COLOCATE repo
+cd repo
+
+printf 'hello\n' > base.txt
+jj commit -m "only local work"

--- a/internal/jj/testdata/init-uncommitted
+++ b/internal/jj/testdata/init-uncommitted
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+# A standalone repository: no remote, and nothing committed.
+jj git init $COLOCATE repo
+printf 'hello\n' > repo/base.txt

--- a/internal/jj/testdata/init-unrelated-origin
+++ b/internal/jj/testdata/init-unrelated-origin
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'unrelated\n' > other.txt
+git add -A
+git commit -qm "unrelated root"
+cd ..
+
+# The repository is built from scratch rather than cloned, so it shares no
+# commit at all with the remote it then fetches.
+jj git init $COLOCATE repo
+cd repo
+
+jj git remote add origin ../origin
+jj git fetch
+printf 'hello\n' > base.txt
+jj commit -m "local root"

--- a/internal/jj/testdata/init-unrelated-origin-bookmark
+++ b/internal/jj/testdata/init-unrelated-origin-bookmark
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+git init -q -b main origin
+cd origin
+printf 'unrelated\n' > other.txt
+git add -A
+git commit -qm "unrelated root"
+cd ..
+
+# The repository is built from scratch rather than cloned, so it shares no
+# commit at all with the remote it then fetches.
+jj git init $COLOCATE repo
+cd repo
+
+jj git remote add origin ../origin
+jj git fetch
+printf 'hello\n' > base.txt
+jj commit -m "local root"
+jj bookmark set feature -r @

--- a/internal/mocks/vcs.go
+++ b/internal/mocks/vcs.go
@@ -12,6 +12,8 @@ type VCS struct {
 	MockGetBranch              string
 	MockGetHead                string
 	MockGetHeadError           error
+	MockGetLastCommit          string
+	MockGetLastCommitError     error
 	MockGetTopLevel            string
 	MockGetCommit              string
 	MockGetCommitError         error
@@ -45,6 +47,10 @@ func (c *VCS) GetHead() string {
 
 func (c *VCS) GetHeadCommit() (string, error) {
 	return c.MockGetHead, c.MockGetHeadError
+}
+
+func (c *VCS) GetLastCommit() (string, error) {
+	return c.MockGetLastCommit, c.MockGetLastCommitError
 }
 
 func (c *VCS) GetTopLevel() string {

--- a/internal/mocks/vcs.go
+++ b/internal/mocks/vcs.go
@@ -37,14 +37,6 @@ func (c *VCS) GetBranch() string {
 	return c.MockGetBranch
 }
 
-func (c *VCS) GetHead() string {
-	head, err := c.GetHeadCommit()
-	if err != nil {
-		return ""
-	}
-	return head
-}
-
 func (c *VCS) GetHeadCommit() (string, error) {
 	return c.MockGetHead, c.MockGetHeadError
 }

--- a/internal/mocks/vcs.go
+++ b/internal/mocks/vcs.go
@@ -12,6 +12,7 @@ type VCS struct {
 	MockGetBranch              string
 	MockGetHead                string
 	MockGetHeadError           error
+	MockGetHeadCommit          func() (string, error)
 	MockGetLastCommit          string
 	MockGetLastCommitError     error
 	MockGetTopLevel            string
@@ -38,6 +39,9 @@ func (c *VCS) GetBranch() string {
 }
 
 func (c *VCS) GetHeadCommit() (string, error) {
+	if c.MockGetHeadCommit != nil {
+		return c.MockGetHeadCommit()
+	}
 	return c.MockGetHead, c.MockGetHeadError
 }
 

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -66,11 +66,18 @@ const (
 	jjBinary  = "jj"
 )
 
-// New picks the backend for dir. The innermost repository containing dir wins,
-// so a jj repo nested inside an unrelated git checkout is not mistaken for part
-// of it. A colocated jj repo has both roots at the same path, and jj takes that
-// tie.
+// New picks the backend for dir. RWX_VCS forces a backend outright; otherwise
+// the innermost repository containing dir wins, so a jj repo nested inside an
+// unrelated git checkout is not mistaken for part of it. A colocated jj repo
+// has both roots at the same path, and jj takes that tie.
 func New(dir string) Client {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("RWX_VCS"))) {
+	case "git":
+		return newGit(dir)
+	case "jj":
+		return newJJ(dir)
+	}
+
 	gitClient := newGit(dir)
 	if !jjAvailable() {
 		return gitClient

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -1,9 +1,13 @@
 package vcs
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/rwx-cloud/rwx/internal/git"
+	"github.com/rwx-cloud/rwx/internal/jj"
 	"github.com/rwx-cloud/rwx/internal/vcs/vcstypes"
 )
 
@@ -29,7 +33,8 @@ type Client interface {
 	IsInsideWorkTree() bool
 	GetTopLevel() string
 	// GetBranch returns the branch naming the current position, or "" when
-	// there is none, as on a detached HEAD.
+	// there is none (a detached HEAD under git, no bookmark at or below @ under
+	// jj).
 	GetBranch() string
 	GetHeadCommit() (string, error)
 	// GetShortHead returns a short identifier for the current position that
@@ -51,15 +56,64 @@ type Client interface {
 	ApplyPatchReject(patch []byte) *exec.Cmd
 }
 
-var _ Client = (*git.Client)(nil)
+var (
+	_ Client = (*git.Client)(nil)
+	_ Client = (*jj.Client)(nil)
+)
 
-const gitBinary = "git"
+const (
+	gitBinary = "git"
+	jjBinary  = "jj"
+)
 
-// New returns the backend for dir. Git is currently the only one.
+// New picks the backend for dir. The innermost repository containing dir wins,
+// so a jj repo nested inside an unrelated git checkout is not mistaken for part
+// of it. A colocated jj repo has both roots at the same path, and jj takes that
+// tie.
 func New(dir string) Client {
-	return newGit(dir)
+	gitClient := newGit(dir)
+	if !jjAvailable() {
+		return gitClient
+	}
+
+	jjClient := newJJ(dir)
+	jjRoot := jjClient.GetTopLevel()
+	if jjRoot == "" {
+		return gitClient
+	}
+
+	// A git repository nested inside the jj workspace is its own repository.
+	gitRoot := gitClient.GetTopLevel()
+	if gitRoot != "" && isProperSubpath(jjRoot, gitRoot) {
+		return gitClient
+	}
+
+	return jjClient
+}
+
+// isProperSubpath reports whether child sits strictly below parent.
+func isProperSubpath(parent, child string) bool {
+	if parent == "" || child == "" {
+		return false
+	}
+
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+
+	return rel != "." && !strings.HasPrefix(rel, "..")
 }
 
 func newGit(dir string) *git.Client {
 	return &git.Client{Binary: gitBinary, Dir: dir}
+}
+
+func newJJ(dir string) *jj.Client {
+	return &jj.Client{Binary: jjBinary, GitBinary: gitBinary, Dir: dir, Stderr: os.Stderr}
+}
+
+func jjAvailable() bool {
+	_, err := exec.LookPath(jjBinary)
+	return err == nil
 }

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -31,7 +31,6 @@ type Client interface {
 	// GetBranch returns the branch naming the current position, or "" when
 	// there is none, as on a detached HEAD.
 	GetBranch() string
-	GetHead() string
 	GetHeadCommit() (string, error)
 	// GetShortHead returns a short identifier for the current position that
 	// stays stable while the working copy is edited. It keys sandbox sessions

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -66,10 +66,10 @@ const (
 	jjBinary  = "jj"
 )
 
-// New picks the backend for dir. RWX_VCS forces a backend outright; otherwise
-// the innermost repository containing dir wins, so a jj repo nested inside an
-// unrelated git checkout is not mistaken for part of it. A colocated jj repo
-// has both roots at the same path, and jj takes that tie.
+// New picks the backend for dir. RWX_VCS forces one; otherwise the innermost
+// repository wins, with jj taking the tie in a colocated repo. Detection reads
+// the filesystem rather than spawning either tool, since most commands never
+// touch version control.
 func New(dir string) Client {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("RWX_VCS"))) {
 	case "git":
@@ -78,24 +78,42 @@ func New(dir string) Client {
 		return newJJ(dir)
 	}
 
-	gitClient := newGit(dir)
 	if !jjAvailable() {
-		return gitClient
+		return newGit(dir)
 	}
 
-	jjClient := newJJ(dir)
-	jjRoot := jjClient.GetTopLevel()
+	jjRoot := nearestRoot(dir, ".jj")
 	if jjRoot == "" {
-		return gitClient
+		return newGit(dir)
 	}
 
-	// A git repository nested inside the jj workspace is its own repository.
-	gitRoot := gitClient.GetTopLevel()
+	gitRoot := nearestRoot(dir, ".git")
 	if gitRoot != "" && isProperSubpath(jjRoot, gitRoot) {
-		return gitClient
+		return newGit(dir)
 	}
 
-	return jjClient
+	return newJJ(dir)
+}
+
+// nearestRoot walks up from dir to the closest directory holding marker, or ""
+// when none does. .git may be a file in a linked work tree, so any entry counts.
+func nearestRoot(dir, marker string) string {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return ""
+	}
+
+	for {
+		if _, err := os.Lstat(filepath.Join(dir, marker)); err == nil {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
 }
 
 // isProperSubpath reports whether child sits strictly below parent.

--- a/internal/vcs/vcs.go
+++ b/internal/vcs/vcs.go
@@ -38,6 +38,10 @@ type Client interface {
 	// when GetBranch is empty.
 	GetShortHead() string
 	GetCommit() (string, error)
+	// GetLastCommit returns the commit a run made from this position would be
+	// for. It differs from GetHeadCommit only when the working copy is itself a
+	// commit, as under jj, where an empty @ is skipped.
+	GetLastCommit() (string, error)
 	GetOriginUrl() string
 	GeneratePatchFile(destDir string, pathspec []string) (PatchFile, error)
 	GeneratePatch(pathspec []string) ([]byte, *LFSChangedFilesMetadata, error)

--- a/internal/vcs/vcs_test.go
+++ b/internal/vcs/vcs_test.go
@@ -37,6 +37,7 @@ func isolate(t *testing.T) string {
 	t.Setenv("JJ_CONFIG", jjConfig)
 	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
 	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	t.Setenv("RWX_VCS", "")
 
 	return dir
 }
@@ -127,4 +128,34 @@ func TestNewResolvesTheClientFromASubdirectory(t *testing.T) {
 
 func TestNewSelectsGitOutsideAnyRepository(t *testing.T) {
 	require.IsType(t, &git.Client{}, vcs.New(isolate(t)))
+}
+
+func TestNewHonorsRWXVCS(t *testing.T) {
+	t.Run("git opts out for a colocated repository", func(t *testing.T) {
+		root := jjRepo(t, true)
+
+		t.Setenv("RWX_VCS", "git")
+		require.IsType(t, &git.Client{}, vcs.New(root))
+	})
+
+	t.Run("git forces git for a non-colocated repository", func(t *testing.T) {
+		root := jjRepo(t, false)
+
+		t.Setenv("RWX_VCS", "git")
+		require.IsType(t, &git.Client{}, vcs.New(root))
+	})
+
+	t.Run("is case and whitespace insensitive", func(t *testing.T) {
+		root := jjRepo(t, true)
+
+		t.Setenv("RWX_VCS", "  GIT ")
+		require.IsType(t, &git.Client{}, vcs.New(root))
+	})
+
+	t.Run("an unknown value falls back to detection", func(t *testing.T) {
+		root := jjRepo(t, false)
+
+		t.Setenv("RWX_VCS", "hg")
+		require.IsType(t, &jj.Client{}, vcs.New(root))
+	})
 }

--- a/internal/vcs/vcs_test.go
+++ b/internal/vcs/vcs_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/rwx-cloud/rwx/internal/git"
+	"github.com/rwx-cloud/rwx/internal/jj"
 	"github.com/rwx-cloud/rwx/internal/vcs"
 	"github.com/stretchr/testify/require"
 )
@@ -20,37 +21,96 @@ func mustRun(t *testing.T, dir, bin string, args ...string) {
 	require.NoError(t, err, "%s failed: %s", bin, out)
 }
 
-// isolate keeps git from reading the developer's real configuration. The temp
-// dir is resolved because macOS puts it behind a /var -> /private/var symlink,
-// which git reports in its resolved form.
+// isolate keeps git and jj from reading the developer's real configuration. The
+// temp dir is resolved because macOS puts it behind a /var -> /private/var
+// symlink, which git reports in its resolved form.
 func isolate(t *testing.T) string {
 	t.Helper()
 
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	jjConfig := filepath.Join(dir, "jj-config.toml")
+	require.NoError(t, os.WriteFile(jjConfig, nil, 0o644))
+
+	t.Setenv("JJ_USER", "Test User")
+	t.Setenv("JJ_EMAIL", "test@example.com")
+	t.Setenv("JJ_CONFIG", jjConfig)
 	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
 	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
 
-	dir, err := filepath.EvalSymlinks(t.TempDir())
-	require.NoError(t, err)
-
 	return dir
+}
+
+func jjRepo(t *testing.T, colocated bool) string {
+	t.Helper()
+
+	if _, err := exec.LookPath("jj"); err != nil {
+		t.Skip("jj is not installed")
+	}
+
+	root := filepath.Join(isolate(t), "repo")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+
+	args := []string{"--no-pager", "--quiet", "git", "init"}
+	if colocated {
+		args = append(args, "--colocate")
+	} else {
+		args = append(args, "--no-colocate")
+	}
+	mustRun(t, root, "jj", args...)
+
+	return root
+}
+
+func TestNewSelectsJJForColocatedRepositories(t *testing.T) {
+	root := jjRepo(t, true)
+	require.DirExists(t, filepath.Join(root, ".git"), "colocated repos keep a top-level .git")
+	require.IsType(t, &jj.Client{}, vcs.New(root))
+}
+
+func TestNewSelectsJJForNonColocatedRepositories(t *testing.T) {
+	root := jjRepo(t, false)
+	require.NoDirExists(t, filepath.Join(root, ".git"), "non-colocated repos have no top-level .git")
+	require.IsType(t, &jj.Client{}, vcs.New(root))
+}
+
+// git rev-parse walks upward, so an enclosing checkout would answer for a
+// nested jj repo that has no .git of its own.
+func TestNewPrefersTheInnermostRepository(t *testing.T) {
+	if _, err := exec.LookPath("jj"); err != nil {
+		t.Skip("jj is not installed")
+	}
+
+	outer := isolate(t)
+	mustRun(t, outer, "git", "init", "-q")
+
+	nested := filepath.Join(outer, "nested")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	mustRun(t, nested, "jj", "--no-pager", "--quiet", "git", "init", "--no-colocate")
+
+	require.NoDirExists(t, filepath.Join(nested, ".git"))
+	require.IsType(t, &jj.Client{}, vcs.New(nested))
+
+	// The enclosing checkout still selects git for its own directories.
+	require.IsType(t, &git.Client{}, vcs.New(outer))
+}
+
+func TestNewPrefersAGitRepositoryNestedInAJJWorkspace(t *testing.T) {
+	outer := jjRepo(t, false)
+
+	nested := filepath.Join(outer, "nested")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	mustRun(t, nested, "git", "init", "-q")
+
+	require.IsType(t, &git.Client{}, vcs.New(nested))
+	require.IsType(t, &jj.Client{}, vcs.New(outer))
 }
 
 func TestNewSelectsGitForGitRepositories(t *testing.T) {
 	root := isolate(t)
 	mustRun(t, root, "git", "init", "-q")
 
-	client := vcs.New(root)
-	require.IsType(t, &git.Client{}, client)
-	require.Equal(t, root, client.GetTopLevel())
-}
-
-func TestNewSelectsGitOutsideAnyRepository(t *testing.T) {
-	root := isolate(t)
-
-	client := vcs.New(root)
-	require.IsType(t, &git.Client{}, client)
-	require.Empty(t, client.GetTopLevel())
-	require.False(t, client.IsInsideWorkTree())
+	require.IsType(t, &git.Client{}, vcs.New(root))
 }
 
 func TestNewResolvesTheClientFromASubdirectory(t *testing.T) {
@@ -60,5 +120,11 @@ func TestNewResolvesTheClientFromASubdirectory(t *testing.T) {
 	nested := filepath.Join(root, "nested")
 	require.NoError(t, os.MkdirAll(nested, 0o755))
 
-	require.Equal(t, root, vcs.New(nested).GetTopLevel())
+	client := vcs.New(nested)
+	require.IsType(t, &git.Client{}, client)
+	require.Equal(t, root, client.GetTopLevel())
+}
+
+func TestNewSelectsGitOutsideAnyRepository(t *testing.T) {
+	require.IsType(t, &git.Client{}, vcs.New(isolate(t)))
 }

--- a/internal/vcs/vcstypes/vcstypes.go
+++ b/internal/vcs/vcstypes/vcstypes.go
@@ -181,10 +181,8 @@ func (r PatchResult) Bytes() ([]byte, *LFSChangedFilesMetadata) {
 	return r.Patch, nil
 }
 
-// UntrackedFilesMetadata carries the files a patch adds that do not exist in
-// the base commit. Under git these are literally untracked working-tree files;
-// under jj, which tracks the whole working copy automatically, they are the
-// files the patch adds relative to the base.
+// UntrackedFilesMetadata carries the untracked working-tree files a git patch
+// picks up. jj tracks the whole working copy, so its patches report none.
 type UntrackedFilesMetadata struct {
 	Files []string
 	Count int

--- a/internal/vcs/vcstypes/vcstypes.go
+++ b/internal/vcs/vcstypes/vcstypes.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -16,6 +17,17 @@ func ConfiguredRemote() string {
 		return remote
 	}
 	return defaultRemote
+}
+
+// MissingRemoteError reports that the configured remote does not exist.
+func MissingRemoteError(remote string) error {
+	return fmt.Errorf("no git remote named '%s' is configured (set RWX_GIT_REMOTE to use a different remote)", remote)
+}
+
+// NoCommonAncestorError reports that subject, the named position the working
+// copy sits on, shares no history with the configured remote.
+func NoCommonAncestorError(subject, remote string) error {
+	return fmt.Errorf("%s has no commits in common with the '%s' remote (set RWX_GIT_REMOTE to use a different remote)", subject, remote)
 }
 
 func CommitMismatchNote(head, runCommit string) string {
@@ -119,6 +131,56 @@ type PatchResult struct {
 	OK        bool
 }
 
+// WriteFile turns a generated patch into the PatchFile callers upload. LFS
+// changes and an empty patch produce no file; anything else is written under
+// destDir, named for the base commit it applies to.
+func (r PatchResult) WriteFile(destDir string) (PatchFile, error) {
+	if !r.OK {
+		return PatchFile{}, fmt.Errorf("unable to generate patch data")
+	}
+
+	if r.LFS.Count > 0 {
+		return PatchFile{LFSChangedFiles: r.LFS}, nil
+	}
+
+	if len(r.Patch) == 0 {
+		return PatchFile{UntrackedFiles: r.Untracked}, nil
+	}
+
+	outputPath := filepath.Join(destDir, r.SHA)
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		return PatchFile{}, fmt.Errorf("unable to create patch directory: %w", err)
+	}
+
+	if err := os.WriteFile(outputPath, r.Patch, 0644); err != nil {
+		return PatchFile{}, fmt.Errorf("unable to write patch file: %w", err)
+	}
+
+	return PatchFile{
+		Written:        true,
+		Path:           outputPath,
+		UntrackedFiles: r.Untracked,
+	}, nil
+}
+
+// Bytes reduces a generated patch to what GeneratePatch reports: the patch
+// itself, or the LFS files that stood in for one, or nothing at all.
+func (r PatchResult) Bytes() ([]byte, *LFSChangedFilesMetadata) {
+	if !r.OK {
+		return nil, nil
+	}
+
+	if r.LFS.Count > 0 {
+		return nil, &r.LFS
+	}
+
+	if len(r.Patch) == 0 {
+		return nil, nil
+	}
+
+	return r.Patch, nil
+}
+
 // UntrackedFilesMetadata carries the files a patch adds that do not exist in
 // the base commit. Under git these are literally untracked working-tree files;
 // under jj, which tracks the whole working copy automatically, they are the
@@ -156,6 +218,36 @@ type PushRefOptions struct {
 	Remote  string
 	Refspec string
 	Env     []string
+}
+
+// Validate rejects options no push can run with.
+func (o PushRefOptions) Validate() error {
+	if o.Remote == "" {
+		return fmt.Errorf("no remote provided")
+	}
+	if o.Refspec == "" {
+		return fmt.Errorf("no refspec provided")
+	}
+	return nil
+}
+
+// RunPush runs a `git push` the backend has already aimed at its repository,
+// applying env and folding git's own output into the error so callers can
+// recognize rejections such as a refused shallow update.
+func RunPush(cmd *exec.Cmd, env []string) error {
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+
+	if out, err := cmd.CombinedOutput(); err != nil {
+		output := strings.TrimSpace(string(out))
+		if output != "" {
+			return fmt.Errorf("git push failed: %s", output)
+		}
+		return fmt.Errorf("git push failed: %w", err)
+	}
+
+	return nil
 }
 
 // PatchError identifies which command failed while generating a patch, along

--- a/internal/vcs/vcstypes/vcstypes.go
+++ b/internal/vcs/vcstypes/vcstypes.go
@@ -68,8 +68,9 @@ func SplitNULPaths(output []byte) []string {
 }
 
 // CommandFactory builds a command that can query a repository. Backends differ
-// in how they reach the object store, so the shared helpers below take a
-// factory instead of building commands themselves.
+// in how they reach the object store — the git client shells out in the work
+// tree, the jj client points git at the jj-managed store — so the shared
+// helpers below take a factory instead of building commands themselves.
 type CommandFactory func(args ...string) (*exec.Cmd, error)
 
 // LFSFilesForPaths returns the subset of files that git-lfs is configured to
@@ -120,8 +121,8 @@ type PatchResult struct {
 
 // UntrackedFilesMetadata carries the files a patch adds that do not exist in
 // the base commit. Under git these are literally untracked working-tree files;
-// a backend that tracks the whole working copy reports the files the patch adds
-// relative to the base instead.
+// under jj, which tracks the whole working copy automatically, they are the
+// files the patch adds relative to the base.
 type UntrackedFilesMetadata struct {
 	Files []string
 	Count int

--- a/test/integration/sandbox-jj-file-sync.sh
+++ b/test/integration/sandbox-jj-file-sync.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/sandbox-helpers.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+command -v jj > /dev/null 2>&1 || fail "jj is not installed"
+
+export JJ_USER="Testing"
+export JJ_EMAIL="git@example.com"
+
+# Colocate the existing git checkout so jj drives the same working copy, which
+# selects the jj backend.
+#
+# Colocating puts @ one commit above the imported HEAD, so the CLI keys the
+# sandbox session by the nearest bookmark below @, or by @'s change id when the
+# checkout carries none. Either key has to survive the edits below, since jj
+# rewrites @ on every snapshot.
+jj --no-pager --color=never --quiet git init --colocate > /dev/null
+
+jj_head() {
+  jj --no-pager --color=never --quiet log -r '@' --no-graph -T 'commit_id'
+}
+
+start_sandbox
+trap stop_sandbox EXIT
+
+echo "new file from jj" > jj-new-file.txt
+echo "# Change from jj" >> go.mod
+
+new_file_sha=$(sha1sum jj-new-file.txt | awk '{print $1}')
+changed_file_sha=$(sha1sum go.mod | awk '{print $1}')
+
+sandbox_new_file_sha=$("${RWX_CLI}" sandbox exec -- sha1sum jj-new-file.txt | awk 'NR==1{print $1}')
+if [ "$new_file_sha" != "$sandbox_new_file_sha" ]; then
+  fail "jj-new-file.txt content mismatch in sandbox (local: $new_file_sha, sandbox: $sandbox_new_file_sha)"
+fi
+
+sandbox_changed_file_sha=$("${RWX_CLI}" sandbox exec -- sha1sum go.mod | awk 'NR==1{print $1}')
+if [ "$changed_file_sha" != "$sandbox_changed_file_sha" ]; then
+  fail "go.mod content mismatch in sandbox (local: $changed_file_sha, sandbox: $sandbox_changed_file_sha)"
+fi
+
+post_new_file_sha=$(sha1sum jj-new-file.txt | awk '{print $1}')
+if [ "$new_file_sha" != "$post_new_file_sha" ]; then
+  fail "jj-new-file.txt was modified during sandbox exec (expected $new_file_sha, got $post_new_file_sha)"
+fi
+
+post_changed_file_sha=$(sha1sum go.mod | awk '{print $1}')
+if [ "$changed_file_sha" != "$post_changed_file_sha" ]; then
+  fail "go.mod was modified during sandbox exec (expected $changed_file_sha, got $post_changed_file_sha)"
+fi
+
+# jj snapshots the working copy into @, so the sandbox is synced by pushing that
+# commit rather than by applying a dirty patch on top of it. A second exec after
+# a further edit must still land, which is what catches a stale snapshot.
+first_head=$(jj_head)
+
+echo "second change from jj" >> jj-new-file.txt
+second_file_sha=$(sha1sum jj-new-file.txt | awk '{print $1}')
+
+sandbox_second_file_sha=$("${RWX_CLI}" sandbox exec -- sha1sum jj-new-file.txt | awk 'NR==1{print $1}')
+if [ "$second_file_sha" != "$sandbox_second_file_sha" ]; then
+  fail "second jj-new-file.txt change did not sync (local: $second_file_sha, sandbox: $sandbox_second_file_sha)"
+fi
+
+second_head=$(jj_head)
+if [ "$first_head" = "$second_head" ]; then
+  fail "expected @ to advance after editing the working copy (still $first_head)"
+fi
+
+# The sandbox must contain the working-copy commit itself, since that is what
+# the jj backend pushes in place of a dirty patch.
+sandbox_has_head=$("${RWX_CLI}" sandbox exec -- git cat-file -t "$second_head" 2>/dev/null | awk 'NR==1{print $1}' || true)
+if [ "$sandbox_has_head" != "commit" ]; then
+  fail "sandbox does not contain the jj working-copy commit $second_head (got '$sandbox_has_head')"
+fi


### PR DESCRIPTION
RWX run patching and sandboxes more or less work for colocated jj repos (where there's also a .git directory).

But because we rely fully on the git binary for all patching and sandbox payload generation commands, it does not support non-colocated jj repos (where there is only a .jj directory).

This introduces jj support. We detect the backend by reading the filesystem for the two directories, without spawning either tool:

- .git only uses git
- .jj only uses jj
- .jj and .git uses jj
- if the jj binary isn't on PATH, we fall back to git even when .jj exists
- the innermost repository wins, so a git repo nested inside a jj repo uses git

The jj backend still needs git. We call the git binary directly against the git store behind .jj for patch generation, push, and apply, so both binaries are required and the "not installed" error names whichever one is missing.

Sandbox sessions are keyed by branch, or by a short head when there is no branch. In a colocated repo git's HEAD is usually detached, so the old key was a short commit SHA; under jj it's the nearest bookmark or a 7-character change id. This means existing users in colocated repos will see the first use of this version of the CLI miss their existing sandbox and spin up a new one. The reverse also holds: forcing git later won't find sessions created under jj.

You can force the backend with `RWX_VCS=jj` or `RWX_VCS=git` - for example, if you want to keep using git in a colocated repo.

I've done my best to exhaustively test this with fixtures similar to what we do for git - creating repos and putting them in various states. There's also a live sandbox sync integration test. I've also manually QAed this on my machine.

Caveat: jj is not my daily driver so I'm relying on documented and llm guidance on how it's typically used. It took us a few passes to get the git binary working the way we wanted it to so I suspect we might discover some edge cases that we want to eventually handle differently here.

I'll also add a jj/install package to our published RWX packages.